### PR TITLE
bug clickhouse: close socket on connection destruction

### DIFF
--- a/clickhouse/src/storages/clickhouse/impl/native_client_factory.cpp
+++ b/clickhouse/src/storages/clickhouse/impl/native_client_factory.cpp
@@ -91,9 +91,7 @@ class ClickhouseSocketAdapter : public clickhouse_cpp::SocketBase {
   ClickhouseSocketAdapter(engine::io::Sockaddr addr, engine::Deadline& deadline)
       : deadline_{deadline}, socket_{CreateSocket(addr, deadline_)} {}
 
-  ~ClickhouseSocketAdapter() override {
-    socket_.Close();
-  }
+  ~ClickhouseSocketAdapter() override { socket_.Close(); }
 
   std::unique_ptr<clickhouse_cpp::InputStream> makeInputStream()
       const override {

--- a/clickhouse/src/storages/clickhouse/impl/native_client_factory.cpp
+++ b/clickhouse/src/storages/clickhouse/impl/native_client_factory.cpp
@@ -92,7 +92,7 @@ class ClickhouseSocketAdapter : public clickhouse_cpp::SocketBase {
       : deadline_{deadline}, socket_{CreateSocket(addr, deadline_)} {}
 
   ~ClickhouseSocketAdapter() override {
-    [[maybe_unused]] auto fd = std::move(socket_).Release();
+    socket_.Close();
   }
 
   std::unique_ptr<clickhouse_cpp::InputStream> makeInputStream()


### PR DESCRIPTION
Well, i guess i was drunk or smth

this test
```
UTEST(Connection, ClosesSocketOnDestruction) {
  ClusterWrapper cluster{};
  for (size_t i = 0; i < 40; ++i) {
    EXPECT_ANY_THROW(cluster->Execute("Some nonsense to force connection reset"));
  }

  engine::SleepUntil({});
}
```

before: https://pastebin.com/raw/bkSi6p6k
after: https://pastebin.com/raw/jXKRY2Ms