### PR TITLE
Make interface const in function taking argc/argv

### DIFF
--- a/core/include/userver/utils/daemon_run.hpp
+++ b/core/include/userver/utils/daemon_run.hpp
@@ -18,7 +18,7 @@ namespace utils {
 /// * --config CONFIG - path to config.yaml
 /// * --config_vars CONFIG_VARS - path to config_vars.yaml
 /// * --config_vars_override CONFIG_VARS - path to config_vars.override.yaml
-int DaemonMain(int argc, char** argv,
+int DaemonMain(int argc, const char* const argv[],
                const components::ComponentList& components_list);
 
 }  // namespace utils

--- a/core/src/utils/daemon_run.cpp
+++ b/core/src/utils/daemon_run.cpp
@@ -24,7 +24,7 @@ std::optional<std::string> ToOptional(std::string&& s) {
 
 }  // namespace
 
-int DaemonMain(int argc, char** argv,
+int DaemonMain(const int argc, const char* const argv[],
                const components::ComponentList& components_list) {
   namespace po = boost::program_options;
 


### PR DESCRIPTION
It is impossible to use `DaemonMain` with `main` that has parameters marked `const`.
No other functions in header files were found to have such an issue (no other external main-like functions found by me).