### PR TITLE
fix cmake: find default python via cmake module

### DIFF
--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -1,43 +1,39 @@
-if (USERVER_OPEN_SOURCE_BUILD)
-  set(PYTHON_PACKAGE_NAME python3)
-  if (APPLE)
-    set(PYTHON_ENV_PATH "/usr/local/bin")
-  else()
-    set(PYTHON_ENV_PATH "/usr/bin")
-  endif()
-else()
-  set(PYTHON_PACKAGE_NAME "taxi-deps-py3-2" CACHE STRING
-    "Python dependencies package name")
-  set(PYTHON_ENV_PATH "/usr/lib/yandex/taxi-py3-2/bin" CACHE STRING
-    "Path to python3 environment")
-endif()
-
 option(PYTHON_CHECK_DEPS "Check python dependencies" ON)
-
-set(PYTHON_BINARY_NAME python3)
 
 # Clear caches
 unset(PYTHON CACHE)
 
-# First of all try taxi-deps-py3
-find_program(PYTHON ${PYTHON_BINARY_NAME}
-  PATHS ${PYTHON_ENV_PATH} NO_DEFAULT_PATH)
+if (USERVER_OPEN_SOURCE_BUILD)
+  set(PYTHON_PACKAGE_NAME python3)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  set(PYTHON ${Python3_EXECUTABLE})
+else()
+  set(PYTHON_BINARY_NAME python3)
+  set(PYTHON_PACKAGE_NAME "taxi-deps-py3-2" CACHE STRING
+    "Python dependencies package name")
+  set(PYTHON_ENV_PATH "/usr/lib/yandex/taxi-py3-2/bin" CACHE STRING
+    "Path to python3 environment")
 
-if (${PYTHON} STREQUAL "PYTHON-NOTFOUND")
-  if (NOT APPLE)
-    message(WARNING
-      "Python not found at ${PYTHON_ENV_PATH}. "
-      "On Ubuntu please consider installing ${PYTHON_PACKAGE_NAME}:\n"
-      "$ sudo apt-get install ${PYTHON_PACKAGE_NAME}\n"
-      "'${PYTHON_PACKAGE_NAME}' not found, falling back to system "
-      "${PYTHON_BINARY_NAME}")
+  # First of all try taxi-deps-py3
+  find_program(PYTHON ${PYTHON_BINARY_NAME}
+    PATHS ${PYTHON_ENV_PATH} NO_DEFAULT_PATH)
+
+  if (${PYTHON} STREQUAL "PYTHON-NOTFOUND")
+    if (NOT APPLE)
+      message(WARNING
+        "Python not found at ${PYTHON_ENV_PATH}. "
+        "On Ubuntu please consider installing ${PYTHON_PACKAGE_NAME}:\n"
+        "$ sudo apt-get install ${PYTHON_PACKAGE_NAME}\n"
+        "'${PYTHON_PACKAGE_NAME}' not found, falling back to system "
+        "${PYTHON_BINARY_NAME}")
+    endif()
+    find_program(PYTHON ${PYTHON_BINARY_NAME})
   endif()
-  find_program(PYTHON ${PYTHON_BINARY_NAME})
-endif()
 
-if (${PYTHON} STREQUAL "PYTHON-NOTFOUND")
-  message(FATAL_ERROR
-    "${PYTHON_BINARY_NAME} not found, try to install '${PYTHON_PACKAGE_NAME}'")
+  if (${PYTHON} STREQUAL "PYTHON-NOTFOUND")
+    message(FATAL_ERROR
+      "${PYTHON_BINARY_NAME} not found, try to install '${PYTHON_PACKAGE_NAME}'")
+  endif()
 endif()
 
 message(STATUS "Python: ${PYTHON}")


### PR DESCRIPTION
При включённом флаге `USERVER_OPEN_SOURCE_BUILD` ищем системный питон с помощью модуля [`FindPython3`](https://cmake.org/cmake/help/latest/module/FindPython3.html), входящего в состав CMake, начиная с версии 3.12.