### PR TITLE
Правка документации для hello_service

### DIFF
--- a/scripts/docs/en/userver/tutorial/hello_service.md
+++ b/scripts/docs/en/userver/tutorial/hello_service.md
@@ -79,8 +79,12 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 make userver-samples-hello_service
 ```
 
-Start the server by running `./samples/hello_service/userver-samples-hello_service`
+Start the server by running `./samples/hello_service/userver-samples-hello_service -c </path/to/static_config.yaml>`
 (do not forget to prepare the configuration files!).
+
+@warning Without file path to `static_config.yaml` `userver-samples-hello_service` will look for a file with name `config_dev.yaml`
+@warning CMake don't copy `static_config.yaml` and `dynamic_config_fallback.json` files from `samples` directory into build directory.
+
 Now you can send a request to your server from another terminal:
 ```
 bash


### PR DESCRIPTION
Без указания пути к файлу конфига сервис пытается найти `config_dev.yaml`, который захардкожен.
CMake не копирует файлы конфига из папки `samples` при сборке hello_service.