### PR TITLE
[not-for-merge] fix grpc: fix package dependencies on Ubuntu 22.04

### DIFF
--- a/external-deps/UserverGrpc.yaml
+++ b/external-deps/UserverGrpc.yaml
@@ -3,7 +3,6 @@ helper-prefix: false
 
 debian-names:
   - libgrpc-dev
-  - libgrpc7
   - libgrpc++-dev
   - libgrpc++1
   - protobuf-compiler-grpc


### PR DESCRIPTION
Relates: TAXICOMMON-5434