### PR TITLE
cc docs: fix recommendation of boost versions to use

### DIFF
--- a/scripts/docs/en/userver/tutorial/build.md
+++ b/scripts/docs/en/userver/tutorial/build.md
@@ -44,7 +44,7 @@ To explicitly specialize the compiler use the cmake options `CMAKE_C_COMPILER` a
 For example to use clang-12 compiler install it and add the following options to cmake:
 `-DCMAKE_CXX_COMPILER=clang++-12 -DCMAKE_C_COMPILER=clang-12`
 
-Prefer avoiding Boost versions that are affected by the bug https://github.com/boostorg/lockfree/issues/59 (1.71 and above).
+Prefer avoiding Boost versions that are affected by the bug https://github.com/boostorg/lockfree/issues/59 (1.71 to 1.73).
 
 
 ## Installation instructions


### PR DESCRIPTION
The described bug seems to be fixed by https://github.com/boostorg/lockfree/commit/df78b9da42d7f5124a865345759d86e95ea79823, which is in 1.74 and above