### PR TITLE
fix cmake: redis tests only if USERVER_IS_THE_ROOT_PROJECT

### DIFF
--- a/redis/CMakeLists.txt
+++ b/redis/CMakeLists.txt
@@ -64,6 +64,7 @@ target_include_directories (${PROJECT_NAME} PRIVATE
 )
 
 
+if (USERVER_IS_THE_ROOT_PROJECT)
 add_library(${PROJECT_NAME}_utest STATIC ${UTESTLIB_SOURCES})
 target_include_directories(
   ${PROJECT_NAME}_utest
@@ -78,7 +79,6 @@ target_link_libraries(${PROJECT_NAME}_utest
   ${PROJECT_NAME}
 )
 
-if (USERVER_IS_THE_ROOT_PROJECT)
   add_executable(${PROJECT_NAME}_unittest ${UNIT_TEST_SOURCES})
   target_link_libraries(${PROJECT_NAME}_unittest
     userver-utest


### PR DESCRIPTION
Cmake fix: enable redis tests only if USERVER_IS_THE_ROOT_PROJECT

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla.