### PR TITLE
fix cmake: don't build tests and benchs when not root project

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -71,8 +71,11 @@ find_package(Boost REQUIRED COMPONENTS
 find_package_required(LibEv "libev-dev")
 find_package_required(ZLIB "zlib1g-dev")
 
-include(SetupGTest)
-include(SetupGBench)
+if (USERVER_IS_THE_ROOT_PROJECT)
+  include(SetupGTest)
+  include(SetupGBench)
+endif()
+
 include(SetupSpdlog)
 
 option(USERVER_FEATURE_SPDLOG_TCP_SINK "Use tcp_sink.h of the spdlog library for testing logs" ON)
@@ -208,32 +211,31 @@ target_link_libraries(userver-core-internal
 )
 
 
-add_library(userver-utest STATIC ${LIBUTEST_SOURCES})
-target_compile_definitions(userver-utest PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
-
-target_link_libraries(userver-utest
-  PUBLIC
-    libgtest
-    libgmock
-	userver-core-internal
-    ${PROJECT_NAME}
-  PRIVATE
-    Boost::program_options
-)
-target_include_directories(userver-utest PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/testing/include
-)
-target_include_directories(userver-utest PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/
-    ${CMAKE_CURRENT_SOURCE_DIR}/testing/src/
-)
-
-# Target with no need to use userver namespace, but includes require userver/
-add_library(yandex-userver-utest INTERFACE)
-target_link_libraries(yandex-userver-utest INTERFACE userver-utest)
-
-
 if (USERVER_IS_THE_ROOT_PROJECT)
+    add_library(userver-utest STATIC ${LIBUTEST_SOURCES})
+    target_compile_definitions(userver-utest PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
+
+    target_link_libraries(userver-utest
+      PUBLIC
+        libgtest
+        libgmock
+      userver-core-internal
+        ${PROJECT_NAME}
+      PRIVATE
+        Boost::program_options
+    )
+    target_include_directories(userver-utest PUBLIC
+      ${CMAKE_CURRENT_SOURCE_DIR}/testing/include
+    )
+    target_include_directories(userver-utest PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/
+        ${CMAKE_CURRENT_SOURCE_DIR}/testing/src/
+    )
+
+    # Target with no need to use userver namespace, but includes require userver/
+    add_library(yandex-userver-utest INTERFACE)
+    target_link_libraries(yandex-userver-utest INTERFACE userver-utest)
+
     add_executable(${PROJECT_NAME}_unittest ${UNIT_TEST_SOURCES})
     target_include_directories (${PROJECT_NAME}_unittest PRIVATE
         $<TARGET_PROPERTY:${PROJECT_NAME},INCLUDE_DIRECTORIES>
@@ -245,23 +247,21 @@ if (USERVER_IS_THE_ROOT_PROJECT)
     # We keep testing deprecated functions, no need to warn about that
     target_compile_options(${PROJECT_NAME}_unittest PRIVATE "-Wno-deprecated-declarations")
     add_google_tests(${PROJECT_NAME}_unittest)
-endif()
 
-add_library(userver-ubench ${LIBUBENCH_SOURCES})
-target_include_directories(userver-ubench PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},INCLUDE_DIRECTORIES>)
-target_compile_definitions(userver-ubench PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
-target_link_libraries(userver-ubench
-  PUBLIC
-    libbenchmark
-	userver-core-internal
-    ${PROJECT_NAME}
-)
+    add_library(userver-ubench ${LIBUBENCH_SOURCES})
+    target_include_directories(userver-ubench PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},INCLUDE_DIRECTORIES>)
+    target_compile_definitions(userver-ubench PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
+    target_link_libraries(userver-ubench
+      PUBLIC
+        libbenchmark
+      userver-core-internal
+        ${PROJECT_NAME}
+    )
 
-# Target with no need to use userver namespace, but includes require userver/
-add_library(yandex-userver-ubench INTERFACE)
-target_link_libraries(yandex-userver-ubench INTERFACE userver-ubench)
+    # Target with no need to use userver namespace, but includes require userver/
+    add_library(yandex-userver-ubench INTERFACE)
+    target_link_libraries(yandex-userver-ubench INTERFACE userver-ubench)
 
-if (USERVER_IS_THE_ROOT_PROJECT)
     add_executable(${PROJECT_NAME}_benchmark ${BENCH_SOURCES})
     target_link_libraries(${PROJECT_NAME}_benchmark PUBLIC userver-ubench)
     add_google_benchmark_tests(${PROJECT_NAME}_benchmark)


### PR DESCRIPTION
It seems like configure tests and benchs is unnecessary when building as subproject or (potentialy) as conan package.
