### PR TITLE
fix ugrpc: fix building with -std=gnu++20 flag

### DIFF
--- a/grpc/include/userver/ugrpc/server/rpc.hpp
+++ b/grpc/include/userver/ugrpc/server/rpc.hpp
@@ -441,8 +441,7 @@ BidirectionalStream<Request, Response>::BidirectionalStream(
       call_span_(call_span) {}
 
 template <typename Request, typename Response>
-BidirectionalStream<Request, Response>::~BidirectionalStream<Request,
-                                                             Response>() {
+BidirectionalStream<Request, Response>::~BidirectionalStream() {
   if (state_ != State::kFinished) impl::Cancel(stream_, call_name_);
 }
 


### PR DESCRIPTION
Building with -std=gnu++20 produces an error:
```
In file included from /home/popov/projects/UServiceTemplate/cmake-build-debug/_deps/userver-src/grpc/include/userver/ugrpc/server/impl/codegen_declarations.hpp:11,
                 from /home/popov/projects/UServiceTemplate/cmake-build-debug/proto/test_service.usrv.pb.hpp:5,
                 from /home/popov/projects/UServiceTemplate/src/service.h:3,
                 from /home/popov/projects/UServiceTemplate/main.cpp:4:
/home/popov/projects/UServiceTemplate/cmake-build-debug/_deps/userver-src/grpc/include/userver/ugrpc/server/rpc.hpp:444:41: error: template-id not allowed for destructor
  444 | BidirectionalStream<Request, Response>::~BidirectionalStream<Request,
```

Compiler: gcc 12.1.1