### PR TITLE
Conan support for userver with ci

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -1,0 +1,52 @@
+name: CI
+
+'on':
+    pull_request:
+    push:
+        branches:
+          - master
+          - develop
+          - feature/**
+
+env:
+    UBSAN_OPTIONS: print_stacktrace=1
+    
+jobs:
+  build:
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    name: Ubuntu-${{ matrix.ubuntu_version }}-shared-${{ matrix.shared }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu_version: [22.04]
+        shared: [True, False]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+            
+    - name: Reuse ccache directory
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: '${{matrix.os}} ${{matrix.info}} ccache-dir ${{github.ref}} run-${{github.run_number}}'
+        restore-keys: |
+          ${{matrix.os}} ${{matrix.info}} ccache-dir ${{github.ref}} run-'
+          ${{matrix.os}} ${{matrix.info}} ccache-     
+                    
+    - name: Install packages
+      run: |
+        sudo apt-get install -y gcc g++ cmake wget git python3 python3-pip ccache
+        pip install jinja2 voluptuous pyyaml conan   
+        conan profile new --detect default && conan profile update settings.compiler.libcxx=libstdc++11 default
+            
+    - name: Setup ccache
+      run: |
+        ccache -M 2.0GB
+        ccache -s            
+    
+    - name: Run conan
+      run: |
+        conan create . --build=missing -pr:b=default -o:shared=${{ matrix.shared }}                 

--- a/conan/patches/0001-thirdparty_packages_from_conan.patch
+++ b/conan/patches/0001-thirdparty_packages_from_conan.patch
@@ -1,0 +1,416 @@
+From 7fe279acc3e35f10c641d4c91ec0c72a66e55f7c Mon Sep 17 00:00:00 2001
+From: atom <tomasiche@gmail.com>
+Date: Sun, 2 Oct 2022 12:21:04 +0300
+Subject: [PATCH] thirdparty_packages_from_conan
+
+---
+ CMakeLists.txt                      |  4 +-
+ cmake/GrpcTargets.cmake             |  5 ++-
+ core/CMakeLists.txt                 | 60 ++++++++++++++---------------
+ grpc/CMakeLists.txt                 |  8 ++--
+ mongo/CMakeLists.txt                |  9 ++++-
+ postgresql/CMakeLists.txt           |  3 +-
+ rabbitmq/CMakeLists.txt             |  4 +-
+ redis/CMakeLists.txt                |  4 +-
+ samples/grpc_service/CMakeLists.txt |  9 +++++
+ tools/json2yaml/CMakeLists.txt      |  1 +
+ universal/CMakeLists.txt            | 43 +++++++++++----------
+ 11 files changed, 85 insertions(+), 65 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 62cef2ac..e5914f6d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -62,6 +62,7 @@ option(USERVER_FEATURE_JEMALLOC "Enable linkage with jemalloc memory allocator"
+ 
+ option(USERVER_CHECK_PACKAGE_VERSIONS "Check package versions" ON)
+ 
++find_package(Boost REQUIRED)
+ include(cmake/SetupEnvironment.cmake)
+ include(AddGoogleTests)
+ include(CheckSubmodule)
+@@ -99,7 +100,8 @@ option(USERVER_FEATURE_RABBITMQ "Provide asynchronous driver for RabbitMQ" ${USE
+ option(USERVER_FEATURE_UNIVERSAL "Provide a universal utilities library that does not use coroutines" ON)
+ 
+ add_subdirectory(core "${CMAKE_BINARY_DIR}/userver/core")
+-add_subdirectory("${USERVER_THIRD_PARTY_DIRS}/boost_stacktrace")
++
++find_package(Boost COMPONENTS stacktrace REQUIRED)
+ add_subdirectory("${USERVER_THIRD_PARTY_DIRS}/compiler-rt")
+ add_subdirectory(uboost_coro)
+ 
+diff --git a/cmake/GrpcTargets.cmake b/cmake/GrpcTargets.cmake
+index 647e15d7..264174cd 100644
+--- a/cmake/GrpcTargets.cmake
++++ b/cmake/GrpcTargets.cmake
+@@ -131,5 +131,8 @@ function(add_grpc_library NAME)
+   add_library(${NAME} STATIC ${generated_sources})
+   target_compile_options(${NAME} PUBLIC -Wno-unused-parameter)
+   target_include_directories(${NAME} SYSTEM PUBLIC ${include_paths})
+-  target_link_libraries(${NAME} PUBLIC userver-grpc Protobuf)
++  target_link_libraries(${NAME} PUBLIC userver-grpc protobuf::protobuf)
++  if(gRPC_VERSION VERSION_GREATER_EQUAL "1.41")
++    target_link_libraries(${NAME} PUBLIC absl::base absl::synchronization)
++  endif()
+ endfunction()
+diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
+index 3c190115..ba4412fb 100644
+--- a/core/CMakeLists.txt
++++ b/core/CMakeLists.txt
+@@ -67,13 +67,14 @@ find_package(Boost REQUIRED COMPONENTS
+     locale
+     regex
+     iostreams
++    stacktrace
+ )
+-find_package_required(LibEv "libev-dev")
++find_package(libev REQUIRED)
+ find_package_required(ZLIB "zlib1g-dev")
+ 
+ if (USERVER_FEATURE_UTEST)
+-    include(SetupGTest)
+-    include(SetupGBench)
++    find_package(benchmark REQUIRED)
++    find_package(GTest REQUIRED)
+ endif()
+ include(SetupSpdlog)
+ 
+@@ -85,17 +86,22 @@ if (NOT USERVER_FEATURE_SPDLOG_TCP_SINK)
+   )
+ endif()
+ 
+-include(SetupCAres)
+-include(SetupCURL)
+-include(SetupCryptoPP)
++find_package(c-ares REQUIRED)
++find_package(CURL REQUIRED)
++find_package(cryptopp REQUIRED)
+ 
+ find_package(Iconv REQUIRED)
+-find_package_required(libyamlcpp "libyaml-cpp-dev")
++find_package(yaml-cpp REQUIRED)
+ find_package_required(OpenSSL "libssl-dev")
+-include(SetupFmt)
+-include(SetupCCTZ)
++find_package(fmt REQUIRED)
++find_package(cctz REQUIRED)
+ 
+-find_package_required(Http_Parser "libhttp-parser-dev")
++find_package(http_parser REQUIRED)
++
++find_package(RapidJSON REQUIRED)
++target_compile_definitions(RapidJSON::RapidJSON INTERFACE RAPIDJSON_HAS_STDSTRING)
++
++find_package(concurrentqueue REQUIRED)
+ 
+ add_library(${PROJECT_NAME} STATIC ${SOURCES})
+ target_compile_definitions(${PROJECT_NAME} PRIVATE SPDLOG_PREVENT_CHILD_FD SPDLOG_FMT_EXTERNAL)
+@@ -121,26 +127,28 @@ target_link_libraries(${PROJECT_NAME}
+     Threads::Threads
+     Boost::locale
+     sanitize-target
+-    libyamlcpp
+-    fmt
+-    c-ares
+-    cctz
++    yaml-cpp
++    fmt::fmt
++    c-ares::cares
++    cctz::cctz
+     CURL::libcurl
+-    userver-stacktrace
++    concurrentqueue::concurrentqueue
++    Boost::stacktrace
+   PRIVATE
+     userver-uboost-coro
+     Boost::filesystem
+     Boost::program_options
+     Boost::iostreams
+     Boost::regex
+-    CryptoPP
+-    Http_Parser
++    cryptopp-static
++    http_parser::http_parser
+     Iconv::Iconv
+-    LibEv
++    libev::libev
+     OpenSSL::Crypto
+     OpenSSL::SSL
+     ZLIB::ZLIB
+-    spdlog_header_only
++    spdlog::spdlog
++    RapidJSON::RapidJSON
+ )
+ 
+ if (NOT MACOS)
+@@ -169,14 +177,6 @@ set_property(
+   APPEND PROPERTY COMPILE_FLAGS -O2
+ )
+ 
+-target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
+-  ${USERVER_THIRD_PARTY_DIRS}/rapidjson/include
+-)
+-
+-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
+-  ${USERVER_THIRD_PARTY_DIRS}/moodycamel/include
+-)
+-
+ target_include_directories(${PROJECT_NAME}
+   PRIVATE
+     ${CMAKE_CURRENT_SOURCE_DIR}/../shared/src/
+@@ -215,8 +215,8 @@ if (USERVER_FEATURE_UTEST)
+ 
+     target_link_libraries(userver-utest
+     PUBLIC
+-        libgtest
+-        libgmock
++        GTest::gtest
++        GTest::gmock
+ 	    userver-core-internal
+         ${PROJECT_NAME}
+     PRIVATE
+@@ -255,7 +255,7 @@ if (USERVER_FEATURE_UTEST)
+     target_compile_definitions(userver-ubench PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
+     target_link_libraries(userver-ubench
+       PUBLIC
+-        libbenchmark
++        benchmark::benchmark
+       userver-core-internal
+         ${PROJECT_NAME}
+     )
+diff --git a/grpc/CMakeLists.txt b/grpc/CMakeLists.txt
+index 42ff882e..e4d66a43 100644
+--- a/grpc/CMakeLists.txt
++++ b/grpc/CMakeLists.txt
+@@ -9,10 +9,8 @@ if (NOT USERVER_FEATURE_GRPC_CHANNELZ)
+ endif()
+ 
+ if(USERVER_OPEN_SOURCE_BUILD)
+-    find_package(UserverGrpc REQUIRED)
+-    find_package(UserverProtobuf REQUIRED)
+-    add_library(Grpc ALIAS UserverGrpc)  # Unify link names
+-    add_library(Protobuf ALIAS UserverProtobuf)  # Unify link names
++    find_package(gRPC REQUIRED)
++    find_package(Protobuf REQUIRED)
+ 
+     if (USERVER_FEATURE_GRPC_CHANNELZ)
+         find_package(GrpcChannelz REQUIRED)
+@@ -59,7 +57,7 @@ target_include_directories(${PROJECT_NAME}
+     ${CMAKE_CURRENT_SOURCE_DIR}/src
+ )
+ 
+-target_link_libraries(${PROJECT_NAME} PUBLIC userver-core Grpc)
++target_link_libraries(${PROJECT_NAME} PUBLIC userver-core gRPC::gRPC protobuf::protobuf)
+ if (USERVER_FEATURE_GRPC_CHANNELZ)
+     target_link_libraries(${PROJECT_NAME} PUBLIC GrpcChannelz)
+ endif()
+diff --git a/mongo/CMakeLists.txt b/mongo/CMakeLists.txt
+index b9f39dfb..291415c4 100644
+--- a/mongo/CMakeLists.txt
++++ b/mongo/CMakeLists.txt
+@@ -1,8 +1,13 @@
+ project(userver-mongo CXX)
+ 
+ if (USERVER_OPEN_SOURCE_BUILD)
+-  find_package(bson REQUIRED)
+-  find_package(mongoc REQUIRED)
++#  find_package(bson REQUIRED)
++  find_package(mongoc-1.0 REQUIRED)
++  set_target_properties(mongo::bson_static PROPERTIES IMPORTED_GLOBAL TRUE)
++  set_target_properties(mongo::mongoc_static PROPERTIES IMPORTED_GLOBAL TRUE)
++  add_library(bson ALIAS mongo::bson_static)
++  add_library(mongoc ALIAS mongo::mongoc_static)
++  find_package(cyrus-sasl REQUIRED)
+ else()
+   find_package(Helperbson-1.0)
+   find_package(Helpermongoc-1.0)
+diff --git a/postgresql/CMakeLists.txt b/postgresql/CMakeLists.txt
+index 10c568b3..3df3db01 100644
+--- a/postgresql/CMakeLists.txt
++++ b/postgresql/CMakeLists.txt
+@@ -1,6 +1,7 @@
+ project(userver-postgresql CXX)
+ 
+ find_package(Boost REQUIRED regex)
++find_package(PostgreSQL REQUIRED)
+ 
+ 
+ option(USERVER_FEATURE_PATCH_LIBPQ "Apply patches to the libpq (add portals support)" ON)
+@@ -18,7 +19,7 @@ else()
+   if (NOT LIBPQ_LIBRARIES)
+     message(FATAL_ERROR "Failed to find libpq")
+   endif()
+-  target_link_libraries(userver-libpq INTERFACE ${LIBPQ_LIBRARIES})
++  target_link_libraries(userver-libpq INTERFACE ${LIBPQ_LIBRARIES} PostgreSQL::PostgreSQL)
+ endif()
+ 
+ file(GLOB_RECURSE SOURCES
+diff --git a/rabbitmq/CMakeLists.txt b/rabbitmq/CMakeLists.txt
+index a1cd9eee..d2378eb7 100644
+--- a/rabbitmq/CMakeLists.txt
++++ b/rabbitmq/CMakeLists.txt
+@@ -9,14 +9,14 @@ file(GLOB_RECURSE RABBITMQ_TEST_SOURCES
+ 
+ list(REMOVE_ITEM SOURCES ${RABBITMQ_TEST_SOURCES})
+ 
+-include(SetupAmqpCPP)
++find_package(amqpcpp)
+ 
+ add_library(${PROJECT_NAME} STATIC ${SOURCES})
+ target_link_libraries(${PROJECT_NAME}
+   PUBLIC
+     userver-core
+   PRIVATE
+-    amqp-cpp
++    amqpcpp
+ )
+ target_include_directories(
+   ${PROJECT_NAME}
+diff --git a/redis/CMakeLists.txt b/redis/CMakeLists.txt
+index d2406e52..b40bb233 100644
+--- a/redis/CMakeLists.txt
++++ b/redis/CMakeLists.txt
+@@ -21,7 +21,7 @@ file(GLOB_RECURSE REDIS_TEST_SOURCES
+ )
+ list(REMOVE_ITEM SOURCES ${REDIS_TEST_SOURCES})
+ 
+-find_package(Hiredis)
++find_package(hiredis REQUIRED)
+ 
+ add_library(${PROJECT_NAME} STATIC ${SOURCES})
+ set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+@@ -48,7 +48,7 @@ endif()
+ target_link_libraries(${PROJECT_NAME}
+   PUBLIC
+     userver-core
+-    Hiredis
++    hiredis::hiredis
+   PRIVATE
+     userver-uboost-coro # uses BlockingFuture
+ )
+diff --git a/samples/grpc_service/CMakeLists.txt b/samples/grpc_service/CMakeLists.txt
+index 9f33a8b6..7078053b 100644
+--- a/samples/grpc_service/CMakeLists.txt
++++ b/samples/grpc_service/CMakeLists.txt
+@@ -1,5 +1,14 @@
+ project(userver-samples-grpc_service CXX)
+ 
++if(USERVER_OPEN_SOURCE_BUILD)
++    find_package(gRPC REQUIRED)
++    find_package(Protobuf REQUIRED)
++else()
++    find_package(Grpc REQUIRED)
++    find_package(Protobuf REQUIRED)
++endif()
++
++
+ add_executable(${PROJECT_NAME} grpc_service.cpp)
+ target_link_libraries(${PROJECT_NAME} userver-core)
+ 
+diff --git a/tools/json2yaml/CMakeLists.txt b/tools/json2yaml/CMakeLists.txt
+index 62eef068..01edfb0c 100644
+--- a/tools/json2yaml/CMakeLists.txt
++++ b/tools/json2yaml/CMakeLists.txt
+@@ -5,4 +5,5 @@ file (GLOB_RECURSE SOURCES *.cpp)
+ add_executable (${PROJECT_NAME} ${SOURCES})
+ target_link_libraries (${PROJECT_NAME}
+     userver-universal
++    Boost::headers
+ )
+diff --git a/universal/CMakeLists.txt b/universal/CMakeLists.txt
+index c3ee3450..66dce215 100644
+--- a/universal/CMakeLists.txt
++++ b/universal/CMakeLists.txt
+@@ -33,12 +33,6 @@ if(NOT TARGET userver-core)
+   # bug on xenial https://bugs.launchpad.net/ubuntu/+source/llvm-toolchain-3.8/+bug/1664321
+   add_definitions (-DBOOST_REGEX_NO_EXTERNAL_TEMPLATES=1)
+ 
+-  # boost.stacktrace
+-  add_subdirectory(${UNIVERSAL_THIRD_PARTY_DIR}/boost_stacktrace ${CMAKE_CURRENT_BINARY_DIR}/boost_stacktrace)
+-  set_target_properties(userver-stacktrace PROPERTIES
+-    CXX_EXTENSIONS OFF
+-    POSITION_INDEPENDENT_CODE ON
+-  )
+ 
+   # sanitizers fixups
+   add_subdirectory(${UNIVERSAL_THIRD_PARTY_DIR}/compiler-rt ${CMAKE_CURRENT_BINARY_DIR}/compiler-rt)
+@@ -72,18 +66,23 @@ list(REMOVE_ITEM SOURCES ${UNIT_TEST_SOURCES} ${BENCH_SOURCES})
+ set(CMAKE_THREAD_PREFER_PTHREAD ON)
+ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ find_package(Threads REQUIRED)
+-find_package(Boost REQUIRED COMPONENTS program_options filesystem regex)
++find_package(Boost REQUIRED COMPONENTS program_options filesystem regex stacktrace)
+ find_package_required(ZLIB "zlib1g-dev")
+ 
+-include(SetupGTest)
+-include(SetupGBench)
+-include(SetupCryptoPP)
++if (USERVER_IS_THE_ROOT_PROJECT)
++  find_package(GTest REQUIRED)
++  find_package(benchmark REQUIRED)
++endif()
++find_package(cryptopp REQUIRED)
+ 
+ find_package(Iconv REQUIRED)
+-find_package_required(libyamlcpp "libyaml-cpp-dev")
++find_package(yaml-cpp REQUIRED)
+ find_package_required(OpenSSL "libssl-dev")
+-include(SetupFmt)
+-include(SetupCCTZ)
++find_package(fmt REQUIRED)
++find_package(cctz REQUIRED)
++
++find_package(RapidJSON REQUIRED)
++target_compile_definitions(RapidJSON::RapidJSON INTERFACE RAPIDJSON_HAS_STDSTRING)
+ 
+ add_library(${PROJECT_NAME} STATIC ${SOURCES})
+ set_target_properties(${PROJECT_NAME} PROPERTIES
+@@ -121,18 +120,19 @@ target_link_libraries(${PROJECT_NAME}
+   PUBLIC
+     Threads::Threads
+     sanitize-target
+-    libyamlcpp
+-    fmt
+-    cctz
+-    userver-stacktrace
++    yaml-cpp
++    fmt::fmt
++    cctz::cctz
++    Boost::stacktrace
+   PRIVATE
+     Boost::filesystem
+     Boost::program_options
+     Boost::regex
+-    CryptoPP
++    cryptopp-static
+     OpenSSL::Crypto
+     OpenSSL::SSL
+     ZLIB::ZLIB
++    RapidJSON::RapidJSON
+ )
+ 
+ set(UNIVERSAL_PUBLIC_INCLUDE_DIRS
+@@ -163,8 +163,9 @@ if (USERVER_IS_THE_ROOT_PROJECT)
+     )
+     target_link_libraries(${PROJECT_NAME}_unittest
+       PUBLIC
+-        libgtest
+-        libgmock
++        GTest::gtest
++        GTest::gmock
++        GTest::gtest_main
+         ${PROJECT_NAME}
+       PRIVATE
+         Boost::program_options
+@@ -180,7 +181,7 @@ if (USERVER_IS_THE_ROOT_PROJECT)
+     )
+     target_link_libraries(${PROJECT_NAME}_benchmark
+       PUBLIC
+-        libbenchmark
++        benchmark::benchmark
+         ${PROJECT_NAME}
+     )
+     add_google_benchmark_tests(${PROJECT_NAME}_benchmark)
+-- 
+2.34.1
+

--- a/conan/test_package/CMakeLists.txt
+++ b/conan/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR}/cmake)
+
+find_package(userver REQUIRED)
+
+
+add_executable(hello_service hello_service.cpp)
+set_property(TARGET hello_service PROPERTY CXX_STANDARD 17)
+
+
+target_link_libraries(hello_service PRIVATE userver::userver)

--- a/conan/test_package/conanfile.py
+++ b/conan/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake
+
+
+class UserverTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake_find_package"
+
+    def requirements(self):
+        self.requires("userver/1.0.0")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        self.run("./hello_service")

--- a/conan/test_package/hello_service.cpp
+++ b/conan/test_package/hello_service.cpp
@@ -1,0 +1,26 @@
+#include <userver/utest/using_namespace_userver.hpp>
+
+#include <userver/components/minimal_server_component_list.hpp>
+#include <userver/server/handlers/http_handler_base.hpp>
+#include <userver/utils/daemon_run.hpp>
+
+class Hello final : public server::handlers::HttpHandlerBase {
+ public:
+  // `kName` is used as the component name in static config
+  static constexpr std::string_view kName = "handler-hello-sample";
+
+  // Component is valid after construction and is able to accept requests
+  using HttpHandlerBase::HttpHandlerBase;
+
+  std::string HandleRequestThrow(
+      const server::http::HttpRequest&,
+      server::request::RequestContext&) const override {
+    return "Hello world!\n";
+  }
+};
+
+int main(int argc, char* argv[]) {
+  const auto component_list =
+      components::MinimalServerComponentList().Append<Hello>();
+  return 0;
+}

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,0 +1,7 @@
+patches:
+  "1.0.0":
+    - patch_file: "conan/patches/0001-thirdparty_packages_from_conan.patch"
+      patch_type: "conan"
+      patch_description: "Patch cmakelists to use thirdparty packages from conan"
+
+

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,179 @@
+from conan.tools.files import apply_conandata_patches
+from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.51.0"
+
+class UserverConan(ConanFile):
+    name = "userver"
+    version = "1.0.0"
+    description = "The C++ Asynchronous Framework"
+    topics = ("framework", "coroutines", "asynchronous")
+    url = "https://github.com/userver-framework/userver"
+    homepage = "https://userver.tech/"
+    license = "Apache-2.0"
+    exports_sources = "*"
+    generators = "cmake_find_package"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False], "fPIC": [True, False], 
+        "with_jemalloc": [True, False],
+        "with_mongodb": [True, False],
+        "with_postgresql": [True, False],
+        "with_postgresql_extra": [True, False],
+        "with_redis": [True, False],
+        "with_grpc": [True, False],
+        "with_clickhouse": [True, False],
+        "with_universal": [True, False],
+        "with_rabbitmq": [True, False],
+        "with_utest" : [True, False],
+        "namespace": ["ANY"],
+        "namespace_begin": ["ANY"],
+        "namespace_end": ["ANY"]
+    }
+
+    default_options = {
+        "shared": False, "fPIC": True, 
+        "with_jemalloc": False,
+        "with_mongodb": True, 
+        "with_postgresql": True,
+        "with_postgresql_extra": False,
+        "with_redis": True,
+        "with_grpc": False, 
+        "with_clickhouse": False,
+        "with_universal": True,
+        "with_rabbitmq": True,
+        "with_utest": True,
+        "namespace": "userver",
+        "namespace_begin": "",
+        "namespace_end": ""
+    }
+
+    #scm = {
+        #"type": "git",
+        #"url": "https://github.com/userver-framework/userver.git",
+        #"revision": "develop"
+    #}
+
+    @property
+    def _source_subfolder(self):
+        return "source"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+        if not self.options.namespace_begin:
+            self.options.namespace_begin = f"namespace {self.options.namespace} {{"
+        if not self.options.namespace_end:
+            self.options.namespace_end = "}"
+
+    def requirements(self):
+        self.requires("boost/1.79.0")
+        self.requires("libev/4.33")
+        self.requires("spdlog/1.9.0")
+        self.requires("fmt/8.1.1")
+        self.requires("c-ares/1.18.1")
+        self.requires("libcurl/7.68.0")
+        self.requires("cryptopp/8.6.0")
+        self.requires("yaml-cpp/0.7.0")
+        self.requires("cctz/2.3")
+        self.requires("http_parser/2.9.4")
+        self.requires("openssl/1.1.1q")
+        self.requires("rapidjson/cci.20220822")
+        self.requires("concurrentqueue/1.0.3")
+
+        if self.options.with_jemalloc:
+            self.requires("jemalloc/5.2.1")
+        if self.options.with_grpc:
+            self.requires("grpc/1.48.0")
+        if self.options.with_postgresql:
+            self.requires("libpq/14.2") 
+        if self.options.with_mongodb:
+            self.requires("mongo-c-driver/1.22.0")
+            self.options["mongo-c-driver"].with_sasl = "cyrus"
+        if self.options.with_redis:
+            self.requires("hiredis/1.0.2")   
+        if self.options.with_rabbitmq:
+            self.requires("amqp-cpp/4.3.16")      
+        if self.options.with_utest:
+            self.requires("gtest/1.12.1") 
+            self.requires("benchmark/1.6.2") 
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["CMAKE_FIND_DEBUG_MODE"] = "OFF"
+
+        cmake.definitions["USERVER_OPEN_SOURCE_BUILD"] = "ON"
+        cmake.definitions["USERVER_IS_THE_ROOT_PROJECT"] = "OFF"
+        cmake.definitions["USERVER_DOWNLOAD_PACKAGES"] = "ON"
+        cmake.definitions["USERVER_FEATURE_DWCAS"] = "ON"
+        cmake.definitions["USERVER_NAMESPACE"] = self.options.namespace
+        cmake.definitions["USERVER_NAMESPACE_BEGIN"] = self.options.namespace_begin
+        cmake.definitions["USERVER_NAMESPACE_END"] = self.options.namespace_end
+
+        if not self.options.with_jemalloc:
+            cmake.definitions["USERVER_FEATURE_JEMALLOC"] = "OFF"
+        if not self.options.with_mongodb:
+            cmake.definitions["USERVER_FEATURE_MONGODB"] = "OFF"
+        if not self.options.with_postgresql:
+            cmake.definitions["USERVER_FEATURE_POSTGRESQL"] = "OFF"
+        if not self.options.with_postgresql_extra:
+            cmake.definitions["USERVER_FEATURE_PATCH_LIBPQ"] = "OFF"    
+        if not self.options.with_redis:
+            cmake.definitions["USERVER_FEATURE_REDIS"] = "OFF"
+        if not self.options.with_grpc:
+            cmake.definitions["USERVER_FEATURE_GRPC"] = "OFF"
+        if not self.options.with_clickhouse:
+            cmake.definitions["USERVER_FEATURE_CLICKHOUSE"] = "OFF"
+        if not self.options.with_universal:
+            cmake.definitions["USERVER_FEATURE_UNIVERSAL"] = "OFF"
+        if not self.options.with_rabbitmq:
+            cmake.definitions["USERVER_FEATURE_RABBITMQ"] = "OFF" 
+        if not self.options.with_utest:
+            cmake.definitions["USERVER_FEATURE_UTEST"] = "OFF"    
+            
+
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+
+        apply_conandata_patches(self)
+
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses")
+        
+        self.copy(pattern="*", dst="include", src="core/include", keep_path=True)
+        self.copy(pattern="*", dst="include", src="shared/include", keep_path=True)
+
+        if self.options.with_grpc:
+            self.copy(pattern="*", dst="include", src="grpc/include", keep_path=True)
+        if self.options.with_postgresql:
+            self.copy(pattern="*", dst="include", src="postgresql/include", keep_path=True)    
+        if self.options.with_mongodb:
+            self.copy(pattern="*", dst="include", src="mongo/include", keep_path=True)
+        if self.options.with_redis:
+            self.copy(pattern="*", dst="include", src="redis/include", keep_path=True)
+        if self.options.with_rabbitmq:
+            self.copy(pattern="*", dst="include", src="rabbitmq/include", keep_path=True) 
+        if self.options.with_clickhouse:
+            self.copy(pattern="*", dst="include", src="clickhouse/include", keep_path=True)                        
+            
+        self.copy(pattern="*.a", dst="lib", src=os.path.join(self._build_subfolder, "userver"), keep_path=False)
+        self.copy(pattern="*.so", dst="lib", src=os.path.join(self._build_subfolder, "userver"), keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+
+        self.cpp_info.defines.append(f"USERVER_NAMESPACE={self.options.namespace}")
+        self.cpp_info.defines.append(f"USERVER_NAMESPACE_BEGIN={self.options.namespace_begin}")
+        self.cpp_info.defines.append(f"USERVER_NAMESPACE_END={self.options.namespace_end}")


### PR DESCRIPTION
Introduce conan package as #119 
Diffs from another pr:
- Do not change anything in source
- Instead of directly changes in source pr introduces another way: patch sources (it's how conan-center-index packaging works). Patch contains only changing packages names and prefer conan packages over source tree thirdparty packages.
- Gihub actions 

Why patch? As previosly was said there is no current plans to change package naming so I decided do not modify source tree and proposed patch for conan.

# Features

Core library building
- [x] Stacktrace support
- [x] Mongodb feature
- [x] Postresql feature
- [ ] Postresql-extra feature (there is no cci package krb5, https://github.com/conan-io/conan-center-index/issues/4102)
- [x] Redis feature
- [ ] Clickhouse feature (there is no cci package)
- [x] GRPC feature
- [x] RabbitMQ feature
- [x] Universal feature

# Current problems
Userver conan package as one monolithic package (userver for cmake for example) instead of 

Finally, big thanx to @JorgenPo 