### PR TITLE
feat core: use coarse now for http Date header

### DIFF
--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -186,8 +186,8 @@ void HttpResponse::SendResponse(engine::io::Socket& socket) {
   if (headers_.find(USERVER_NAMESPACE::http::headers::kDate) == end) {
     static const std::string kFormatString = "%a, %d %b %Y %H:%M:%S %Z";
     static const auto tz = cctz::utc_time_zone();
-    const auto& time_str =
-        cctz::format(kFormatString, utils::datetime::WallCoarseClock::now(), tz);
+    const auto& time_str = cctz::format(
+        kFormatString, utils::datetime::WallCoarseClock::now(), tz);
 
     impl::OutputHeader(header, USERVER_NAMESPACE::http::headers::kDate,
                        time_str);

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -7,7 +7,6 @@
 
 #include <userver/engine/deadline.hpp>
 #include <userver/engine/io/socket.hpp>
-#include <userver/engine/sleep.hpp>
 #include <userver/hostinfo/blocking/get_hostname.hpp>
 #include <userver/http/common_headers.hpp>
 #include <userver/http/content_type.hpp>
@@ -15,7 +14,7 @@
 #include <userver/tracing/set_throttle_reason.hpp>
 #include <userver/tracing/span.hpp>
 #include <userver/utils/assert.hpp>
-#include <userver/utils/userver_info.hpp>
+#include <userver/utils/datetime/wall_coarse_clock.hpp>
 
 #include "http_request_impl.hpp"
 
@@ -188,7 +187,7 @@ void HttpResponse::SendResponse(engine::io::Socket& socket) {
     static const std::string kFormatString = "%a, %d %b %Y %H:%M:%S %Z";
     static const auto tz = cctz::utc_time_zone();
     const auto& time_str =
-        cctz::format(kFormatString, std::chrono::system_clock::now(), tz);
+        cctz::format(kFormatString, utils::datetime::WallCoarseClock::now(), tz);
 
     impl::OutputHeader(header, USERVER_NAMESPACE::http::headers::kDate,
                        time_str);

--- a/shared/include/userver/utils/datetime/steady_coarse_clock.hpp
+++ b/shared/include/userver/utils/datetime/steady_coarse_clock.hpp
@@ -9,9 +9,9 @@ USERVER_NAMESPACE_BEGIN
 
 namespace utils::datetime {
 
-/// @brief Steady clock with up to a few millisecond resulution that is slightly
+/// @brief Steady clock with up to a few millisecond resolution that is slightly
 /// faster than the std::chrono::steady_clock
-struct SteadyCoarseClock {
+struct SteadyCoarseClock final {
   // Duration matches steady clock, but it is updated once in a few milliseconds
   using duration = std::chrono::steady_clock::duration;
   using rep = duration::rep;

--- a/shared/include/userver/utils/datetime/wall_coarse_clock.hpp
+++ b/shared/include/userver/utils/datetime/wall_coarse_clock.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <chrono>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace utils::datetime {
+
+/// @brief System clock with up to a few millisecond resolution that is slightly
+/// faster than the std::chrono::system_clock
+struct WallCoarseClock final {
+  // Duration matches system clock, but it is updated once in a few milliseconds
+  using duration = std::chrono::system_clock::duration;
+  using rep = duration::rep;
+  using period = duration::period;
+  using time_point = std::chrono::system_clock::time_point;
+
+  static constexpr bool is_steady = false;
+
+  static time_point now() noexcept;
+  static duration resolution() noexcept;
+};
+
+}  // namespace utils::datetime
+
+USERVER_NAMESPACE_END

--- a/shared/include/userver/utils/datetime/wall_coarse_clock.hpp
+++ b/shared/include/userver/utils/datetime/wall_coarse_clock.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+/// @file userver/utils/datetime/wall_coarse_clock.hpp
+/// @brief @copybrief utils::datetime::WallCoarseClock
+
 #include <chrono>
 
 USERVER_NAMESPACE_BEGIN

--- a/shared/src/utils/datetime/coarse_clock_gettime.hpp
+++ b/shared/src/utils/datetime/coarse_clock_gettime.hpp
@@ -26,7 +26,7 @@ TimePoint CoarseNow() noexcept {
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ::timespec tp;
-  const auto res = ::clock_gettime(kCoarseSteadyClockNativeFlag, &tp);
+  const auto res = ::clock_gettime(Flag, &tp);
   UASSERT_MSG(res == 0, "Must always succeed");
   return TimePoint{std::chrono::seconds(tp.tv_sec) +
                     std::chrono::nanoseconds(tp.tv_nsec)};
@@ -39,7 +39,7 @@ Duration CoarseResolution() noexcept {
   static const Duration cached_resolution = []() {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     ::timespec tp;
-    const auto res = ::clock_getres(kCoarseSteadyClockNativeFlag, &tp);
+    const auto res = ::clock_getres(Flag, &tp);
     UASSERT_MSG(res == 0, "Must always succeed");
     return std::chrono::seconds(tp.tv_sec) +
            std::chrono::nanoseconds(tp.tv_nsec);

--- a/shared/src/utils/datetime/coarse_clock_gettime.hpp
+++ b/shared/src/utils/datetime/coarse_clock_gettime.hpp
@@ -11,7 +11,7 @@ namespace utils::datetime {
 #if defined(CLOCK_MONOTONIC_COARSE)
 constexpr auto kCoarseSteadyClockNativeFlag = CLOCK_MONOTONIC_COARSE;
 #else
-constexpr auto kCoarseClockNativeFlag = CLOCK_MONOTONIC;
+constexpr auto kCoarseSteadyClockNativeFlag = CLOCK_MONOTONIC;
 #endif
 
 #if defined(CLOCK_REALTIME_COARSE)

--- a/shared/src/utils/datetime/coarse_clock_gettime.hpp
+++ b/shared/src/utils/datetime/coarse_clock_gettime.hpp
@@ -1,0 +1,53 @@
+#include <userver/utils/datetime/steady_coarse_clock.hpp>
+
+#include <ctime>
+
+#include <userver/utils/assert.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace utils::datetime {
+
+#if defined(CLOCK_MONOTONIC_COARSE)
+constexpr auto kCoarseSteadyClockNativeFlag = CLOCK_MONOTONIC_COARSE;
+#else
+constexpr auto kCoarseClockNativeFlag = CLOCK_MONOTONIC;
+#endif
+
+#if defined(CLOCK_REALTIME_COARSE)
+constexpr auto kCoarseRealtimeClockNativeFlag = CLOCK_REALTIME_COARSE;
+#else
+constexpr auto kCoarseRealtimeClockNativeFlag = CLOCK_REALTIME;
+#endif
+
+template <typename TimePoint, int Flag>
+TimePoint CoarseNow() noexcept {
+  static_assert(Flag == kCoarseSteadyClockNativeFlag || Flag == kCoarseRealtimeClockNativeFlag);
+
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  ::timespec tp;
+  const auto res = ::clock_gettime(kCoarseSteadyClockNativeFlag, &tp);
+  UASSERT_MSG(res == 0, "Must always succeed");
+  return TimePoint{std::chrono::seconds(tp.tv_sec) +
+                    std::chrono::nanoseconds(tp.tv_nsec)};
+}
+
+template <typename Duration, int Flag>
+Duration CoarseResolution() noexcept {
+  static_assert(Flag == kCoarseSteadyClockNativeFlag || Flag == kCoarseRealtimeClockNativeFlag);
+
+  static const Duration cached_resolution = []() {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+    ::timespec tp;
+    const auto res = ::clock_getres(kCoarseSteadyClockNativeFlag, &tp);
+    UASSERT_MSG(res == 0, "Must always succeed");
+    return std::chrono::seconds(tp.tv_sec) +
+           std::chrono::nanoseconds(tp.tv_nsec);
+  }();
+
+  return cached_resolution;
+}
+
+}  // namespace utils::datetime
+
+USERVER_NAMESPACE_END

--- a/shared/src/utils/datetime/steady_coarse_clock.cpp
+++ b/shared/src/utils/datetime/steady_coarse_clock.cpp
@@ -1,39 +1,19 @@
 #include <userver/utils/datetime/steady_coarse_clock.hpp>
 
-#include <ctime>
-
-#include <userver/utils/assert.hpp>
+#include <utils/datetime/coarse_clock_gettime.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
 namespace utils::datetime {
 
-#if defined(CLOCK_MONOTONIC_COARSE)
-constexpr auto kCoarseClockNativeFlag = CLOCK_MONOTONIC_COARSE;
-#else
-constexpr auto kCoarseClockNativeFlag = CLOCK_MONOTONIC;
-#endif
+constexpr auto kClockFlag = kCoarseSteadyClockNativeFlag;
 
 SteadyCoarseClock::time_point SteadyCoarseClock::now() noexcept {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-  ::timespec tp;
-  const auto res = ::clock_gettime(kCoarseClockNativeFlag, &tp);
-  UASSERT_MSG(res == 0, "Must always succeed");
-  return time_point(std::chrono::seconds(tp.tv_sec) +
-                    std::chrono::nanoseconds(tp.tv_nsec));
+  return CoarseNow<time_point, kClockFlag>();
 }
 
 SteadyCoarseClock::duration SteadyCoarseClock::resolution() noexcept {
-  static const duration cached_resolution = []() {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-    ::timespec tp;
-    const auto res = ::clock_getres(kCoarseClockNativeFlag, &tp);
-    UASSERT_MSG(res == 0, "Must always succeed");
-    return std::chrono::seconds(tp.tv_sec) +
-           std::chrono::nanoseconds(tp.tv_nsec);
-  }();
-
-  return cached_resolution;
+  return CoarseResolution<duration, kClockFlag>();
 }
 
 }  // namespace utils::datetime

--- a/shared/src/utils/datetime/wall_coarse_clock.cpp
+++ b/shared/src/utils/datetime/wall_coarse_clock.cpp
@@ -1,0 +1,21 @@
+#include <userver/utils/datetime/wall_coarse_clock.hpp>
+
+#include <utils/datetime/coarse_clock_gettime.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace utils::datetime {
+
+constexpr auto kClockFlag = kCoarseRealtimeClockNativeFlag;
+
+WallCoarseClock::time_point WallCoarseClock::now() noexcept {
+  return CoarseNow<time_point, kClockFlag>();
+}
+
+WallCoarseClock::duration WallCoarseClock::resolution() noexcept {
+  return CoarseResolution<duration, kClockFlag>();
+}
+
+} // namespace utils::datetime
+
+USERVER_NAMESPACE_END

--- a/shared/src/utils/datetime/wall_coarse_clock_benchmark.cpp
+++ b/shared/src/utils/datetime/wall_coarse_clock_benchmark.cpp
@@ -1,0 +1,23 @@
+#include <userver/utils/datetime/wall_coarse_clock.hpp>
+
+#include <chrono>
+
+#include <benchmark/benchmark.h>
+
+USERVER_NAMESPACE_BEGIN
+
+void wall_clock_benchmark(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(std::chrono::system_clock::now());
+  }
+}
+BENCHMARK(wall_clock_benchmark);
+
+void wall_coarse_clock_benchmark(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(utils::datetime::WallCoarseClock::now());
+  }
+}
+BENCHMARK(wall_coarse_clock_benchmark);
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
We don't need the very precise `system_clock::now` in Date header, because it is truncated to seconds anyway.

I'm hitting this [AMD/Kernel bug](https://bugzilla.kernel.org/show_bug.cgi?id=202525) at my machine, thus my clocksource is HPET, and benchmarks look like this:

```
Benchmark                              Time             CPU   Iterations
------------------------------------------------------------------------
steady_clock_benchmark              1102 ns         1102 ns       629395
steady_coarse_clock_benchmark       4.53 ns         4.53 ns    154522883
wall_clock_benchmark                1108 ns         1108 ns       629032
wall_coarse_clock_benchmark         4.28 ns         4.28 ns    163649300
```
