### PR TITLE
feat core: do not use RequestsView if no one is interested in it

### DIFF
--- a/core/src/server/server.cpp
+++ b/core/src/server/server.cpp
@@ -59,9 +59,7 @@ class ServerImpl final {
   mutable std::shared_timed_mutex stat_mutex_;
   bool is_stopping_{false};
 
-#ifndef NDEBUG
   std::atomic<bool> started_{false};
-#endif
   std::atomic<bool> has_requests_view_watchers_{false};
 };
 
@@ -180,9 +178,7 @@ void ServerImpl::StartPortInfos() {
     LOG_WARNING() << "No 'listener-monitor' in 'server' component";
   }
 
-#ifndef NDEBUG
   started_.store(true);
-#endif
 }
 
 Server::Server(ServerConfig config,

--- a/core/src/server/server.cpp
+++ b/core/src/server/server.cpp
@@ -45,10 +45,10 @@ class ServerImpl final {
 
   void Stop();
 
-  void InitPortInfo(PortInfo& info, const ServerConfig& config,
+  static void InitPortInfo(PortInfo& info, const ServerConfig& config,
                     const net::ListenerConfig& listener_config,
                     const components::ComponentContext& component_context,
-                    bool is_monitor) const;
+                    bool is_monitor);
 
   void StartPortInfos();
 
@@ -132,7 +132,7 @@ void ServerImpl::InitPortInfo(
     PortInfo& info, const ServerConfig& config,
     const net::ListenerConfig& listener_config,
     const components::ComponentContext& component_context,
-    bool is_monitor) const {
+    bool is_monitor) {
   LOG_INFO() << "Creating listener" << (is_monitor ? " (monitor)" : "");
 
   engine::TaskProcessor& task_processor =

--- a/core/src/server/server.cpp
+++ b/core/src/server/server.cpp
@@ -46,10 +46,10 @@ class ServerImpl final {
 
   void Stop();
 
-  static void InitPortInfo(PortInfo& info, const ServerConfig& config,
-                    const net::ListenerConfig& listener_config,
-                    const components::ComponentContext& component_context,
-                    bool is_monitor);
+  static void InitPortInfo(
+      PortInfo& info, const ServerConfig& config,
+      const net::ListenerConfig& listener_config,
+      const components::ComponentContext& component_context, bool is_monitor);
 
   void StartPortInfos();
 
@@ -133,8 +133,7 @@ void ServerImpl::Stop() {
 void ServerImpl::InitPortInfo(
     PortInfo& info, const ServerConfig& config,
     const net::ListenerConfig& listener_config,
-    const components::ComponentContext& component_context,
-    bool is_monitor) {
+    const components::ComponentContext& component_context, bool is_monitor) {
   LOG_INFO() << "Creating listener" << (is_monitor ? " (monitor)" : "");
 
   engine::TaskProcessor& task_processor =
@@ -286,7 +285,7 @@ void Server::Start() {
 void Server::Stop() { pimpl->Stop(); }
 
 RequestsView& Server::GetRequestsView() {
-  UASSERT(!pimpl->started_ || pimpl->has_requests_view_watchers_.load());
+  UASSERT(!pimpl->started_.load() || pimpl->has_requests_view_watchers_.load());
 
   pimpl->has_requests_view_watchers_.store(true);
   return *pimpl->requests_view_;


### PR DESCRIPTION
The only use of `Server::GetRequestsView` (hence the only use of `RequestsView`) is in `InspectRequests`, which is not even used in `MinimalServerComponentList`.

`RequestsView::DoJob` takes around ~1.2-1.5% in the perfflames i've got, not much, but still.

The proposed solution doesn't work correctly if `Server::GetRequestsView` is requested from outside of component constructor, but no one uses it anyway except for `InspectRequests`, and no one can, because `RequestsView` is private.