### PR TITLE
feat http, shared: bits of perf here and there

### DIFF
--- a/core/include/userver/server/request/request_base.hpp
+++ b/core/include/userver/server/request/request_base.hpp
@@ -31,6 +31,7 @@ class RequestBase {
   void SetTaskCreateTime();
   void SetTaskStartTime();
   void SetResponseNotifyTime();
+  void SetResponseNotifyTime(std::chrono::steady_clock::time_point now);
   void SetStartSendResponseTime();
   void SetFinishSendResponseTime();
 

--- a/core/include/userver/server/request/response_base.hpp
+++ b/core/include/userver/server/request/response_base.hpp
@@ -57,6 +57,7 @@ class ResponseBase {
   /// @cond
   // TODO: server internals. remove from public interface
   void SetReady();
+  void SetReady(std::chrono::steady_clock::time_point now);
   virtual void SetSendFailed(
       std::chrono::steady_clock::time_point failure_time);
   bool IsLimitReached() const;

--- a/core/src/server/http/http_request_handler.cpp
+++ b/core/src/server/http/http_request_handler.cpp
@@ -176,8 +176,9 @@ engine::TaskWithResult<void> HttpRequestHandler::StartRequestTask(
     request::RequestContext context;
     handler->HandleRequest(*request, context);
 
-    request->SetResponseNotifyTime();
-    request->GetResponse().SetReady();
+    const auto now = std::chrono::steady_clock::now();
+    request->SetResponseNotifyTime(now);
+    request->GetResponse().SetReady(now);
   };
 
   if (!is_monitor_ && throttling_enabled) {

--- a/core/src/server/http/http_request_handler.cpp
+++ b/core/src/server/http/http_request_handler.cpp
@@ -13,6 +13,7 @@
 #include <userver/logging/logger.hpp>
 #include <userver/server/http/http_request.hpp>
 #include <userver/server/http/http_response.hpp>
+#include <userver/utils/assert.hpp>
 #include "http_request_impl.hpp"
 
 USERVER_NAMESPACE_BEGIN
@@ -22,7 +23,10 @@ namespace {
 
 engine::TaskWithResult<void> StartFailsafeTask(
     std::shared_ptr<request::RequestBase> request) {
-  auto& http_request = dynamic_cast<http::HttpRequestImpl&>(*request);
+  UASSERT(dynamic_cast<http::HttpRequestImpl*>(&*request));
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+  auto& http_request = static_cast<http::HttpRequestImpl&>(*request);
+
   const auto* handler = http_request.GetHttpHandler();
   static handlers::HttpRequestStatistics dummy_statistics;
 
@@ -92,8 +96,11 @@ utils::statistics::MetricTag<std::atomic<size_t>> kCcStatusCodeIsCustom{
 
 engine::TaskWithResult<void> HttpRequestHandler::StartRequestTask(
     std::shared_ptr<request::RequestBase> request) const {
+  UASSERT(dynamic_cast<http::HttpRequestImpl*>(&*request));
   const auto& http_request =
-      dynamic_cast<const http::HttpRequestImpl&>(*request);
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+      static_cast<const http::HttpRequestImpl&>(*request);
+
   auto& http_response = http_request.GetHttpResponse();
   http_response.SetHeader(USERVER_NAMESPACE::http::headers::kServer,
                           server_name_);

--- a/core/src/server/request/request_base.cpp
+++ b/core/src/server/request/request_base.cpp
@@ -17,7 +17,11 @@ void RequestBase::SetTaskStartTime() {
 }
 
 void RequestBase::SetResponseNotifyTime() {
-  response_notify_time_ = std::chrono::steady_clock::now();
+  SetResponseNotifyTime(std::chrono::steady_clock::now());
+}
+
+void RequestBase::SetResponseNotifyTime(std::chrono::steady_clock::time_point now) {
+  response_notify_time_ = now;
 }
 
 void RequestBase::SetStartSendResponseTime() {

--- a/core/src/server/request/response_base.cpp
+++ b/core/src/server/request/response_base.cpp
@@ -57,7 +57,11 @@ void ResponseBase::SetData(std::string data) {
 }
 
 void ResponseBase::SetReady() {
-  ready_time_ = std::chrono::steady_clock::now();
+  SetReady(std::chrono::steady_clock::now());
+}
+
+void ResponseBase::SetReady(std::chrono::steady_clock::time_point now) {
+  ready_time_ = now;
   is_ready_ = true;
 }
 

--- a/shared/include/userver/utils/encoding/hex.hpp
+++ b/shared/include/userver/utils/encoding/hex.hpp
@@ -48,7 +48,6 @@ void ToHex(std::string_view input, std::string& out) noexcept;
 /// @param input range of input bytes
 inline std::string ToHex(std::string_view data) noexcept {
   std::string result;
-  result.reserve(LengthInHexForm(data));
   ToHex(data, result);
   return result;
 }

--- a/shared/src/utils/encoding/hex.cpp
+++ b/shared/src/utils/encoding/hex.cpp
@@ -122,14 +122,15 @@ std::string_view GetHexPart(std::string_view encoded) noexcept {
 
 void ToHex(std::string_view input, std::string& out) noexcept {
   out.clear();
-  out.reserve(input.size() * 2);
+  out.resize(input.size() * 2);
   const auto* first = input.data();
   const auto* last = input.data() + input.size();
+  size_t ind = 0;
   while (first != last) {
     const auto value = *first;
     // We don't use ToHexChar because it does range checking
-    out.push_back(detail::kXdigits[(value >> 4) & 0xf]);
-    out.push_back(detail::kXdigits[value & 0xf]);
+    out[ind++] = detail::kXdigits[(value >> 4) & 0xf];
+    out[ind++] = detail::kXdigits[value & 0xf];
     ++first;
   }
 }

--- a/shared/src/utils/encoding/hex_benchmark.cpp
+++ b/shared/src/utils/encoding/hex_benchmark.cpp
@@ -1,0 +1,18 @@
+#include <benchmark/benchmark.h>
+
+#include <userver/utils/encoding/hex.hpp>
+
+#include <string_view>
+
+USERVER_NAMESPACE_BEGIN
+
+void to_hex_benchmark(benchmark::State& state) {
+  constexpr std::string_view kUuid = "21e30c92afe54396";
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(utils::encoding::ToHex(kUuid));
+  }
+}
+BENCHMARK(to_hex_benchmark);
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
1. replaced `dynamic_cast` with `UASSERT + static_cast` 
2. reused current time instead of calling `now()` 2 times 
3. improved `encoding::ToHex`:
```
Comparing ./develop to ./patch
Benchmark                          Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------
to_hex_benchmark                -0.3815         -0.3815            57            35            57            35
OVERALL_GEOMEAN                 -0.3750         -0.3750             0             0             0             0
```