### PR TITLE
feat cache: implement dumps for LRU caches

### DIFF
--- a/core/include/userver/cache/lru_cache_component_base.hpp
+++ b/core/include/userver/cache/lru_cache_component_base.hpp
@@ -7,6 +7,9 @@
 #include <userver/cache/lru_cache_config.hpp>
 #include <userver/components/loggable_component_base.hpp>
 #include <userver/concurrent/async_event_source.hpp>
+#include <userver/dump/dumper.hpp>
+#include <userver/dump/meta.hpp>
+#include <userver/dump/operations.hpp>
 #include <userver/dynamic_config/source.hpp>
 #include <userver/testsuite/component_control.hpp>
 #include <userver/utils/statistics/storage.hpp>
@@ -27,6 +30,8 @@ formats::json::Value GetCacheStatisticsAsJson(
   return GetCacheStatisticsAsJson(cache.GetStatistics(),
                                   cache.GetSizeApproximate());
 }
+
+bool HasDumps(const components::ComponentConfig& config);
 
 testsuite::ComponentControl& FindComponentControl(
     const components::ComponentContext& context);
@@ -77,7 +82,8 @@ yaml_config::Schema GetLruCacheComponentBaseSchema();
 // clang-format on
 template <typename Key, typename Value, typename Hash = std::hash<Key>,
           typename Equal = std::equal_to<Key>>
-class LruCacheComponent : public components::LoggableComponentBase {
+class LruCacheComponent : public components::LoggableComponentBase,
+                          private dump::DumpableEntity {
  public:
   using Cache = ExpirableLruCache<Key, Value, Hash, Equal>;
   using CacheWrapper = LruCacheWrapper<Key, Value, Hash, Equal>;
@@ -103,12 +109,19 @@ class LruCacheComponent : public components::LoggableComponentBase {
 
   void UpdateConfig(const LruCacheConfig& config);
 
+  static constexpr bool kCacheIsDumpable =
+      dump::kIsDumpable<Key> && dump::kIsDumpable<Value>;
+
+  void GetAndWrite(dump::Writer& writer) const override;
+  void ReadAndSet(dump::Reader& reader) override;
+
  protected:
   std::shared_ptr<Cache> GetCacheRaw() { return cache_; }
 
  private:
   const std::string name_;
   const LruCacheConfigStatic static_config_;
+  std::optional<dump::Dumper> dumper_;
   const std::shared_ptr<Cache> cache_;
   concurrent::AsyncEventSubscriberScope config_subscription_;
   utils::statistics::Entry statistics_holder_;
@@ -124,6 +137,12 @@ LruCacheComponent<Key, Value, Hash, Equal>::LruCacheComponent(
       static_config_(config),
       cache_(std::make_shared<Cache>(static_config_.ways,
                                      static_config_.GetWaySize())) {
+  if (impl::HasDumps(config)) {
+    dumper_.emplace(config, context, static_cast<dump::DumpableEntity&>(*this));
+    cache_->SetDumper(*dumper_);
+    dumper_->ReadDump();
+  }
+
   cache_->SetMaxLifetime(static_config_.config.lifetime);
   cache_->SetBackgroundUpdate(static_config_.config.background_update);
 
@@ -155,6 +174,10 @@ LruCacheComponent<Key, Value, Hash, Equal>::~LruCacheComponent() {
   invalidator_holder_.reset();
   statistics_holder_.Unregister();
   config_subscription_.Unsubscribe();
+
+  if (dumper_) {
+    dumper_->CancelWriteTaskAndWait();
+  }
 }
 
 template <typename Key, typename Value, typename Hash, typename Equal>
@@ -198,6 +221,26 @@ template <typename Key, typename Value, typename Hash, typename Equal>
 yaml_config::Schema
 LruCacheComponent<Key, Value, Hash, Equal>::GetStaticConfigSchema() {
   return impl::GetLruCacheComponentBaseSchema();
+}
+
+template <typename Key, typename Value, typename Hash, typename Equal>
+void LruCacheComponent<Key, Value, Hash, Equal>::GetAndWrite(
+    dump::Writer& writer) const {
+  if constexpr (kCacheIsDumpable) {
+    cache_->Write(writer);
+  } else {
+    dump::ThrowDumpUnimplemented(name_);
+  }
+}
+
+template <typename Key, typename Value, typename Hash, typename Equal>
+void LruCacheComponent<Key, Value, Hash, Equal>::ReadAndSet(
+    dump::Reader& reader) {
+  if constexpr (kCacheIsDumpable) {
+    cache_->Read(reader);
+  } else {
+    dump::ThrowDumpUnimplemented(name_);
+  }
 }
 
 }  // namespace cache

--- a/core/src/cache/expirable_lru_cache.cpp
+++ b/core/src/cache/expirable_lru_cache.cpp
@@ -1,0 +1,27 @@
+#include <userver/cache/expirable_lru_cache.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace cache::impl {
+
+namespace {
+
+std::atomic<SystemTimePoint> system_clock_now{{}};
+std::atomic<SteadyTimePoint> steady_clock_now{{}};
+
+}  // namespace
+
+void UpdateGlobalTime() {
+  system_clock_now.store(utils::datetime::Now(), std::memory_order_relaxed);
+  steady_clock_now.store(utils::datetime::SteadyNow(),
+                         std::memory_order_relaxed);
+}
+
+std::tuple<SystemTimePoint, SteadyTimePoint> GetGlobalTime() {
+  return {system_clock_now.load(std::memory_order_relaxed),
+          steady_clock_now.load(std::memory_order_relaxed)};
+}
+
+}  // namespace cache::impl
+
+USERVER_NAMESPACE_END

--- a/core/src/cache/expirable_lru_cache_test.cpp
+++ b/core/src/cache/expirable_lru_cache_test.cpp
@@ -3,6 +3,7 @@
 #include <userver/utest/utest.hpp>
 
 #include <userver/cache/expirable_lru_cache.hpp>
+#include <userver/dump/operations_mock.hpp>
 #include <userver/engine/sleep.hpp>
 #include <userver/utils/mock_now.hpp>
 
@@ -14,6 +15,20 @@ using SimpleCacheKey = std::string;
 using SimpleCacheValue = int;
 using SimpleCache = cache::ExpirableLruCache<SimpleCacheKey, SimpleCacheValue>;
 using SimpleWrapper = cache::LruCacheWrapper<SimpleCacheKey, SimpleCacheValue>;
+
+void WriteAndReadFromDump(SimpleCache& cache) {
+  const auto cache_size_before = cache.GetSizeApproximate();
+  dump::MockWriter writer;
+  cache.Write(writer);
+  writer.Finish();
+
+  cache.Invalidate();
+
+  dump::MockReader reader(std::move(writer).Extract());
+  cache.Read(reader);
+  reader.Finish();
+  EXPECT_EQ(cache_size_before, cache.GetSizeApproximate());
+}
 
 void EngineYield() {
   engine::Yield();
@@ -85,6 +100,8 @@ UTEST(ExpirableLruCache, Hit) {
   EXPECT_EQ(1, cache.Get(key, UpdateValue(counter, 1)));
   EXPECT_EQ(Counter::One(), *counter);
 
+  WriteAndReadFromDump(cache);
+
   EXPECT_EQ(1, cache.Get(key, UpdateNever()));
 }
 
@@ -100,6 +117,8 @@ UTEST(ExpirableLruCache, HitOptional) {
   EXPECT_EQ(1, cache.Get(key, UpdateValue(counter, 1)));
   EXPECT_EQ(Counter::One(), *counter);
 
+  WriteAndReadFromDump(cache);
+
   EXPECT_EQ(std::make_optional(1), cache.GetOptional(key, UpdateNever()));
 }
 
@@ -114,6 +133,7 @@ UTEST(ExpirableLruCache, HitOptionalUnexpirable) {
   counter->Flush();
 
   cache.Put(key, 1);
+  WriteAndReadFromDump(cache);
 
   for (int i = 0; i < 10; i++) {
     utils::datetime::MockSleep(std::chrono::seconds(10));
@@ -133,9 +153,11 @@ UTEST(ExpirableLruCache, HitOptionalUnexpirableWithUpdate) {
   counter->Flush();
 
   cache.Put(key, 1);
+  WriteAndReadFromDump(cache);
   utils::datetime::MockSleep(std::chrono::seconds(3));
   EXPECT_EQ(
       1, cache.GetOptionalUnexpirableWithUpdate(key, UpdateValue(counter, 2)));
+  WriteAndReadFromDump(cache);
 
   EngineYield();
 
@@ -155,12 +177,15 @@ UTEST(ExpirableLruCache, HitOptionalNoUpdate) {
 
   cache.Put(key, 1);
   EXPECT_EQ(1, cache.GetOptionalNoUpdate(key));
+
   utils::datetime::MockSleep(std::chrono::seconds(1));
 
   EXPECT_EQ(1, cache.GetOptionalNoUpdate(key));
+
   utils::datetime::MockSleep(std::chrono::seconds(1));
 
   EXPECT_EQ(1, cache.GetOptionalNoUpdate(key));
+
   utils::datetime::MockSleep(std::chrono::seconds(1));
 
   EXPECT_EQ(std::nullopt, cache.GetOptionalNoUpdate(key));
@@ -177,6 +202,8 @@ UTEST(ExpirableLruCache, NoCache) {
   counter->Flush();
   EXPECT_EQ(1, cache.Get(key, UpdateValue(counter, 1), read_mode));
   EXPECT_EQ(Counter::One(), *counter);
+
+  WriteAndReadFromDump(cache);
 
   counter->Flush();
   EXPECT_EQ(2, cache.Get(key, UpdateValue(counter, 2), read_mode));
@@ -196,6 +223,8 @@ UTEST(ExpirableLruCache, Expire) {
   EXPECT_EQ(1, cache.Get(key, UpdateValue(counter, 1)));
   EXPECT_EQ(Counter::One(), *counter);
 
+  WriteAndReadFromDump(cache);
+
   EXPECT_EQ(1, cache.Get(key, UpdateNever()));
 
   utils::datetime::MockSleep(std::chrono::seconds(3));
@@ -203,6 +232,29 @@ UTEST(ExpirableLruCache, Expire) {
   counter->Flush();
   EXPECT_EQ(2, cache.Get(key, UpdateValue(counter, 2)));
   EXPECT_EQ(Counter::One(), *counter);
+}
+
+UTEST(ExpirableLruCache, DumpAndChangeMaxLiftime) {
+  auto counter = std::make_shared<Counter>();
+
+  auto cache = CreateSimpleCache();
+  cache.SetMaxLifetime(std::chrono::seconds(10));
+  SimpleCacheKey key = "my-key";
+
+  utils::datetime::MockNowSet(std::chrono::system_clock::now());
+
+  counter->Flush();
+  EXPECT_EQ(1, cache.Get(key, UpdateValue(counter, 1)));
+  EXPECT_EQ(Counter::One(), *counter);
+  WriteAndReadFromDump(cache);
+
+  EXPECT_EQ(1, cache.Get(key, UpdateNever()));
+
+  cache.SetMaxLifetime(std::chrono::seconds(1));
+  utils::datetime::MockSleep(std::chrono::seconds(2));
+  counter->Flush();
+  EXPECT_EQ(std::nullopt, cache.GetOptionalNoUpdate(key));
+  EXPECT_EQ(Counter::Zero(), *counter);
 }
 
 UTEST(ExpirableLruCache, DefaultNoExpire) {
@@ -217,8 +269,11 @@ UTEST(ExpirableLruCache, DefaultNoExpire) {
   EXPECT_EQ(1, cache.Get(key, UpdateValue(counter, 1)));
   EXPECT_EQ(Counter::One(), *counter);
 
+  WriteAndReadFromDump(cache);
+
   for (int i = 0; i < 10; i++) {
     utils::datetime::MockSleep(std::chrono::seconds(10));
+    WriteAndReadFromDump(cache);
     EXPECT_EQ(1, cache.Get(key, UpdateNever()));
   }
 }
@@ -234,6 +289,8 @@ UTEST(ExpirableLruCache, InvalidateByKey) {
   EXPECT_EQ(Counter::One(), *counter);
 
   cache.InvalidateByKey(key);
+
+  WriteAndReadFromDump(cache);
 
   counter->Flush();
   EXPECT_EQ(2, cache.Get(key, UpdateValue(counter, 2)));
@@ -255,6 +312,8 @@ UTEST(ExpirableLruCache, BackgroundUpdate) {
   EXPECT_EQ(1, cache.Get(key, UpdateValue(counter, 1)));
   EXPECT_EQ(Counter::One(), *counter);
 
+  WriteAndReadFromDump(cache);
+
   EXPECT_EQ(1, cache.Get(key, UpdateNever()));
 
   EngineYield();
@@ -266,6 +325,7 @@ UTEST(ExpirableLruCache, BackgroundUpdate) {
   counter->Flush();
   EXPECT_EQ(1, cache.Get(key, UpdateValue(counter, 2)));
 
+  WriteAndReadFromDump(cache);
   EngineYield();
 
   EXPECT_EQ(Counter::One(), *counter);
@@ -311,11 +371,13 @@ UTEST(LruCacheWrapper, HitWrapper) {
   EXPECT_EQ(std::nullopt, wrapper.GetOptional(key));
   EXPECT_EQ(Counter::Zero(), *counter);
 
+  WriteAndReadFromDump(*cache_ptr);
   counter->Flush();
   EXPECT_EQ(1, wrapper.Get(key));
   EXPECT_EQ(Counter::One(), *counter);
 
   counter->Flush();
+  WriteAndReadFromDump(*cache_ptr);
   EXPECT_EQ(std::make_optional(1), wrapper.GetOptional(key));
   EXPECT_EQ(Counter::Zero(), *counter);
 }

--- a/core/src/cache/lru_cache_component_base.cpp
+++ b/core/src/cache/lru_cache_component_base.cpp
@@ -1,5 +1,6 @@
 #include <userver/cache/lru_cache_component_base.hpp>
 
+#include <userver/components/component_config.hpp>
 #include <userver/components/component_context.hpp>
 #include <userver/components/statistics_storage.hpp>
 #include <userver/dynamic_config/storage/component.hpp>
@@ -56,6 +57,10 @@ utils::statistics::Storage& FindStatisticsStorage(
 dynamic_config::Source FindDynamicConfigSource(
     const components::ComponentContext& context) {
   return context.FindComponent<components::DynamicConfig>().GetSource();
+}
+
+bool HasDumps(const components::ComponentConfig& config) {
+  return config.HasMember("dump");
 }
 
 yaml_config::Schema GetLruCacheComponentBaseSchema() {


### PR DESCRIPTION
**Hi userver-team, I had some free time :wink: and decided to help with the 🚀[big issue](https://github.com/userver-framework/userver/issues/175)🚀**

---
> Implement `dump::DumpableEntity` for `LruCacheComponent`
> Add `dump::Dumper` to `LruCacheComponent`, see `SampleComponentWithDumps`

 `LruCacheComponent` :point_down:
- [X] Inherited from `dump::DumpableEntity`
- [X] Has optional field `dump::Dumper`
- [X] Implemented `GetAndWrite & ReadAndSet` virtual methods from `DumpableEntity`
---
>Implement `Write & Read` for `ExpirableLruCache`

`ExpirableLruCache` :point_down:
- [X] Has no more `private struct MapValue` (detached to `impl::ExpirableValue<Value>`)
- [X] Implemented   `Write() & Read()` functions for `impl::ExpirableValue<Value>` with `steady_clock` time (convert to :clock530:`system_clock` update time of `Key & Value` to be able up it from dump)
- [X] Has pointer to `dumper` if exists
- [X] Notifies `dumper` for all changes in cache (new item / update  / invalidate etc)
---
> Implement `Write & Read` for `NWayLRU` using `VisitAll`

`cache::NWayLru` :point_down:
- [X] Has `Write() & Read()` methods that dumps the cache correctly. 
- [X] `Write()` uses `VisitAll()` for each `Way` for thread-safe binary serialization of `Key & Value` pair. 
- [X] `Read()` at start `Invalidate()` the cache, and then reads from the dump number of `Ways`, and then for each `Way` reads number of elements, and then gets each `Key & Value` pair and `Put()` it into the cache. Deserialization done :boom:
---
> Add a test in `samples` :point_down:
- [X] Integrated `Write & Read` dump testing for `ExpirableLruCache` into existing tests (also checks correct dumping for `NWayLru Write & Read`)
- [ ] Need more integrated tests with using `LruCacheComponent` dump feature in production

Closes #175