### PR TITLE
feat core: optimize http response headers gathering

### DIFF
--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -80,10 +80,20 @@ namespace impl {
 
 void OutputHeader(std::string& header, std::string_view key,
                   std::string_view val) {
-  header.append(key);
-  header.append(kKeyValueHeaderSeparator);
-  header.append(val);
-  header.append(kCrlf);
+  const auto old_size = header.size();
+  header.resize(old_size + key.size() + kKeyValueHeaderSeparator.size() +
+                val.size() + kCrlf.size());
+
+  char* append_position = header.data() + old_size;
+  const auto append = [&append_position](std::string_view what) {
+    std::memcpy(append_position, what.data(), what.size());
+    append_position += what.size();
+  };
+
+  append(key);
+  append(kKeyValueHeaderSeparator);
+  append(val);
+  append(kCrlf);
 }
 
 }  // namespace impl


### PR DESCRIPTION
```
Comparing ./develop to ./faster_output_header
Benchmark                                                Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------------
http_headers_serialization_no_ostreams                -0.2550         -0.2550           287           214           287           214
OVERALL_GEOMEAN                                       -0.2544         -0.2544             0             0             0             0
```

before: https://godbolt.org/z/6rq8KdrnT
after: https://godbolt.org/z/PTfWqrKob