### PR TITLE
feat core: add GetScheme method to HttpRequest

### DIFF
--- a/core/include/userver/server/http/http_request.hpp
+++ b/core/include/userver/server/http/http_request.hpp
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -68,6 +69,9 @@ class HttpRequest final {
 
   std::chrono::duration<double> GetRequestTime() const;
   std::chrono::duration<double> GetResponseTime() const;
+
+  /// @return Scheme from the URL.
+  std::string_view GetScheme() const;
 
   /// @return Host from the URL.
   const std::string& GetHost() const;

--- a/core/src/server/http/http_request.cpp
+++ b/core/src/server/http/http_request.cpp
@@ -44,6 +44,7 @@ std::chrono::duration<double> HttpRequest::GetResponseTime() const {
   return impl_.GetResponseTime();
 }
 
+std::string_view HttpRequest::GetScheme() const { return impl_.GetScheme(); }
 const std::string& HttpRequest::GetHost() const { return impl_.GetHost(); }
 
 const std::string& HttpRequest::GetArg(const std::string& arg_name) const {

--- a/core/src/server/http/http_request_impl.cpp
+++ b/core/src/server/http/http_request_impl.cpp
@@ -93,6 +93,14 @@ std::chrono::duration<double> HttpRequestImpl::GetResponseTime() const {
   return GetResponse().ReadyTime() - StartTime();
 }
 
+std::string_view HttpRequestImpl::GetScheme() const {
+  const auto pos = url_.find(':');
+  if (pos == std::string::npos) {
+    return {};
+  }
+  return std::string_view{url_.data(), pos};
+}
+
 const std::string& HttpRequestImpl::GetHost() const {
   return GetHeader(USERVER_NAMESPACE::http::headers::kHost);
 }

--- a/core/src/server/http/http_request_impl.hpp
+++ b/core/src/server/http/http_request_impl.hpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -42,6 +43,7 @@ class HttpRequestImpl final : public request::RequestBase {
   std::chrono::duration<double> GetRequestTime() const;
   std::chrono::duration<double> GetResponseTime() const;
 
+  std::string_view GetScheme() const;
   const std::string& GetHost() const;
 
   const std::string& GetArg(const std::string& arg_name) const;


### PR DESCRIPTION
The GetScheme method is useful, for example, when you need to generate a link for the user, given what scheme he used to call us.