### PR TITLE
feat docs: archlinux install dependencies manual

### DIFF
--- a/scripts/docs/en/deps/arch.md
+++ b/scripts/docs/en/deps/arch.md
@@ -2,7 +2,6 @@ benchmark
 boost
 c-ares
 ccache
-cctz
 cmake
 crypto++
 curl
@@ -14,10 +13,9 @@ hiredis
 http-parser
 jemalloc
 krb5
-libbacktrace-git
 libev
 mongo-c-driver
-nghttp2
+libnghttp2
 openssl
 postgresql
 postgresql-libs
@@ -31,3 +29,5 @@ python-yaml
 spdlog
 yaml-cpp
 zlib
+makepkg|cctz
+makepkg|libbacktrace-git

--- a/scripts/docs/en/userver/tutorial/build.md
+++ b/scripts/docs/en/userver/tutorial/build.md
@@ -220,7 +220,7 @@ pikaur -S $(cat scripts/docs/en/deps/arch.md | sed 's/^makepkg|//g' | tr '\n' ' 
 ```
 bash
 sudo pacman -S $(cat scripts/docs/en/deps/arch.md | grep -v -- 'makepkg|' | tr '\n' ' ')
-cat scripts/docs/en/deps/arch.md | grep -oP '^makepkg|\K.*' | while read ;\
+cat scripts/docs/en/deps/arch.md | grep -oP '^makepkg\|\K.*' | while read ;\
   do \
     DIR=$(mktemp -d) ;\
     git clone https://aur.archlinux.org/$REPLY.git $DIR ;\

--- a/scripts/docs/en/userver/tutorial/build.md
+++ b/scripts/docs/en/userver/tutorial/build.md
@@ -214,13 +214,13 @@ Follow the platforms specific instructions:
     * Using an AUR helper (pikaur in this example)
 ```
 bash
-pikaur -S $(cat scripts/docs/en/deps/arch.md | tr '\n' ' ')
+pikaur -S $(cat scripts/docs/en/deps/arch.md | sed 's/^makepkg|//g' | tr '\n' ' ')
 ```
     * No AUR helper
 ```
 bash
-sudo pacman -S $(cat scripts/docs/en/deps/arch.md | grep -v -- '-git' | tr '\n' ' ')
-cat scripts/docs/en/deps/arch.md | grep -- '-git' | while read ;\
+sudo pacman -S $(cat scripts/docs/en/deps/arch.md | grep -v -- 'makepkg|' | tr '\n' ' ')
+cat scripts/docs/en/deps/arch.md | grep -oP '^makepkg|\K.*' | while read ;\
   do \
     DIR=$(mktemp -d) ;\
     git clone https://aur.archlinux.org/$REPLY.git $DIR ;\


### PR DESCRIPTION
In Arch install dependencies manual has broken code block called 'No AUR helper':
```bash
sudo pacman -S $(cat scripts/docs/en/deps/arch.md | grep -v -- '-git' | tr '\n' ' ')
cat scripts/docs/en/deps/arch.md | grep -- '-git' | while read ;\
```

It's not working because scripts/docs/en/deps/arch.md file has 'cctz' dependency, which needs to build via AUR. And this file has wrong dependency name 'nghttp2' (should 'libnghttp2').

In this file we can't understand which dependencies has in repository, and which should build from AUR.