### PR TITLE
feat build: link with libasan statically under gcc

### DIFF
--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -61,7 +61,11 @@ if (USERVER_SANITIZE)
 
     # https://clang.llvm.org/docs/AddressSanitizer.html
     set(SANITIZE_ASAN_ENABLED ON)
-    set(SANITIZE_BUILD_FLAGS ${SANITIZE_BUILD_FLAGS} -fsanitize=address)
+    if (CLANG)
+      set(SANITIZE_BUILD_FLAGS ${SANITIZE_BUILD_FLAGS} -fsanitize=address)
+    else()
+      set(SANITIZE_BUILD_FLAGS ${SANITIZE_BUILD_FLAGS} -fsanitize=address -static-libasan)
+    endif()
     set(SANITIZE_CXX_FLAGS -fno-omit-frame-pointer)
   endif()
 


### PR DESCRIPTION
By default gcc links with libasan dynamically, which leads to all sorts of initialization order/loading order problems when we intercept `dl_iterate_phdr` in exception_hacks.cpp, because ASAN uses that function in initialization to ensure ASAN is the first item in .so list.

Related: https://github.com/scylladb/seastar/commit/37316f1b0890d68a9c57dd241280b5660c3090af