### PR TITLE
Fixed incorrect string test

### DIFF
--- a/shared/src/utils/small_string_benchmark.cpp
+++ b/shared/src/utils/small_string_benchmark.cpp
@@ -37,16 +37,13 @@ BENCHMARK(SmallString_Small)->Range(2, 2 << 10);
 
 static void SmallString_Std_Copy(benchmark::State& state) {
   auto s = GenerateString(state.range(0));
+  std::array<std::string, kArraySize> str, str2;
+  for (auto& x : str) x = s;
   for ([[maybe_unused]] auto _ : state) {
-    std::array<std::string, kArraySize> str;
-    for (auto& x : str) x = s;
-    state.ResumeTiming();
-
-    std::array<std::string, kArraySize> str2;
     for (size_t i = 0; i < str.size(); i++) str2[i] = str[i];
-    benchmark::DoNotOptimize(str);
-    benchmark::DoNotOptimize(str2);
     state.PauseTiming();
+    str2.fill({});
+    state.ResumeTiming();
   }
 }
 BENCHMARK(SmallString_Std_Copy)
@@ -55,16 +52,13 @@ BENCHMARK(SmallString_Std_Copy)
 
 static void SmallString_Small_Copy(benchmark::State& state) {
   auto s = GenerateString(state.range(0));
+  std::array<utils::SmallString<1000>, kArraySize> str, str2;
+  for (auto& x : str) x = s;
   for ([[maybe_unused]] auto _ : state) {
-    std::array<utils::SmallString<1000>, kArraySize> str;
-    for (auto& x : str) x = s;
-    state.ResumeTiming();
-
-    std::array<utils::SmallString<1000>, kArraySize> str2;
     for (size_t i = 0; i < str.size(); i++) str2[i] = str[i];
-    benchmark::DoNotOptimize(str);
-    benchmark::DoNotOptimize(str2);
     state.PauseTiming();
+    str2.fill({});
+    state.ResumeTiming();
   }
 }
 BENCHMARK(SmallString_Small_Copy)
@@ -73,16 +67,13 @@ BENCHMARK(SmallString_Small_Copy)
 
 static void SmallString_Std_Move(benchmark::State& state) {
   auto s = GenerateString(state.range(0));
+  std::array<std::string, kArraySize> str, str2;
+  for (auto& x : str) x = s;
   for ([[maybe_unused]] auto _ : state) {
-    std::array<std::string, kArraySize> str;
-    for (auto& x : str) x = s;
-    state.ResumeTiming();
-
-    std::array<std::string, kArraySize> str2;
     for (size_t i = 0; i < str.size(); i++) str2[i] = std::move(str[i]);
-    benchmark::DoNotOptimize(str);
-    benchmark::DoNotOptimize(str2);
     state.PauseTiming();
+    str2.fill({});
+    state.ResumeTiming();
   }
 }
 BENCHMARK(SmallString_Std_Move)
@@ -91,16 +82,13 @@ BENCHMARK(SmallString_Std_Move)
 
 static void SmallString_Small_Move(benchmark::State& state) {
   auto s = GenerateString(state.range(0));
+  std::array<utils::SmallString<1000>, kArraySize> str, str2;
+  for (auto& x : str) x = s;
   for ([[maybe_unused]] auto _ : state) {
-    std::array<utils::SmallString<1000>, kArraySize> str;
-    for (auto& x : str) x = s;
-    state.ResumeTiming();
-
-    std::array<utils::SmallString<1000>, kArraySize> str2;
     for (size_t i = 0; i < str.size(); i++) str2[i] = std::move(str[i]);
-    benchmark::DoNotOptimize(str);
-    benchmark::DoNotOptimize(str2);
     state.PauseTiming();
+    str2.fill({});
+    state.ResumeTiming();
   }
 }
 BENCHMARK(SmallString_Small_Move)


### PR DESCRIPTION
An incorrect order of `state.ResumeTiming()` and `state.PauseTiming()` calls designed to exclude the `std::array`'s destructor calls from benchmark actually caused the test to crash, since benchmark code calls `PauseTiming()` which asserts that timing isn't paused (which fails) in the != operator when finishing the iteration over `state` (see `State::FinishKeepRunning()` and `StateIterator::operator!=` in benchmark.cc and .h) 

I propose to move the allocation and destruction of the arrays outside the cycle and use the pause functionality to reset the array and destroy copied strings.

I hereby agree to the terms of the CLA available at: [link](https://yandex.ru/legal/cla/?lang=ru).