### PR TITLE
feat mongo: Added Get/Set batch size for Mongo Cursor

### DIFF
--- a/mongo/include/userver/storages/mongo/cursor.hpp
+++ b/mongo/include/userver/storages/mongo/cursor.hpp
@@ -57,6 +57,8 @@ class Cursor {
 
   bool HasMore() const;
   explicit operator bool() const { return HasMore(); }
+  uint32_t GetBatchSize() const;
+  void SetBatchSize(uint32_t);
 
   Iterator begin();
   Iterator end();

--- a/mongo/src/storages/mongo/cdriver/cursor_impl.cpp
+++ b/mongo/src/storages/mongo/cdriver/cursor_impl.cpp
@@ -40,6 +40,16 @@ bool CDriverCursorImpl::HasMore() const {
   return cursor_ && mongoc_cursor_more(cursor_.get());
 }
 
+uint32_t CDriverCursorImpl::GetBatchSize() const {
+  if (!cursor_) throw std::logic_error("GetBatchSize for invalid cursor");
+  return mongoc_cursor_get_batch_size(cursor_.get());
+}
+
+void CDriverCursorImpl::SetBatchSize(uint32_t size) {
+  if (!cursor_) throw std::logic_error("SetBatchSize for invalid cursor");
+  mongoc_cursor_set_batch_size(cursor_.get(), size);
+}
+
 const formats::bson::Document& CDriverCursorImpl::Current() const {
   if (!IsValid()) throw std::logic_error("Reading from invalid cursor");
   return *current_;

--- a/mongo/src/storages/mongo/cdriver/cursor_impl.hpp
+++ b/mongo/src/storages/mongo/cdriver/cursor_impl.hpp
@@ -23,6 +23,8 @@ class CDriverCursorImpl final : public CursorImpl {
 
   bool IsValid() const override;
   bool HasMore() const override;
+  uint32_t GetBatchSize() const override;
+  void SetBatchSize(uint32_t) override;
 
   const formats::bson::Document& Current() const override;
   void Next() override;

--- a/mongo/src/storages/mongo/cursor.cpp
+++ b/mongo/src/storages/mongo/cursor.cpp
@@ -15,6 +15,10 @@ Cursor& Cursor::operator=(Cursor&&) noexcept = default;
 
 bool Cursor::HasMore() const { return impl_->IsValid(); }
 
+uint32_t Cursor::GetBatchSize() const { return impl_->GetBatchSize(); }
+
+void Cursor::SetBatchSize(uint32_t size) { impl_->SetBatchSize(size); }
+
 Cursor::Iterator Cursor::begin() { return Iterator(this); }
 
 // no, part of the iterator interface

--- a/mongo/src/storages/mongo/cursor_impl.hpp
+++ b/mongo/src/storages/mongo/cursor_impl.hpp
@@ -12,6 +12,8 @@ class CursorImpl {
 
   virtual bool IsValid() const = 0;
   virtual bool HasMore() const = 0;
+  virtual uint32_t GetBatchSize() const = 0;
+  virtual void SetBatchSize(uint32_t) = 0;
 
   virtual const formats::bson::Document& Current() const = 0;
   virtual void Next() = 0;


### PR DESCRIPTION
Add ability to get/set [batchSize](https://www.mongodb.com/docs/manual/reference/method/cursor.batchSize/) for mongo::Cursor