### PR TITLE
fix conan: remove shared dir from includes

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -34,7 +34,6 @@ class UserverConan(ConanFile):
         'with_redis': [True, False],
         'with_grpc': [True, False],
         'with_clickhouse': [True, False],
-        'with_universal': [True, False],
         'with_rabbitmq': [True, False],
         'with_utest': [True, False],
         'namespace': ['ANY'],
@@ -53,7 +52,6 @@ class UserverConan(ConanFile):
         'with_redis': True,
         'with_grpc': True,
         'with_clickhouse': True,
-        'with_universal': True,
         'with_rabbitmq': True,
         'with_utest': True,
         'namespace': 'userver',
@@ -161,9 +159,6 @@ class UserverConan(ConanFile):
             'USERVER_FEATURE_CLICKHOUSE'
         ] = self.options.with_clickhouse
         tool_ch.variables[
-            'USERVER_FEATURE_UNIVERSAL'
-        ] = self.options.with_universal
-        tool_ch.variables[
             'USERVER_FEATURE_RABBITMQ'
         ] = self.options.with_rabbitmq
         tool_ch.variables['USERVER_FEATURE_UTEST'] = self.options.with_utest
@@ -219,9 +214,8 @@ class UserverConan(ConanFile):
             )
 
         copy_component('core')
+        copy_component('universal')
 
-        if self.options.with_universal:
-            copy_component('universal')
         if self.options.with_grpc:
             copy_component('grpc')
             copy(
@@ -377,7 +371,7 @@ class UserverConan(ConanFile):
                 'target': 'core',
                 'lib': 'core',
                 'requires': (
-                    ['core-internal']
+                    ['core-internal', 'universal']
                     + fmt()
                     + cctz()
                     + boost()
@@ -392,25 +386,25 @@ class UserverConan(ConanFile):
                 ),
             },
         ]
-        if self.options.with_universal:
-            userver_components.extend(
-                [
-                    {
-                        'target': 'universal',
-                        'lib': 'universal',
-                        'requires': (
-                            fmt()
-                            + cctz()
-                            + boost()
-                            + concurrentqueue()
-                            + yaml()
-                            + cryptopp()
-                            + jemalloc()
-                            + openssl()
-                        ),
-                    },
-                ],
-            )
+        userver_components.extend(
+            [
+                {
+                    'target': 'universal',
+                    'lib': 'universal',
+                    'requires': (
+                        fmt()
+                        + cctz()
+                        + boost()
+                        + concurrentqueue()
+                        + yaml()
+                        + cryptopp()
+                        + jemalloc()
+                        + openssl()
+                    ),
+                },
+            ],
+        )
+
         if self.options.with_grpc:
             userver_components.extend(
                 [

--- a/conanfile.py
+++ b/conanfile.py
@@ -190,14 +190,6 @@ class UserverConan(ConanFile):
         copy(
             self,
             pattern='*',
-            dst=os.path.join(self.package_folder, 'include', 'shared'),
-            src=os.path.join(self.source_folder, 'shared', 'include'),
-            keep_path=True,
-        )
-
-        copy(
-            self,
-            pattern='*',
             dst=os.path.join(self.package_folder, 'scripts'),
             src=os.path.join(self.source_folder, 'scripts'),
             keep_path=True,
@@ -552,10 +544,6 @@ class UserverConan(ConanFile):
                     ].includedirs.append(
                         os.path.join('include', cmake_component),
                     )
-                if cmake_component == 'core' or cmake_component == 'universal':
-                    self.cpp_info.components[
-                        conan_component
-                    ].includedirs.append(os.path.join('include', 'shared'))
 
                 self.cpp_info.components[conan_component].requires = requires
 


### PR DESCRIPTION
After shared dir was removed in commit https://github.com/userver-framework/userver/commit/3e9d8f710aa452604329f46e8239a4aa22d9fc97 it should be also deleted from include directories of conan package. In other case cmake will search for non-exsistent path

```
CMake Error in src/my_project/CMakeLists.txt:
  Imported target "userver::userver" includes non-existent path

    "/home/user/.conan/data/userver/1.0.0/_/_/package/a2b7b631f74abfe8f54bf08ae69a0f2fed5f6cf6/include/shared"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```

Also after this move core requires universal. So universal library should be also required. Option with_universal was deleted from conanfile.py