### PR TITLE
fix build: fix DWCAS setup via boost

### DIFF
--- a/cmake/SetupEnvironment.cmake
+++ b/cmake/SetupEnvironment.cmake
@@ -45,7 +45,6 @@ endif()
 
 include(SetupLinker)
 include(SetupLTO)
-include(RequireDWCAS)
 
 option(USE_CCACHE "Use ccache for build" ON)
 if (USE_CCACHE)
@@ -140,5 +139,7 @@ else ()
   # enable additional glibc checks (used in debian packaging, requires -O)
   add_definitions(-D_FORTIFY_SOURCE=2)
 endif ()
+
+include(RequireDWCAS)
 
 enable_testing ()


### PR DESCRIPTION
Building on linux with GCC always produces warning 
```
CMake Warning at cmake/RequireDWCAS.cmake:85 (message):
  DWCAS seems not to work on the host platform, userver may have suboptimal
  performance.  Either use Clang compiler or install a modern C++ Boost
  Library (1.66 or hihgher for x86; Boost 1.74 or higher for ARM)
Call Stack (most recent call first):
  cmake/SetupEnvironment.cmake:48 (include)
  CMakeLists.txt:76 (include)
```
because find_package(Boost ...) is called after executing RequireDWCAS script with breaks linking with boost.atomic.
This PR fixes order of calling this two cmake commands