### PR TITLE
fix(StrongTypedef): floating point ToString()

### DIFF
--- a/universal/include/userver/utils/meta_light.hpp
+++ b/universal/include/userver/utils/meta_light.hpp
@@ -102,11 +102,6 @@ template <typename T>
 inline constexpr bool kIsInteger =
     std::is_integral_v<T> && !kIsCharacter<T> && !std::is_same_v<T, bool>;
 
-/// Returns `true` if the type is a true number type (integer or floating point,
-/// not `*char*` or `bool`) `signed char` and `unsigned char` are integer types
-template <typename T>
-inline constexpr bool kIsNumber = kIsNumber<T> || std::is_floating_point_v<T>;
-
 }  // namespace meta
 
 USERVER_NAMESPACE_END

--- a/universal/include/userver/utils/meta_light.hpp
+++ b/universal/include/userver/utils/meta_light.hpp
@@ -102,6 +102,11 @@ template <typename T>
 inline constexpr bool kIsInteger =
     std::is_integral_v<T> && !kIsCharacter<T> && !std::is_same_v<T, bool>;
 
+/// Returns `true` if the type is a true number type (integer or floating point)
+/// `signed char` and `unsigned char` are integer types
+template <typename T>
+inline constexpr bool kIsNumber = kIsNumber<T> || std::is_floating_point_v<T>;
+
 }  // namespace meta
 
 USERVER_NAMESPACE_END

--- a/universal/include/userver/utils/meta_light.hpp
+++ b/universal/include/userver/utils/meta_light.hpp
@@ -105,7 +105,7 @@ inline constexpr bool kIsInteger =
 /// Returns `true` if the type is a true number type (integer or floating point,
 /// not `*char*` or `bool`) `signed char` and `unsigned char` are integer types
 template <typename T>
-inline constexpr bool kIsNumber = kIsNumber<T> || std::is_floating_point_v<T>;
+inline constexpr bool kIsNumber = kIsInteger<T> || std::is_floating_point_v<T>;
 
 }  // namespace meta
 

--- a/universal/include/userver/utils/meta_light.hpp
+++ b/universal/include/userver/utils/meta_light.hpp
@@ -102,8 +102,8 @@ template <typename T>
 inline constexpr bool kIsInteger =
     std::is_integral_v<T> && !kIsCharacter<T> && !std::is_same_v<T, bool>;
 
-/// Returns `true` if the type is a true number type (integer or floating point)
-/// `signed char` and `unsigned char` are integer types
+/// Returns `true` if the type is a true number type (integer or floating point,
+/// not `*char*` or `bool`) `signed char` and `unsigned char` are integer types
 template <typename T>
 inline constexpr bool kIsNumber = kIsNumber<T> || std::is_floating_point_v<T>;
 

--- a/universal/include/userver/utils/strong_typedef.hpp
+++ b/universal/include/userver/utils/strong_typedef.hpp
@@ -365,7 +365,7 @@ std::string ToString(const StrongTypedef<Tag, std::string, Ops>& object) {
 }
 
 template <typename Tag, typename T, StrongTypedefOps Ops,
-          typename = std::enable_if_t<meta::kIsInteger<T>>>
+          typename = std::enable_if_t<meta::kIsNumber<T>>>
 std::string ToString(const StrongTypedef<Tag, T, Ops>& object) {
   impl::strong_typedef::CheckIfAllowsLogging<
       StrongTypedef<Tag, std::string, Ops>>();

--- a/universal/include/userver/utils/strong_typedef.hpp
+++ b/universal/include/userver/utils/strong_typedef.hpp
@@ -365,11 +365,19 @@ std::string ToString(const StrongTypedef<Tag, std::string, Ops>& object) {
 }
 
 template <typename Tag, typename T, StrongTypedefOps Ops,
-          typename = std::enable_if_t<meta::kIsNumber<T>>>
+          std::enable_if_t<meta::kIsInteger<T>, bool> = true>
 std::string ToString(const StrongTypedef<Tag, T, Ops>& object) {
   impl::strong_typedef::CheckIfAllowsLogging<
       StrongTypedef<Tag, std::string, Ops>>();
   return std::to_string(object.GetUnderlying());
+}
+
+template <typename Tag, typename T, StrongTypedefOps Ops,
+          std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+std::string ToString(const StrongTypedef<Tag, T, Ops>& object) {
+  impl::strong_typedef::CheckIfAllowsLogging<
+      StrongTypedef<Tag, std::string, Ops>>();
+  return fmt::format("{}", object.GetUnderlying());
 }
 
 // Explicit casting

--- a/universal/src/utils/strong_typedef_test.cpp
+++ b/universal/src/utils/strong_typedef_test.cpp
@@ -35,8 +35,8 @@ using MySpecialShort =
                          utils::StrongTypedefOps::kCompareTransparent>;
 
 using MySpecialDouble =
-    userver::utils::StrongTypedef<class MyDoubleTag, double,
-                                  utils::StrongTypedefOps::kCompareTransparent>;
+    utils::StrongTypedef<class MyDoubleTag, double,
+                         utils::StrongTypedefOps::kCompareTransparent>;
 
 using MySpecialVector =
     utils::StrongTypedef<class MySpecialVectorTag, std::vector<bool>>;

--- a/universal/src/utils/strong_typedef_test.cpp
+++ b/universal/src/utils/strong_typedef_test.cpp
@@ -34,6 +34,10 @@ using MySpecialShort =
     utils::StrongTypedef<class MySpecialShortTag, short,
                          utils::StrongTypedefOps::kCompareTransparent>;
 
+using MySpecialDouble =
+    userver::utils::StrongTypedef<class MyDoubleTag, double,
+                                  utils::StrongTypedefOps::kCompareTransparent>;
+
 using MySpecialVector =
     utils::StrongTypedef<class MySpecialVectorTag, std::vector<bool>>;
 
@@ -291,6 +295,12 @@ TEST(StrongTypedef, StrongTypedefForStringIsNotARange) {
   // 'std::string' as an array.
   EXPECT_FALSE(meta::kIsRange<MyString>);
   EXPECT_FALSE(meta::kIsRange<MyString2>);
+}
+
+TEST(StrongTypedef, ToString) {
+  EXPECT_EQ(utils::ToString(MySpecialInt{123}), "123");
+  EXPECT_EQ(utils::ToString(MySpecialShort{123}), "123");
+  EXPECT_EQ(utils::ToString(MySpecialDouble{123.456}), "123.456");
 }
 
 USERVER_NAMESPACE_END


### PR DESCRIPTION
Without this patch, the following code will not compile:

```cpp
#include <userver/utils/strong_typedef.hpp>

using Double = userver::utils::StrongTypedef<class DoubleTag, double>;

int main() {
  Double d{123};
  std::string s = userver::utils::ToString(d);
}
```