### PR TITLE
fix(cryptopp): compilation error

### DIFF
--- a/cmake/SetupCryptoPP.cmake
+++ b/cmake/SetupCryptoPP.cmake
@@ -22,18 +22,10 @@ endif()
 
 include(DownloadUsingCPM)
 CPMAddPackage(
-    NAME cryptopp
-    VERSION 8.7.0
-    GITHUB_REPOSITORY weidai11/cryptopp
-    GIT_TAG CRYPTOPP_8_7_0
-    DOWNLOAD_ONLY YES
-)
-CPMAddPackage(
     NAME cryptopp-cmake
     VERSION 8.7.0
     GITHUB_REPOSITORY abdes/cryptopp-cmake
     OPTIONS
-    "CRYPTOPP_SOURCES ${cryptopp_SOURCE_DIR}"
     "cryptopp_DISPLAY_CMAKE_SUPPORT_WARNING OFF"
     "CRYPTOPP_BUILD_SHARED OFF"
     "CRYPTOPP_BUILD_TESTING OFF"


### PR DESCRIPTION
I'm trying to compile the latest commit from the develop branch on a MacBook Air M1 macOS 13.4. There were no problems before switching to CPM. Now, when downloading cryptopp together with cryptopp-cmake, a compilation error occurs. If cryptopp-cmake loads cryptopp on its own, the error will disappear.

**Logs**

<details>
<summary>Configure log</summary>

```
-- The CXX compiler identification is AppleClang 14.0.3.14030022
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- C compiler:
-- C++ compiler: /Library/Developer/CommandLineTools/usr/bin/c++
-- C++ standard 17
-- LTO: disabled (user request)
-- ccache: enabled
-- Looking for C++ include variant
-- Looking for C++ include variant - found
-- variant: 1
-- Found Boost: /opt/homebrew/include (found version "1.82.0")
-- Performing Test HAS_mcx16
-- Performing Test HAS_mcx16 - Failed
-- DWCAS works - checked
-- Checking -ftemplate-backtrace-limit=0
-- Performing Test HAS_ftemplate_backtrace_limit_0
-- Performing Test HAS_ftemplate_backtrace_limit_0 - Success
-- Checking -ftemplate-backtrace-limit=0 - found
-- Checking -Wdisabled-optimization
-- Performing Test HAS_Wdisabled_optimization
-- Performing Test HAS_Wdisabled_optimization - Success
-- Checking -Wdisabled-optimization - found
-- Checking -Winvalid-pch
-- Performing Test HAS_Winvalid_pch
-- Performing Test HAS_Winvalid_pch - Success
-- Checking -Winvalid-pch - found
-- Checking -Wlogical-op
-- Performing Test HAS_Wlogical_op
-- Performing Test HAS_Wlogical_op - Failed
-- Checking -Wlogical-op - not found
-- Checking -Wformat=2
-- Performing Test HAS_Wformat_2
-- Performing Test HAS_Wformat_2 - Success
-- Checking -Wformat=2 - found
-- Checking -Wno-error=deprecated-declarations
-- Performing Test HAS_Wno_error_deprecated_declarations
-- Performing Test HAS_Wno_error_deprecated_declarations - Success
-- Checking -Wno-error=deprecated-declarations - found
-- Checking -Wimplicit-fallthrough
-- Performing Test HAS_Wimplicit_fallthrough
-- Performing Test HAS_Wimplicit_fallthrough - Success
-- Checking -Wimplicit-fallthrough - found
-- Checking -Wno-useless-cast
-- Performing Test HAS_Wno_useless_cast
-- Performing Test HAS_Wno_useless_cast - Failed
-- Checking -Wno-useless-cast - not found
-- boost: 108200
-- The C compiler identification is AppleClang 14.0.3.14030022
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Building utest with gtest and ubench with gbench
-- Building userver as a subproject
-- Python: python3
-- Generating cmake files ...
Requirement already satisfied: voluptuous>=0.11.1 in /Users/danilshvalov/Library/Python/3.9/lib/python/site-packages (from -r /Users/danilshvalov/projects/pg_service_template/third_party/userver/scripts/external_deps/requirements.txt (line 1)) (0.13.1)
Requirement already satisfied: Jinja2>=2.10 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from -r /Users/danilshvalov/projects/pg_service_template/third_party/userver/scripts/external_deps/requirements.txt (line 2)) (3.1.2)
Requirement already satisfied: PyYAML>=3.13 in /Users/danilshvalov/Library/Python/3.9/lib/python/site-packages (from -r /Users/danilshvalov/projects/pg_service_template/third_party/userver/scripts/external_deps/requirements.txt (line 3)) (6.0)
Requirement already satisfied: MarkupSafe>=2.0 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from Jinja2>=2.10->-r /Users/danilshvalov/projects/pg_service_template/third_party/userver/scripts/external_deps/requirements.txt (line 2)) (2.1.3)
-- Found Protobuf: /opt/homebrew/lib/libprotobuf.dylib (found version "4.23.4")
-- Found Threads: TRUE
-- Found Boost: /opt/homebrew/include (found version "1.82.0") found components: program_options filesystem regex
-- Performing Test Iconv_IS_BUILT_IN
-- Performing Test Iconv_IS_BUILT_IN - Failed
-- Found Iconv: /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib/libiconv.tbd (found version "1.11")
-- Found OpenSSL: /opt/homebrew/opt/openssl@3/lib/libcrypto.dylib (found version "3.1.2")
-- Failed to find brew package version for 'cryptopp'
-- Downloading CPM.cmake to /Users/danilshvalov/projects/pg_service_template/build/cmake/CPM_0.38.2.cmake
-- CPM: Adding package cryptopp@8.7.0 (CRYPTOPP_8_7_0)
-- CPM: Adding package cryptopp-cmake@8.7.0 (v8.7.0)
-- Using ccache (/opt/homebrew/bin/ccache) (via wrapper).
-- Downloading CPM.cmake to /Users/danilshvalov/projects/pg_service_template/build/cmake/CPM_0.35.5.cmake
-- CPM: cryptopp-cmake: Adding package Ccache.cmake@1.2.3 (v1.2.3)
-- Using ccache: /opt/homebrew/bin/ccache
-- Crypto++ from user-specified location at: /Users/danilshvalov/projects/pg_service_template/build/_deps/cryptopp-src
-- [cryptopp] CMake version 3.27.1
-- [cryptopp] System Darwin
-- [cryptopp] Processor arm64
-- [cryptopp] Performing Test CRYPTOPP_ARM_ACLE_HEADER
-- [cryptopp] Performing Test CRYPTOPP_ARM_ACLE_HEADER - Success
-- Performing Test CRYPTOPP_ARMV8A_ASIMD
-- Performing Test CRYPTOPP_ARMV8A_ASIMD - Success
-- Performing Test CRYPTOPP_ARMV8A_CRC
-- Performing Test CRYPTOPP_ARMV8A_CRC - Success
-- Performing Test CRYPTOPP_ARMV8A_CRYPTO
-- Performing Test CRYPTOPP_ARMV8A_CRYPTO - Success
-- [cryptopp] Generating cmake package config files
-- [cryptopp] Generating pkgconfig files
-- [cryptopp] Platform: ARMv8
-- [cryptopp] Compiler definitions:  CRYPTOPP_DATA_DIR="/Users/danilshvalov/projects/pg_service_template/build/_deps/cryptopp-src"
-- [cryptopp] Compiler options:
-- [cryptopp] Build type:
-- brew version of yaml-cpp: 0.7.0
-- Found libyamlcpp: /opt/homebrew/lib/libyaml-cpp.dylib
-- libyamlcpp include directories: /opt/homebrew/include
-- libyamlcpp libraries: /opt/homebrew/lib/libyaml-cpp.dylib
-- Failed to find brew package version for 'fmt'
-- CPM: Adding package fmt@8.1.1 (8.1.1)
-- Module support is disabled.
-- Version: 8.1.1
-- Build type:
-- CXX_STANDARD: 17
-- Performing Test has_std_17_flag
-- Performing Test has_std_17_flag - Success
-- Performing Test has_std_1z_flag
-- Performing Test has_std_1z_flag - Success
-- Performing Test SUPPORTS_USER_DEFINED_LITERALS
-- Performing Test SUPPORTS_USER_DEFINED_LITERALS - Success
-- Performing Test FMT_HAS_VARIANT
-- Performing Test FMT_HAS_VARIANT - Success
-- Required features: cxx_variadic_templates
-- Performing Test HAS_NULLPTR_WARNING
-- Performing Test HAS_NULLPTR_WARNING - Success
-- Looking for strtod_l
-- Looking for strtod_l - found
-- brew version of cctz: 2.3
-- cctz include directories: /opt/homebrew/include
-- cctz libraries: /opt/homebrew/lib/libcctz.dylib
-- Putting userver into namespace 'userver': namespace userver { }
-- Found Boost: /opt/homebrew/include (found version "1.82.0")
-- brew version of googletest: 1.13.0
-- UserverGTest include directories: /opt/homebrew/include;/opt/homebrew/include
-- UserverGTest libraries: /opt/homebrew/lib/libgtest.a;/opt/homebrew/lib/libgtest_main.a;/opt/homebrew/lib/libgmock.a
-- brew version of google-benchmark: 1.8.2
-- UserverGBench include directories: /opt/homebrew/include
-- UserverGBench libraries: /opt/homebrew/lib/libbenchmark_main.a;/opt/homebrew/lib/libbenchmark.a
-- Found Git: /opt/homebrew/bin/git
-- Userver version 1.0.0
-- Looking for accept4
-- Looking for accept4 - not found
-- Looking for pipe2
-- Looking for pipe2 - not found
-- Found Boost: /opt/homebrew/include (found version "1.82.0") found components: program_options filesystem locale regex iostreams
-- Found ZLIB: /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib/libz.tbd (found version "1.2.11")
-- brew version of c-ares: 1.19.1
-- c-ares include directories: /opt/homebrew/include
-- c-ares libraries: /opt/homebrew/lib/libcares.dylib
-- brew version of http-parser: 2.9.4
-- Found Http_Parser: /opt/homebrew/lib/libhttp_parser.dylib
-- Http_Parser include directories: /opt/homebrew/include
-- Http_Parser libraries: /opt/homebrew/lib/libhttp_parser.dylib
-- brew version of nghttp2: 1.55.1
-- Found Nghttp2: /opt/homebrew/lib/libnghttp2.dylib
-- Nghttp2 include directories: /opt/homebrew/include
-- Nghttp2 libraries: /opt/homebrew/lib/libnghttp2.dylib
-- brew version of libev: 4.33
-- Found LibEv: /opt/homebrew/lib/libev.dylib
-- LibEv include directories: /opt/homebrew/include
-- LibEv libraries: /opt/homebrew/lib/libev.dylib
-- Context impl: fcontext
-- The ASM compiler identification is AppleClang
-- Found assembler: /Library/Developer/CommandLineTools/usr/bin/cc
-- Found Boost: /opt/homebrew/include (found version "1.82.0")
-- Found Boost: /opt/homebrew/include (found version "1.82.0") found components: regex
-- brew version of postgresql@14: 14.8_2
-- Found PostgreSQL: /opt/homebrew/opt/postgresql@13/lib/libpq.a
-- PostgreSQL include directories: /opt/homebrew/opt/postgresql@13/include
-- PostgreSQL libraries: /opt/homebrew/opt/postgresql@13/lib/libpq.a
-- brew version of postgresql@14: 14.8_2
-- Found PostgreSQLInternal: /opt/homebrew/opt/postgresql@13/lib/libpq.a;/opt/homebrew/opt/postgresql@13/lib/libpgcommon.a;/opt/homebrew/opt/postgresql@13/lib/libpgport.a
-- PostgreSQLInternal include directories: /opt/homebrew/opt/postgresql@13/include/postgresql/server;/opt/homebrew/opt/postgresql@13/include/postgresql/internal;/opt/homebrew/opt/postgresql@13/include
-- PostgreSQLInternal libraries: /opt/homebrew/opt/postgresql@13/lib/libpq.a;/opt/homebrew/opt/postgresql@13/lib/libpgcommon.a;/opt/homebrew/opt/postgresql@13/lib/libpgport.a
-- brew version of krb5: 1.21.1
-- Found GssApi: /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib/libgssapi_krb5.tbd
-- GssApi include directories: /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/System/Library/Frameworks/GSS.framework/Headers
-- GssApi libraries: /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/lib/libgssapi_krb5.tbd
-- brew version of hiredis: 1.2.0
-- Found Hiredis: /opt/homebrew/lib/libhiredis.dylib
-- Hiredis include directories: /opt/homebrew/include
-- Hiredis libraries: /opt/homebrew/lib/libhiredis.dylib
-- Found RE2 via CMake.
-- Protobuf version: 23.4.0
-- gRPC version: 1.56.2
Requirement already satisfied: protobuf>=4.21.12 in /Users/danilshvalov/Library/Python/3.9/lib/python/site-packages (from -r /Users/danilshvalov/projects/pg_service_template/third_party/userver/scripts/grpc/requirements.txt (line 1)) (4.23.2)
-- CPM: Adding package api-common-protos@1.50.0 (1.50.0)
-- Generating sources for protos in /Users/danilshvalov/Documents/dev/projects/pg_service_template/build/_deps/api-common-protos-src:
-- Generated sources for google/api/annotations.proto
-- Generated sources for google/api/auth.proto
-- Generated sources for google/api/backend.proto
-- Generated sources for google/api/billing.proto
-- Generated sources for google/api/client.proto
-- Generated sources for google/api/config_change.proto
-- Generated sources for google/api/consumer.proto
-- Generated sources for google/api/context.proto
-- Generated sources for google/api/control.proto
-- Generated sources for google/api/distribution.proto
-- Generated sources for google/api/documentation.proto
-- Generated sources for google/api/endpoint.proto
-- Generated sources for google/api/field_behavior.proto
-- Generated sources for google/api/http.proto
-- Generated sources for google/api/httpbody.proto
-- Generated sources for google/api/label.proto
-- Generated sources for google/api/log.proto
-- Generated sources for google/api/logging.proto
-- Generated sources for google/api/metric.proto
-- Generated sources for google/api/monitored_resource.proto
-- Generated sources for google/api/monitoring.proto
-- Generated sources for google/api/quota.proto
-- Generated sources for google/api/resource.proto
-- Generated sources for google/api/service.proto
-- Generated sources for google/api/source_info.proto
-- Generated sources for google/api/system_parameter.proto
-- Generated sources for google/api/usage.proto
-- Generated sources for google/iam/admin/v1/iam.proto with gRPC
-- Generated sources for google/iam/v1/iam_policy.proto with gRPC
-- Generated sources for google/iam/v1/logging/audit_data.proto
-- Generated sources for google/iam/v1/policy.proto
-- Generated sources for google/logging/type/http_request.proto
-- Generated sources for google/logging/type/log_severity.proto
-- Generated sources for google/longrunning/operations.proto with gRPC
-- Generated sources for google/rpc/code.proto
-- Generated sources for google/rpc/error_details.proto
-- Generated sources for google/rpc/status.proto
-- Generated sources for google/type/calendar_period.proto
-- Generated sources for google/type/color.proto
-- Generated sources for google/type/date.proto
-- Generated sources for google/type/dayofweek.proto
-- Generated sources for google/type/expr.proto
-- Generated sources for google/type/fraction.proto
-- Generated sources for google/type/latlng.proto
-- Generated sources for google/type/money.proto
-- Generated sources for google/type/month.proto
-- Generated sources for google/type/postal_address.proto
-- Generated sources for google/type/quaternion.proto
-- Generated sources for google/type/timeofday.proto
-- gRPC Channelz enabled
-- Generating sources for protos in /Users/danilshvalov/Documents/dev/projects/pg_service_template/third_party/userver/grpc/handlers/proto:
-- Generated sources for healthchecking/healthchecking.proto with gRPC
-- Python: python3
-- Setting up the virtualenv with requirements:
--   /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt
created virtual environment CPython3.9.5.final.0-64 in 157ms
  creator CPython3Posix(dest=/Users/danilshvalov/Documents/dev/projects/pg_service_template/build/tests/venv-testsuite-pg_service_template, clear=False, no_vcs_ignore=False, global=True)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/Users/danilshvalov/Library/Application Support/virtualenv)
    added seed packages: pip==23.1.2, setuptools==68.0.0, wheel==0.40.0
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
Requirement already satisfied: yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from -r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (0.1.10)
Collecting yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2 (from -r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1))
  Using cached yandex_taxi_testsuite-0.1.17-py3-none-any.whl (120 kB)
Requirement already satisfied: PyYAML>=3.13 in /Users/danilshvalov/Library/Python/3.9/lib/python/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (6.0)
Requirement already satisfied: aiohttp>=3.5.4 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (3.8.4)
Requirement already satisfied: yarl!=1.6,>=1.4.2 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (1.9.2)
Requirement already satisfied: py>=1.10 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (1.11.0)
Requirement already satisfied: pytest-aiohttp>=0.3.0 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (1.0.4)
Requirement already satisfied: pytest>=4.5.0 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (7.3.1)
Requirement already satisfied: python-dateutil>=2.7.3 in /Users/danilshvalov/Library/Python/3.9/lib/python/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (2.8.2)
Requirement already satisfied: pytz>=2018.5 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (2023.3)
Requirement already satisfied: uvloop>=0.12.1 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (0.17.0)
Requirement already satisfied: pymongo>=3.7.1 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (4.3.3)
Requirement already satisfied: cached-property>=1.5.1 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (1.5.2)
Requirement already satisfied: psycopg2-binary>=2.7.5 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (2.9.6)
Requirement already satisfied: attrs>=17.3.0 in /Users/danilshvalov/Library/Python/3.9/lib/python/site-packages (from aiohttp>=3.5.4->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (21.2.0)
Requirement already satisfied: charset-normalizer<4.0,>=2.0 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from aiohttp>=3.5.4->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (3.1.0)
Requirement already satisfied: multidict<7.0,>=4.5 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from aiohttp>=3.5.4->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (6.0.4)
Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from aiohttp>=3.5.4->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (4.0.2)
Requirement already satisfied: frozenlist>=1.1.1 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from aiohttp>=3.5.4->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (1.3.3)
Requirement already satisfied: aiosignal>=1.1.2 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from aiohttp>=3.5.4->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (1.3.1)
Requirement already satisfied: dnspython<3.0.0,>=1.16.0 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from pymongo>=3.7.1->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (2.3.0)
Requirement already satisfied: iniconfig in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from pytest>=4.5.0->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (2.0.0)
Requirement already satisfied: packaging in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from pytest>=4.5.0->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (21.0)
Requirement already satisfied: pluggy<2.0,>=0.12 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from pytest>=4.5.0->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (1.0.0)
Requirement already satisfied: exceptiongroup>=1.0.0rc8 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from pytest>=4.5.0->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (1.1.1)
Requirement already satisfied: tomli>=1.0.0 in /Users/danilshvalov/Library/Python/3.9/lib/python/site-packages (from pytest>=4.5.0->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (1.2.1)
Requirement already satisfied: pytest-asyncio>=0.17.2 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from pytest-aiohttp>=0.3.0->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (0.21.0)
Requirement already satisfied: six>=1.5 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from python-dateutil>=2.7.3->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (1.16.0)
Requirement already satisfied: idna>=2.0 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from yarl!=1.6,>=1.4.2->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (3.4)
Requirement already satisfied: pyparsing>=2.0.2 in /Users/danilshvalov/Library/Python/3.9/lib/python/site-packages (from packaging->pytest>=4.5.0->yandex-taxi-testsuite[postgresql-binary]>=0.1.7.2->-r /Users/danilshvalov/projects/pg_service_template/tests/requirements.txt (line 1)) (2.4.7)
Installing collected packages: yandex-taxi-testsuite
  Attempting uninstall: yandex-taxi-testsuite
    Found existing installation: yandex-taxi-testsuite 0.1.10
    Not uninstalling yandex-taxi-testsuite at /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages, outside environment /Users/danilshvalov/Documents/dev/projects/pg_service_template/build/tests/venv-testsuite-pg_service_template
    Can't uninstall 'yandex-taxi-testsuite'. No files were found to uninstall.
Successfully installed yandex-taxi-testsuite-0.1.17
-- Configuring done (38.7s)
-- Generating done (0.3s)
-- Build files have been written to: /Users/danilshvalov/projects/pg_service_template/build
```

</details>

<details>
<summary>Compile error</summary>

```
/Users/danilshvalov/projects/pg_service_template/third_party/userver/universal/src/crypto/algorithm.cpp:3:10: fatal error: 'cryptopp/misc.h' file not found
#include <cryptopp/misc.h>
         ^~~~~~~~~~~~~~~~~
1 error generated.
/Users/danilshvalov/projects/pg_service_template/third_party/userver/universal/src/crypto/hash.cpp:5:10: fatal error: 'cryptopp/base64.h' file not found
#include <cryptopp/base64.h>
         ^~~~~~~~~~~~~~~~~~~
gmake[2]: *** [userver/universal/CMakeFiles/userver-universal.dir/build.make:90: userver/universal/CMakeFiles/userver-universal.dir/src/crypto/algorithm.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
/Users/danilshvalov/projects/pg_service_template/third_party/userver/universal/src/crypto/base64.cpp:3:10: fatal error: 'cryptopp/base64.h' file not found
#include <cryptopp/base64.h>
         ^~~~~~~~~~~~~~~~~~~
1 error generated.
gmake[2]: *** [userver/universal/CMakeFiles/userver-universal.dir/build.make:146: userver/universal/CMakeFiles/userver-universal.dir/src/crypto/hash.cpp.o] Error 1
1 error generated.
gmake[2]: *** [userver/universal/CMakeFiles/userver-universal.dir/build.make:118: userver/universal/CMakeFiles/userver-universal.dir/src/crypto/base64.cpp.o] Error 1
/Users/danilshvalov/projects/pg_service_template/third_party/userver/universal/src/crypto/signers.cpp:5:10: fatal error: 'cryptopp/dsa.h' file not found
#include <cryptopp/dsa.h>
         ^~~~~~~~~~~~~~~~
/Users/danilshvalov/projects/pg_service_template/third_party/userver/universal/src/crypto/verifiers.cpp:3:10: fatal error: 'cryptopp/dsa.h' file not found
#include <cryptopp/dsa.h>
         ^~~~~~~~~~~~~~~~
1 error generated.
gmake[2]: *** [userver/universal/CMakeFiles/userver-universal.dir/build.make:216: userver/universal/CMakeFiles/userver-universal.dir/src/crypto/signers.cpp.o] Error 1
1 error generated.
gmake[2]: *** [userver/universal/CMakeFiles/userver-universal.dir/build.make:230: userver/universal/CMakeFiles/userver-universal.dir/src/crypto/verifiers.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:529: userver/universal/CMakeFiles/userver-universal.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

</details>
