### PR TITLE
fix: use correct protobuf include dir in external protobuf case

### DIFF
--- a/cmake/GrpcTargets.cmake
+++ b/cmake/GrpcTargets.cmake
@@ -14,7 +14,7 @@ else()
   if(Protobuf_INCLUDE_DIR)
     set(USERVER_PROTOBUF_IMPORT_DIR "${Protobuf_INCLUDE_DIR}")
   else()
-    set(USERVER_PROTOBUF_IMPORT_DIR "${Protobuf_INCLUDE_DIRS}")
+    set(USERVER_PROTOBUF_IMPORT_DIR "${protobuf_INCLUDE_DIRS}")
   endif()
 
   include(SetupGrpc)


### PR DESCRIPTION
There was cmake configure error when we use userver as git submodule and external protobuf with conan package manager

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/.