### PR TITLE
fix core: use of deprecated API

### DIFF
--- a/core/src/fs/fs_cache_client.cpp
+++ b/core/src/fs/fs_cache_client.cpp
@@ -113,7 +113,7 @@ void FsCacheClient::HandleCreate(const std::string& path) {
   if (IsFilepathHidden(path)) return;
 
   FileInfoWithData info{};
-  info.extension = boost::filesystem::extension(path);
+  info.extension = boost::filesystem::path(path).extension().string();
   info.data = ReadFileContents(tp_, path);
   data_.InsertOrAssign(
       GetLexicallyRelative(path, dir_),


### PR DESCRIPTION
"warning: 'extension' is deprecated: Use path::extension() instead [-Wdeprecated-declarations]"