### PR TITLE
fix core: unused result warning

### DIFF
--- a/core/src/clients/dns/resolver.cpp
+++ b/core/src/clients/dns/resolver.cpp
@@ -412,7 +412,7 @@ AddrVector Resolver::Resolve(const std::string& name,
   if (net_result.status == Impl::NetCacheResult::Status::kMiss) {
     // synchronize with possible parallel updates
     if (deadline.IsReachable()) {
-      lock.try_lock_for(deadline.TimeLeft());
+      [[maybe_unused]] auto lock_result = lock.try_lock_for(deadline.TimeLeft());
     } else {
       lock.lock();
     }


### PR DESCRIPTION
warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]