### PR TITLE
feat rabbitmq: add basic.get command, which retrieves only a single message

### DIFF
--- a/rabbitmq/include/userver/urabbitmq/broker_interface.hpp
+++ b/rabbitmq/include/userver/urabbitmq/broker_interface.hpp
@@ -103,6 +103,20 @@ class IChannelInterface {
                        const std::string& message,
                        engine::Deadline deadline) = 0;
 
+  /// @brief Gets a single message.
+  ///
+  /// You have to set kNoAck flag in order for server to implicitely
+  /// acknowledge gathered message.
+  /// By default the gathered message has to be explicitly
+  /// acknowledged or rejected.
+  ///
+  /// @param queue name of the queue
+  /// @param flags queue flags
+  /// @param message consumed message
+  /// @param deadline execution deadline
+  virtual std::string Get(const Queue& queue, utils::Flags<Queue::Flags> flags,
+                          engine::Deadline deadline) = 0;
+
  protected:
   ~IChannelInterface();
 };

--- a/rabbitmq/include/userver/urabbitmq/channel.hpp
+++ b/rabbitmq/include/userver/urabbitmq/channel.hpp
@@ -41,6 +41,9 @@ class Channel final : IChannelInterface {
     Publish(exchange, routing_key, message, MessageType::kTransient, deadline);
   };
 
+  std::string Get(const Queue& queue, utils::Flags<Queue::Flags> flags,
+                  engine::Deadline deadline) override;
+
  private:
   utils::FastPimpl<ConnectionPtr, 32, 8> impl_;
 };

--- a/rabbitmq/include/userver/urabbitmq/client.hpp
+++ b/rabbitmq/include/userver/urabbitmq/client.hpp
@@ -82,6 +82,9 @@ class Client : public std::enable_shared_from_this<Client>,
     Publish(exchange, routing_key, message, MessageType::kTransient, deadline);
   };
 
+  std::string Get(const Queue& queue, utils::Flags<Queue::Flags> flags,
+                  engine::Deadline deadline) override;
+
   /// @brief Get a publisher interface for the broker.
   ///
   /// @param deadline deadline for connection acquisition from the pool

--- a/rabbitmq/include/userver/urabbitmq/typedefs.hpp
+++ b/rabbitmq/include/userver/urabbitmq/typedefs.hpp
@@ -20,7 +20,8 @@ class Queue final : public utils::StrongTypedef<class QueueTag, std::string> {
     kPassive = 1 << 0,
     kDurable = 1 << 1,
     kExclusive = 1 << 2,
-    kAutoDelete = 1 << 3
+    kAutoDelete = 1 << 3,
+    kNoAck = 1 << 4
   };
 };
 

--- a/rabbitmq/src/tests/publish_consume_rmqtest.cpp
+++ b/rabbitmq/src/tests/publish_consume_rmqtest.cpp
@@ -113,6 +113,23 @@ UTEST(Consumer, ConsumeWorks) {
   EXPECT_EQ(consumed[0], message);
 }
 
+UTEST(Consumer, BasicConsumeWorks) {
+  ClientWrapper client{};
+  client.SetupRmqEntities();
+  const urabbitmq::ConsumerSettings settings{client.GetQueue(), 10};
+
+  const std::string message = "Hi from userver!";
+  client->PublishReliable(client.GetExchange(), client.GetRoutingKey(), message,
+                          urabbitmq::MessageType::kTransient,
+                          client.GetDeadline());
+
+  const std::string consumed_message =
+      client->Get(client.GetQueue(), {}, client.GetDeadline());
+
+  EXPECT_EQ(!consumed_message.empty(), true);
+  EXPECT_EQ(consumed_message, message);
+}
+
 UTEST(Consumer, ExhaustesQueue) {
   ClientWrapper client{};
   client.SetupRmqEntities();

--- a/rabbitmq/src/urabbitmq/channel.cpp
+++ b/rabbitmq/src/urabbitmq/channel.cpp
@@ -20,6 +20,13 @@ void Channel::Publish(const Exchange& exchange, const std::string& routing_key,
                             deadline);
 }
 
+std::string Channel::Get(const Queue& queue, utils::Flags<Queue::Flags> flags,
+                         engine::Deadline deadline) {
+  std::string message{};
+  ConnectionHelper::Get(*impl_, queue, flags, message, deadline).Wait(deadline);
+  return message;
+}
+
 ReliableChannel::ReliableChannel(ConnectionPtr&& channel)
     : impl_{std::move(channel)} {}
 

--- a/rabbitmq/src/urabbitmq/client.cpp
+++ b/rabbitmq/src/urabbitmq/client.cpp
@@ -60,6 +60,16 @@ void Client::RemoveQueue(const Queue& queue, engine::Deadline deadline) {
   awaiter.Wait(deadline);
 }
 
+std::string Client::Get(const Queue& queue, utils::Flags<Queue::Flags> flags,
+                        engine::Deadline deadline) {
+  std::string message{};
+  auto awaiter = ConnectionHelper::Get(impl_->GetConnection(deadline), queue,
+                                       flags, message, deadline);
+  awaiter.Wait(deadline);
+
+  return message;
+}
+
 void Client::Publish(const Exchange& exchange, const std::string& routing_key,
                      const std::string& message, MessageType type,
                      engine::Deadline deadline) {

--- a/rabbitmq/src/urabbitmq/connection_helper.cpp
+++ b/rabbitmq/src/urabbitmq/connection_helper.cpp
@@ -51,6 +51,16 @@ impl::ResponseAwaiter ConnectionHelper::RemoveQueue(
   });
 }
 
+impl::ResponseAwaiter ConnectionHelper::Get(const ConnectionPtr& connection,
+                                            const Queue& queue,
+                                            utils::Flags<Queue::Flags> flags,
+                                            std::string& message,
+                                            engine::Deadline deadline) {
+  return WithSpan("get", [&] {
+    return connection->GetChannel().Get(queue, flags, message, deadline);
+  });
+}
+
 void ConnectionHelper::Publish(const ConnectionPtr& connection,
                                const Exchange& exchange,
                                const std::string& routing_key,

--- a/rabbitmq/src/urabbitmq/connection_helper.hpp
+++ b/rabbitmq/src/urabbitmq/connection_helper.hpp
@@ -42,6 +42,11 @@ class ConnectionHelper final {
       const ConnectionPtr& connection, const Queue& queue,
       engine::Deadline deadline);
 
+  [[nodiscard]] static impl::ResponseAwaiter Get(
+      const ConnectionPtr& connection, const Queue& queue,
+      utils::Flags<Queue::Flags> flags, std::string& message,
+      engine::Deadline deadline);
+
   static void Publish(const ConnectionPtr& connection, const Exchange& exchange,
                       const std::string& routing_key,
                       const std::string& message, MessageType type,

--- a/rabbitmq/src/urabbitmq/impl/amqp_channel.hpp
+++ b/rabbitmq/src/urabbitmq/impl/amqp_channel.hpp
@@ -50,6 +50,9 @@ class AmqpChannel final {
 
   ResponseAwaiter RemoveQueue(const Queue& queue, engine::Deadline deadline);
 
+  ResponseAwaiter Get(const Queue& queue, utils::Flags<Queue::Flags> flags,
+                      std::string& message, engine::Deadline deadline);
+
   void Publish(const Exchange& exchange, const std::string& routing_key,
                const std::string& message, MessageType type,
                engine::Deadline deadline);

--- a/rabbitmq/src/urabbitmq/impl/deferred_wrapper.cpp
+++ b/rabbitmq/src/urabbitmq/impl/deferred_wrapper.cpp
@@ -47,6 +47,19 @@ void DeferredWrapper::Wrap(AMQP::Deferred& deferred) {
       });
 }
 
+void DeferredWrapper::WrapGet(AMQP::DeferredGet& deferred,
+                              std::string& message) {
+  deferred
+      .onSuccess([wrap = shared_from_this(), &message](
+                     const AMQP::Message& message_rec, uint64_t, bool) {
+        message = std::string(message_rec.body(), message_rec.bodySize());
+        wrap->Ok();
+      })
+      .onError([wrap = shared_from_this()](const char* error) {
+        wrap->Fail(error);
+      });
+}
+
 }  // namespace urabbitmq::impl
 
 USERVER_NAMESPACE_END

--- a/rabbitmq/src/urabbitmq/impl/deferred_wrapper.hpp
+++ b/rabbitmq/src/urabbitmq/impl/deferred_wrapper.hpp
@@ -10,7 +10,8 @@
 
 namespace AMQP {
 class Deferred;
-}
+class DeferredGet;
+}  // namespace AMQP
 
 USERVER_NAMESPACE_BEGIN
 
@@ -27,6 +28,8 @@ class DeferredWrapper : public std::enable_shared_from_this<DeferredWrapper> {
   void Wait(engine::Deadline deadline);
 
   void Wrap(AMQP::Deferred& deferred);
+
+  void WrapGet(AMQP::DeferredGet& deferred, std::string& message);
 
   static std::shared_ptr<DeferredWrapper> Create();
 


### PR DESCRIPTION
https://www.rabbitmq.com/amqp-0-9-1-quickref.html#basic.get

might be useful for publish-consume chain, when needed to send request(publish data) and receive response(consume single response message) as soon as possible 