### PR TITLE
Add options to disable `DISCARD ALL` processing on connection startup

### DIFF
--- a/postgresql/include/userver/storages/postgres/options.hpp
+++ b/postgresql/include/userver/storages/postgres/options.hpp
@@ -232,6 +232,9 @@ struct ConnectionSettings {
   /// Turns on connection pipeline mode
   PipelineMode pipeline_mode = PipelineMode::kDisabled;
 
+  // Tunrs on 'DISCARD ALL' on connection acquire
+  bool discard_all_on_acquire_connection = false;
+
   /// This many connection errors in 15 seconds block new connections opening
   size_t recent_errors_threshold = 2;
 

--- a/postgresql/src/storages/postgres/component.cpp
+++ b/postgresql/src/storages/postgres/component.cpp
@@ -102,6 +102,8 @@ Postgres::Postgres(const ComponentConfig& config,
           config.As<storages::postgres::ConnectionSettings>());
   initial_settings_.conn_settings.pipeline_mode =
       initial_config[storages::postgres::kPipelineModeKey];
+  initial_settings_.conn_settings.discard_all_on_acquire_connection =
+      initial_config[storages::postgres::kDiscardAllOnAcquireConnection];
   initial_settings_.statement_metrics_settings =
       pg_config.statement_metrics_settings.GetOptional(name_).value_or(
           config.As<storages::postgres::StatementMetricsSettings>());
@@ -187,6 +189,7 @@ void Postgres::OnConfigUpdate(const dynamic_config::Snapshot& cfg) {
       pg_config.connection_settings.GetOptional(name_).value_or(
           initial_settings_.conn_settings);
   connection_settings.pipeline_mode = cfg[storages::postgres::kPipelineModeKey];
+  connection_settings.discard_all_on_acquire_connection = cfg[storages::postgres::kDiscardAllOnAcquireConnection];
   const auto statement_metrics_settings =
       pg_config.statement_metrics_settings.GetOptional(name_).value_or(
           initial_settings_.statement_metrics_settings);

--- a/postgresql/src/storages/postgres/detail/connection_impl.cpp
+++ b/postgresql/src/storages/postgres/detail/connection_impl.cpp
@@ -217,7 +217,9 @@ void ConnectionImpl::AsyncConnect(const Dsn& dsn, engine::Deadline deadline) {
   conn_wrapper_.FillSpanTags(span);
   scope.Reset(scopes::kGetConnectData);
   // We cannot handle exceptions here, so we let them got to the caller
-  ExecuteCommandNoPrepare("DISCARD ALL", deadline);
+  if (settings_.discard_all_on_acquire_connection) {
+  	ExecuteCommandNoPrepare("DISCARD ALL", deadline);
+  }
   SetParameter("client_encoding", "UTF8", Connection::ParameterScope::kSession,
                deadline);
   RefreshReplicaState(deadline);

--- a/postgresql/src/storages/postgres/postgres_config.cpp
+++ b/postgresql/src/storages/postgres/postgres_config.cpp
@@ -186,6 +186,9 @@ const dynamic_config::Key<PipelineMode> kPipelineModeKey{
     "POSTGRES_CONNECTION_PIPELINE_EXPERIMENT", ParsePipelineMode,
     dynamic_config::DefaultAsJsonString{"0"}};
 
+const dynamic_config::Key<bool> kDiscardAllOnAcquireConnection{
+    "POSTGRES_DISCARD_ALL_ON_ACQUIRE_CONNECTION", false};
+
 const dynamic_config::Key<bool> kConnlimitModeAutoEnabled{
     "POSTGRES_CONNLIMIT_MODE_AUTO_ENABLED", false};
 

--- a/postgresql/src/storages/postgres/postgres_config.hpp
+++ b/postgresql/src/storages/postgres/postgres_config.hpp
@@ -47,6 +47,8 @@ extern const dynamic_config::Key<Config> kConfig;
 
 extern const dynamic_config::Key<PipelineMode> kPipelineModeKey;
 
+extern const dynamic_config::Key<bool> kDiscardAllOnAcquireConnection;
+
 extern const dynamic_config::Key<bool> kConnlimitModeAutoEnabled;
 
 extern const dynamic_config::Key<int> kDeadlinePropagationVersionConfig;


### PR DESCRIPTION
current status: not tested