### PR TITLE
feat http: remove GetOrigMethod from HttpRequestImpl

### DIFF
--- a/core/src/server/http/handler_methods.hpp
+++ b/core/src/server/http/handler_methods.hpp
@@ -9,9 +9,9 @@ USERVER_NAMESPACE_BEGIN
 namespace server::http {
 
 inline constexpr HttpMethod kHandlerMethods[] = {
-    HttpMethod::kGet,    HttpMethod::kPost,  HttpMethod::kPut,
-    HttpMethod::kDelete, HttpMethod::kPatch, HttpMethod::kOptions,
-    HttpMethod::kUnknown};
+    HttpMethod::kGet,     HttpMethod::kHead,   HttpMethod::kPost,
+    HttpMethod::kPut,     HttpMethod::kDelete, HttpMethod::kPatch,
+    HttpMethod::kOptions, HttpMethod::kUnknown};
 
 inline constexpr size_t kHandlerMethodsMax = static_cast<size_t>(
     *std::max_element(std::begin(kHandlerMethods), std::end(kHandlerMethods)));

--- a/core/src/server/http/http_request_constructor.cpp
+++ b/core/src/server/http/http_request_constructor.cpp
@@ -49,8 +49,7 @@ HttpRequestConstructor::HttpRequestConstructor(
       request_(std::make_shared<HttpRequestImpl>(data_accounter)) {}
 
 void HttpRequestConstructor::SetMethod(HttpMethod method) {
-  request_->orig_method_ = method;
-  request_->method_ = (method == HttpMethod::kHead ? HttpMethod::kGet : method);
+  request_->method_ = method;
 }
 
 void HttpRequestConstructor::SetHttpMajor(unsigned short http_major) {
@@ -167,8 +166,7 @@ void HttpRequestConstructor::SetIsFinal(bool is_final) {
 }
 
 std::shared_ptr<request::RequestBase> HttpRequestConstructor::Finalize() {
-  LOG_TRACE() << "method=" << request_->GetMethodStr()
-              << " orig_method=" << request_->GetOrigMethodStr();
+  LOG_TRACE() << "method=" << request_->GetMethodStr();
 
   FinalizeImpl();
 

--- a/core/src/server/http/http_request_impl.cpp
+++ b/core/src/server/http/http_request_impl.cpp
@@ -355,7 +355,7 @@ void HttpRequestImpl::WriteAccessLog(
           utils::datetime::LocalTimezoneTimestring(tp,
                                                    "%Y-%m-%d %H:%M:%E6S %Ez"),
           EscapeForAccessLog(GetHost()), EscapeForAccessLog(remote_address),
-          EscapeForAccessLog(GetOrigMethodStr()), EscapeForAccessLog(GetUrl()),
+          EscapeForAccessLog(GetMethodStr()), EscapeForAccessLog(GetUrl()),
           GetHttpMajor(), GetHttpMinor(),
           static_cast<int>(response_.GetStatus()),
           EscapeForAccessLog(GetHeader("Referer")),
@@ -394,7 +394,7 @@ void HttpRequestImpl::WriteAccessTskvLog(
                   utils::datetime::LocalTimezoneTimestring(
                       tp, "timestamp=%Y-%m-%dT%H:%M:%S\ttimezone=%Ez"),
                   static_cast<int>(response_.GetStatus()), GetHttpMajor(),
-                  GetHttpMinor(), EscapeForAccessTskvLog(GetOrigMethodStr()),
+                  GetHttpMinor(), EscapeForAccessTskvLog(GetMethodStr()),
                   EscapeForAccessTskvLog(GetUrl()),
                   EscapeForAccessTskvLog(GetHeader("Referer")),
                   EscapeForAccessTskvLog(GetHeader("Cookie")),

--- a/core/src/server/http/http_request_impl.hpp
+++ b/core/src/server/http/http_request_impl.hpp
@@ -32,9 +32,7 @@ class HttpRequestImpl final : public request::RequestBase {
   ~HttpRequestImpl() override;
 
   const HttpMethod& GetMethod() const { return method_; }
-  const HttpMethod& GetOrigMethod() const { return orig_method_; }
   const std::string& GetMethodStr() const { return ToString(method_); }
-  const std::string& GetOrigMethodStr() const { return ToString(orig_method_); }
   int GetHttpMajor() const { return http_major_; }
   int GetHttpMinor() const { return http_minor_; }
   const std::string& GetUrl() const { return url_; }
@@ -141,9 +139,7 @@ class HttpRequestImpl final : public request::RequestBase {
   friend class HttpRequestConstructor;
 
  private:
-  // method_ = (orig_method_ == kHead ? kGet : orig_method_)
   HttpMethod method_{HttpMethod::kUnknown};
-  HttpMethod orig_method_{HttpMethod::kUnknown};
   unsigned short http_major_{1};
   unsigned short http_minor_{1};
   std::string url_;

--- a/core/src/server/http/http_request_method_test.cpp
+++ b/core/src/server/http/http_request_method_test.cpp
@@ -13,7 +13,6 @@ using HttpMethod = server::http::HttpMethod;
 
 struct MethodsData {
   std::string method_query;
-  HttpMethod orig_method;
   HttpMethod method;
 };
 
@@ -31,21 +30,19 @@ std::string PrintMethodsDataTestName(
 INSTANTIATE_UTEST_SUITE_P(
     /**/, HttpRequestMethods,
     ::testing::Values(
-        MethodsData{"DELETE", HttpMethod::kDelete, HttpMethod::kDelete},
-        MethodsData{"GET", HttpMethod::kGet, HttpMethod::kGet},
-        // HEAD should works as GET except response sending and access logs
-        // writing
-        MethodsData{"HEAD", HttpMethod::kHead, HttpMethod::kGet},
-        MethodsData{"POST", HttpMethod::kPost, HttpMethod::kPost},
-        MethodsData{"PUT", HttpMethod::kPut, HttpMethod::kPut},
-        MethodsData{"CONNECT", HttpMethod::kConnect, HttpMethod::kConnect},
-        MethodsData{"PATCH", HttpMethod::kPatch, HttpMethod::kPatch},
-        MethodsData{"OPTIONS", HttpMethod::kOptions, HttpMethod::kOptions},
-        MethodsData{"GE", HttpMethod::kUnknown, HttpMethod::kUnknown},
-        MethodsData{"GETT", HttpMethod::kUnknown, HttpMethod::kUnknown},
-        MethodsData{"get", HttpMethod::kUnknown, HttpMethod::kUnknown},
-        MethodsData{"", HttpMethod::kUnknown, HttpMethod::kUnknown},
-        MethodsData{"XXX", HttpMethod::kUnknown, HttpMethod::kUnknown}),
+        MethodsData{"DELETE", HttpMethod::kDelete},
+        MethodsData{"GET", HttpMethod::kGet},
+        MethodsData{"HEAD", HttpMethod::kHead},
+        MethodsData{"POST", HttpMethod::kPost},
+        MethodsData{"PUT", HttpMethod::kPut},
+        MethodsData{"CONNECT", HttpMethod::kConnect},
+        MethodsData{"PATCH", HttpMethod::kPatch},
+        MethodsData{"OPTIONS", HttpMethod::kOptions},
+        MethodsData{"GE", HttpMethod::kUnknown},
+        MethodsData{"GETT", HttpMethod::kUnknown},
+        MethodsData{"get", HttpMethod::kUnknown},
+        MethodsData{"", HttpMethod::kUnknown},
+        MethodsData{"XXX", HttpMethod::kUnknown}),
     PrintMethodsDataTestName);
 
 UTEST_P(HttpRequestMethods, Test) {
@@ -58,7 +55,6 @@ UTEST_P(HttpRequestMethods, Test) {
         auto& http_request_impl =
             dynamic_cast<server::http::HttpRequestImpl&>(*request);
         const server::http::HttpRequest http_request(http_request_impl);
-        EXPECT_EQ(http_request_impl.GetOrigMethod(), param.orig_method);
         EXPECT_EQ(http_request.GetMethod(), param.method);
       });
 

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -293,7 +293,7 @@ void HttpResponse::SendResponse(engine::io::RwBase& socket) {
 std::size_t HttpResponse::SetBodyNotStreamed(engine::io::RwBase& socket,
                                              std::string& header) {
   const bool is_body_forbidden = IsBodyForbiddenForStatus(status_);
-  const bool is_head_request = request_.GetOrigMethod() == HttpMethod::kHead;
+  const bool is_head_request = request_.GetMethod() == HttpMethod::kHead;
   const auto& data = GetData();
 
   if (!is_body_forbidden) {


### PR DESCRIPTION
Решение №1 для проблемы #428, в котором убран костыль с принудительным превращением HEAD в GET.
Это решение позволяет добавить HEAD в описание ручки в static_config.yaml

Для проверки сделал такой вывод в лог (только без GetOrigMethod):
![userver_head_test](https://github.com/userver-framework/userver/assets/3821904/67499da6-21ca-419b-b726-71da4150272e)

Проверял командой curl:
![userver_head_curl](https://github.com/userver-framework/userver/assets/3821904/03eb948e-753a-4758-878e-0d681d14a7ff)

Получил такой результат:
![userver_head_log_good](https://github.com/userver-framework/userver/assets/3821904/4c9c98dc-44c2-4b26-9398-63ad55178931)
