### PR TITLE
feat http: add GetOrigMethod to HttpRequest

### DIFF
--- a/core/include/userver/server/http/http_request.hpp
+++ b/core/include/userver/server/http/http_request.hpp
@@ -55,6 +55,9 @@ class HttpRequest final {
   const HttpMethod& GetMethod() const;
   const std::string& GetMethodStr() const;
 
+  const HttpMethod& GetOrigMethod() const;
+  const std::string& GetOrigMethodStr() const;
+
   /// @return Major version of HTTP. For example, for HTTP 1.0 it returns 1
   int GetHttpMajor() const;
 

--- a/core/src/server/http/http_request.cpp
+++ b/core/src/server/http/http_request.cpp
@@ -23,6 +23,10 @@ const std::string& HttpRequest::GetMethodStr() const {
   return impl_.GetMethodStr();
 }
 
+const HttpMethod& HttpRequest::GetOrigMethod() const { return impl_.GetOrigMethod(); }
+
+const std::string& HttpRequest::GetOrigMethodStr() const { return impl_.GetOrigMethodStr(); }
+
 int HttpRequest::GetHttpMajor() const { return impl_.GetHttpMajor(); }
 
 int HttpRequest::GetHttpMinor() const { return impl_.GetHttpMinor(); }


### PR DESCRIPTION
Решение №2 для проблемы #428, в котором добавлена костыльная ручка GetOrigMethod
Это решение **не** позволяет добавить HEAD в описание ручки в static_config.yaml

Для проверки сделал такой вывод в лог:
![userver_head_test](https://github.com/userver-framework/userver/assets/3821904/67499da6-21ca-419b-b726-71da4150272e)

Проверял командой curl:
![userver_head_curl](https://github.com/userver-framework/userver/assets/3821904/03eb948e-753a-4758-878e-0d681d14a7ff)

Получил такой результат:
![userver_head_log](https://github.com/userver-framework/userver/assets/3821904/57362a41-2ff7-42cb-b3a0-bd543a470a8d)
