### PR TITLE
implement small_string::resize_and_overwrite, tests and benchmarks for it

### DIFF
--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -86,6 +86,11 @@ class SmallString final {
   /// fill new chars with %c.
   void resize(std::size_t n, char c);
 
+  /// @brief Resize the string. Use op to write into the string and replace a
+  /// sequence of characters
+  template <class Operation>
+  void resize_and_overwrite(std::size_t size, Operation op);
+
   /// @brief Get current capacity.
   std::size_t capacity() const noexcept;
 
@@ -250,6 +255,13 @@ void SmallString<N>::pop_back() {
 template <std::size_t N>
 void SmallString<N>::resize(std::size_t n, char c) {
   data_.resize(n, c);
+}
+
+template <std::size_t N>
+template <class Operation>
+void SmallString<N>::resize_and_overwrite(std::size_t size, Operation op) {
+  data_.resize(size);
+  data_.erase(data_.begin() + op(data_.data(), size), data_.end());
 }
 
 template <std::size_t N>

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -261,8 +261,7 @@ template <std::size_t N>
 template <class Operation>
 void SmallString<N>::resize_and_overwrite(std::size_t size, Operation op) {
   data_.resize(size, boost::container::default_init);
-  data_.resize(std::move(op(data_.data(), size)),
-               boost::container::default_init);
+  data_.resize(std::move(op)(data_.data(), size));
 }
 
 template <std::size_t N>

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -260,8 +260,9 @@ void SmallString<N>::resize(std::size_t n, char c) {
 template <std::size_t N>
 template <class Operation>
 void SmallString<N>::resize_and_overwrite(std::size_t size, Operation op) {
-  data_.resize(size);
-  data_.erase(data_.begin() + op(data_.data(), size), data_.end());
+  data_.resize(size, boost::container::default_init);
+  data_.resize(std::move(op(data_.data(), size)),
+               boost::container::default_init);
 }
 
 template <std::size_t N>

--- a/universal/src/utils/small_string_benchmark.cpp
+++ b/universal/src/utils/small_string_benchmark.cpp
@@ -99,7 +99,7 @@ BENCHMARK(SmallString_Small_Move)
     ->Range(2, 2 << 10)
     ->Unit(benchmark::kMicrosecond);
 
-static void SmallString_Resize_and_Overwrite(benchmark::State& state) {
+static void SmallString_Resize_And_Overwrite(benchmark::State& state) {
   auto s = GenerateString(state.range(0));
   std::array<utils::SmallString<1000>, kArraySize> str;
   std::array<utils::SmallString<1>, kArraySize> str2;
@@ -116,11 +116,11 @@ static void SmallString_Resize_and_Overwrite(benchmark::State& state) {
     state.ResumeTiming();
   }
 }
-BENCHMARK(SmallString_Resize_and_Overwrite)
+BENCHMARK(SmallString_Resize_And_Overwrite)
     ->Range(2, 2 << 12)
     ->Unit(benchmark::kMicrosecond);
 
-static void SmallString_Resize_then_Overwrite(benchmark::State& state) {
+static void SmallString_Resize_Then_Overwrite(benchmark::State& state) {
   auto s = GenerateString(state.range(0));
   std::array<utils::SmallString<1000>, kArraySize> str;
   std::array<utils::SmallString<1>, kArraySize> str2;
@@ -135,7 +135,7 @@ static void SmallString_Resize_then_Overwrite(benchmark::State& state) {
     state.ResumeTiming();
   }
 }
-BENCHMARK(SmallString_Resize_then_Overwrite)
+BENCHMARK(SmallString_Resize_Then_Overwrite)
     ->Range(2, 2 << 12)
     ->Unit(benchmark::kMicrosecond);
 

--- a/universal/src/utils/small_string_benchmark.cpp
+++ b/universal/src/utils/small_string_benchmark.cpp
@@ -16,6 +16,7 @@ std::string GenerateString(size_t size) {
   std::string_view chars{"0123456789"};
   std::string result;
   for (size_t i = 0; i < size; i++) result += chars[i % 10];
+  return Launder(std::move(result));
 }
 
 static void SmallString_Std(benchmark::State& state) {

--- a/universal/src/utils/small_string_benchmark.cpp
+++ b/universal/src/utils/small_string_benchmark.cpp
@@ -2,6 +2,8 @@
 
 #include <array>
 
+#include <utils/gbench_auxilary.hpp>
+
 #include <benchmark/benchmark.h>
 
 USERVER_NAMESPACE_BEGIN
@@ -14,7 +16,6 @@ std::string GenerateString(size_t size) {
   std::string_view chars{"0123456789"};
   std::string result;
   for (size_t i = 0; i < size; i++) result += chars[i % 10];
-  return result;
 }
 
 static void SmallString_Std(benchmark::State& state) {
@@ -99,7 +100,7 @@ BENCHMARK(SmallString_Small_Move)
     ->Range(2, 2 << 10)
     ->Unit(benchmark::kMicrosecond);
 
-static void SmallString_Resize_And_Overwrite(benchmark::State& state) {
+static void SmallStringResizeAndOverwrite(benchmark::State& state) {
   auto s = GenerateString(state.range(0));
   std::array<utils::SmallString<1000>, kArraySize> str;
   std::array<utils::SmallString<1>, kArraySize> str2;
@@ -116,11 +117,11 @@ static void SmallString_Resize_And_Overwrite(benchmark::State& state) {
     state.ResumeTiming();
   }
 }
-BENCHMARK(SmallString_Resize_And_Overwrite)
-    ->Range(2, 2 << 12)
+BENCHMARK(SmallStringResizeAndOverwrite)
+    ->Range(2, 2 << 10)
     ->Unit(benchmark::kMicrosecond);
 
-static void SmallString_Resize_Then_Overwrite(benchmark::State& state) {
+static void SmallStringResizeThenOverwrite(benchmark::State& state) {
   auto s = GenerateString(state.range(0));
   std::array<utils::SmallString<1000>, kArraySize> str;
   std::array<utils::SmallString<1>, kArraySize> str2;
@@ -135,8 +136,8 @@ static void SmallString_Resize_Then_Overwrite(benchmark::State& state) {
     state.ResumeTiming();
   }
 }
-BENCHMARK(SmallString_Resize_Then_Overwrite)
-    ->Range(2, 2 << 12)
+BENCHMARK(SmallStringResizeThenOverwrite)
+    ->Range(2, 2 << 10)
     ->Unit(benchmark::kMicrosecond);
 
 USERVER_NAMESPACE_END

--- a/universal/src/utils/small_string_test.cpp
+++ b/universal/src/utils/small_string_test.cpp
@@ -70,6 +70,21 @@ TEST(SmallString, SizeCapacity) {
   EXPECT_GT(str.capacity(), capacity);
 }
 
+TEST(SmallString, ResizeAndOverwrite) {
+  utils::SmallString<4> small_str("abcd");
+
+  size_t count = 3;
+  std::string str = "mnkp";
+
+  small_str.resize_and_overwrite(16, [&](char* data, size_t size) {
+    for (size_t ind = 0; ind < count; ++ind) {
+      std::copy(str.data(), str.data() + str.size(), data + ind * str.size());
+    }
+    return count * str.size();
+  });
+  EXPECT_EQ(small_str, "mnkpmnkpmnkp");
+}
+
 TEST(SmallString, Assign) {
   utils::SmallString<10> str("abcd");
   utils::SmallString<10> str2;

--- a/universal/src/utils/small_string_test.cpp
+++ b/universal/src/utils/small_string_test.cpp
@@ -73,7 +73,7 @@ TEST(SmallString, SizeCapacity) {
 TEST(SmallString, ResizeAndOverwrite) {
   utils::SmallString<4> small_str("abcd");
 
-  size_t count = 3;
+  std::size_t count = 3;
   std::string str = "mnkp";
 
   small_str.resize_and_overwrite(16, [&](char* data, size_t size) {

--- a/universal/src/utils/small_string_test.cpp
+++ b/universal/src/utils/small_string_test.cpp
@@ -10,6 +10,14 @@
 
 USERVER_NAMESPACE_BEGIN
 
+struct CheckRvalueCall {
+  std::size_t operator()(char*, std::size_t s) const& {
+    ADD_FAILURE() << "Wrond overload called";
+    return s;
+  }
+  std::size_t operator()(char*, std::size_t s) && { return s; }
+};
+
 TEST(SmallString, Empty) {
   utils::SmallString<10> str;
   EXPECT_TRUE(str.empty());
@@ -76,13 +84,20 @@ TEST(SmallString, ResizeAndOverwrite) {
   std::size_t count = 3;
   std::string str = "mnkp";
 
-  small_str.resize_and_overwrite(16, [&](char* data, [[maybe_unused]] size_t size) {
+  small_str.resize_and_overwrite(16, [&](char* data,
+                                         [[maybe_unused]] size_t size) {
     for (size_t ind = 0; ind < count; ++ind) {
       std::copy(str.data(), str.data() + str.size(), data + ind * str.size());
     }
     return count * str.size();
   });
   EXPECT_EQ(small_str, "mnkpmnkpmnkp");
+}
+
+TEST(SmallString, ResizeAndOverwriteRvalueCall) {
+  utils::SmallString<4> small_str("abcd");
+
+  small_str.resize_and_overwrite(16, CheckRvalueCall());
 }
 
 TEST(SmallString, Assign) {

--- a/universal/src/utils/small_string_test.cpp
+++ b/universal/src/utils/small_string_test.cpp
@@ -76,7 +76,7 @@ TEST(SmallString, ResizeAndOverwrite) {
   std::size_t count = 3;
   std::string str = "mnkp";
 
-  small_str.resize_and_overwrite(16, [&](char* data, size_t size) {
+  small_str.resize_and_overwrite(16, [&](char* data, [[maybe_unused]] size_t size) {
     for (size_t ind = 0; ind < count; ++ind) {
       std::copy(str.data(), str.data() + str.size(), data + ind * str.size());
     }


### PR DESCRIPTION
Имплементация метода resize_and_overwrite из #406
Улучшение производительности:

```
Benchmark                                    Time             CPU   Iterations

SmallStringResizeAndOverwrite/2           5.01 us         5.03 us       100485
SmallStringResizeAndOverwrite/8           4.43 us         4.45 us       157111
SmallStringResizeAndOverwrite/64          5.20 us         5.24 us       132817
SmallStringResizeAndOverwrite/512         15.9 us         16.0 us        45383
SmallStringResizeAndOverwrite/2048         206 us          207 us         3385

SmallStringResizeThenOverwrite/2          6.90 us         6.92 us       106967
SmallStringResizeThenOverwrite/8          6.29 us         6.31 us       114793
SmallStringResizeThenOverwrite/64         5.77 us         5.81 us        92461
SmallStringResizeThenOverwrite/512        19.9 us         20.0 us        37919
SmallStringResizeThenOverwrite/2048        288 us          289 us         2435

```

