### PR TITLE
Optimize send response

### DIFF
--- a/core/include/userver/server/http/http_response.hpp
+++ b/core/include/userver/server/http/http_response.hpp
@@ -24,9 +24,6 @@ namespace server::http {
 
 namespace impl {
 
-void OutputHeader(std::string& header, std::string_view key,
-                  std::string_view val);
-
 void OutputHeader(USERVER_NAMESPACE::http::headers::HeadersString& header,
                   std::string_view key, std::string_view val);
 

--- a/core/include/userver/server/http/http_response.hpp
+++ b/core/include/userver/server/http/http_response.hpp
@@ -24,10 +24,8 @@ namespace server::http {
 
 namespace impl {
 
-void OutputHeader(userver::http::headers::HeadersString& header,
+void OutputHeader(USERVER_NAMESPACE::http::headers::HeadersString& header,
                   std::string_view key, std::string_view val);
-void OutputHeader(std::string& header, std::string_view key,
-                  std::string_view val);
 
 }  // namespace impl
 
@@ -141,12 +139,14 @@ class HttpResponse final : public request::ResponseBase {
 
  private:
   // Returns total size of the response
-  std::size_t SetBodyStreamed(engine::io::RwBase& socket,
-                              userver::http::headers::HeadersString& header);
+  std::size_t SetBodyStreamed(
+      engine::io::RwBase& socket,
+      USERVER_NAMESPACE::http::headers::HeadersString& header);
 
   // Returns total size of the response
-  std::size_t SetBodyNotStreamed(engine::io::RwBase& socket,
-                                 userver::http::headers::HeadersString& header);
+  std::size_t SetBodyNotStreamed(
+      engine::io::RwBase& socket,
+      USERVER_NAMESPACE::http::headers::HeadersString& header);
 
   const HttpRequestImpl& request_;
   HttpStatus status_ = HttpStatus::kOk;

--- a/core/include/userver/server/http/http_response.hpp
+++ b/core/include/userver/server/http/http_response.hpp
@@ -15,6 +15,7 @@
 #include <userver/server/request/response_base.hpp>
 #include <userver/utils/impl/projecting_view.hpp>
 #include <userver/utils/str_icase.hpp>
+#include <userver/utils/small_string.hpp>
 
 #include "http_status.hpp"
 
@@ -139,11 +140,13 @@ class HttpResponse final : public request::ResponseBase {
 
  private:
   // Returns total size of the response
-  std::size_t SetBodyStreamed(engine::io::RwBase& socket, std::string& header);
+  template <std::size_t N>
+  std::size_t SetBodyStreamed(engine::io::RwBase& socket, utils::SmallString<N>& header);
 
   // Returns total size of the response
+  template <std::size_t N>
   std::size_t SetBodyNotStreamed(engine::io::RwBase& socket,
-                                 std::string& header);
+                                 utils::SmallString<N>& header);
 
   const HttpRequestImpl& request_;
   HttpStatus status_ = HttpStatus::kOk;

--- a/core/include/userver/server/http/http_response.hpp
+++ b/core/include/userver/server/http/http_response.hpp
@@ -14,8 +14,8 @@
 #include <userver/server/http/http_response_cookie.hpp>
 #include <userver/server/request/response_base.hpp>
 #include <userver/utils/impl/projecting_view.hpp>
-#include <userver/utils/str_icase.hpp>
 #include <userver/utils/small_string.hpp>
+#include <userver/utils/str_icase.hpp>
 
 #include "http_status.hpp"
 
@@ -139,14 +139,16 @@ class HttpResponse final : public request::ResponseBase {
   Queue::Producer GetBodyProducer();
 
  private:
+  static constexpr std::size_t kTypicalHeaderSize = 1024;
+
+  using HeadersString = utils::SmallString<kTypicalHeaderSize>;
   // Returns total size of the response
-  template <std::size_t N>
-  std::size_t SetBodyStreamed(engine::io::RwBase& socket, utils::SmallString<N>& header);
+  std::size_t SetBodyStreamed(engine::io::RwBase& socket,
+                              HeadersString& header);
 
   // Returns total size of the response
-  template <std::size_t N>
   std::size_t SetBodyNotStreamed(engine::io::RwBase& socket,
-                                 utils::SmallString<N>& header);
+                                 HeadersString& header);
 
   const HttpRequestImpl& request_;
   HttpStatus status_ = HttpStatus::kOk;

--- a/core/include/userver/server/http/http_response.hpp
+++ b/core/include/userver/server/http/http_response.hpp
@@ -24,10 +24,12 @@ namespace server::http {
 
 namespace impl {
 
+void OutputHeader(userver::http::headers::HeadersString& header,
+                  std::string_view key, std::string_view val);
 void OutputHeader(std::string& header, std::string_view key,
                   std::string_view val);
 
-}
+}  // namespace impl
 
 class HttpRequestImpl;
 

--- a/core/include/userver/server/http/http_response.hpp
+++ b/core/include/userver/server/http/http_response.hpp
@@ -14,7 +14,6 @@
 #include <userver/server/http/http_response_cookie.hpp>
 #include <userver/server/request/response_base.hpp>
 #include <userver/utils/impl/projecting_view.hpp>
-#include <userver/utils/small_string.hpp>
 #include <userver/utils/str_icase.hpp>
 
 #include "http_status.hpp"
@@ -139,16 +138,13 @@ class HttpResponse final : public request::ResponseBase {
   Queue::Producer GetBodyProducer();
 
  private:
-  static constexpr std::size_t kTypicalHeaderSize = 1024;
-
-  using HeadersString = utils::SmallString<kTypicalHeaderSize>;
   // Returns total size of the response
   std::size_t SetBodyStreamed(engine::io::RwBase& socket,
-                              HeadersString& header);
+                              userver::http::headers::HeadersString& header);
 
   // Returns total size of the response
   std::size_t SetBodyNotStreamed(engine::io::RwBase& socket,
-                                 HeadersString& header);
+                                 userver::http::headers::HeadersString& header);
 
   const HttpRequestImpl& request_;
   HttpStatus status_ = HttpStatus::kOk;

--- a/core/include/userver/server/http/http_response.hpp
+++ b/core/include/userver/server/http/http_response.hpp
@@ -24,6 +24,9 @@ namespace server::http {
 
 namespace impl {
 
+void OutputHeader(std::string& header, std::string_view key,
+                  std::string_view val);
+
 void OutputHeader(USERVER_NAMESPACE::http::headers::HeadersString& header,
                   std::string_view key, std::string_view val);
 

--- a/core/include/userver/server/http/http_response_cookie.hpp
+++ b/core/include/userver/server/http/http_response_cookie.hpp
@@ -64,7 +64,6 @@ class Cookie final {
   USERVER_NAMESPACE::http::headers::HeadersString ToSmallString() const;
   std::string ToString() const;
 
-  void AppendToString(std::string& os) const;
   void AppendToString(USERVER_NAMESPACE::http::headers::HeadersString& os) const;
 
  private:

--- a/core/include/userver/server/http/http_response_cookie.hpp
+++ b/core/include/userver/server/http/http_response_cookie.hpp
@@ -61,7 +61,7 @@ class Cookie final {
   std::string SameSite() const;
   Cookie& SetSameSite(std::string value);
 
-  USERVER_NAMESPACE::http::headers::HeadersString ToString() const;
+  std::string ToString() const;
 
   void AppendToString(
       USERVER_NAMESPACE::http::headers::HeadersString& os) const;

--- a/core/include/userver/server/http/http_response_cookie.hpp
+++ b/core/include/userver/server/http/http_response_cookie.hpp
@@ -61,6 +61,7 @@ class Cookie final {
   std::string SameSite() const;
   Cookie& SetSameSite(std::string value);
 
+  USERVER_NAMESPACE::http::headers::HeadersString ToSmallString() const;
   std::string ToString() const;
 
   void AppendToString(std::string& os) const;

--- a/core/include/userver/server/http/http_response_cookie.hpp
+++ b/core/include/userver/server/http/http_response_cookie.hpp
@@ -9,8 +9,8 @@
 #include <string>
 #include <unordered_map>
 
-#include <userver/utils/str_icase.hpp>
 #include <userver/http/predefined_header.hpp>
+#include <userver/utils/str_icase.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -61,9 +61,10 @@ class Cookie final {
   std::string SameSite() const;
   Cookie& SetSameSite(std::string value);
 
-   USERVER_NAMESPACE::http::headers::HeadersString ToString() const;
+  USERVER_NAMESPACE::http::headers::HeadersString ToString() const;
 
-  void AppendToString(USERVER_NAMESPACE::http::headers::HeadersString& os) const;
+  void AppendToString(
+      USERVER_NAMESPACE::http::headers::HeadersString& os) const;
 
  private:
   class CookieData;

--- a/core/include/userver/server/http/http_response_cookie.hpp
+++ b/core/include/userver/server/http/http_response_cookie.hpp
@@ -61,8 +61,7 @@ class Cookie final {
   std::string SameSite() const;
   Cookie& SetSameSite(std::string value);
 
-  USERVER_NAMESPACE::http::headers::HeadersString ToSmallString() const;
-  std::string ToString() const;
+   USERVER_NAMESPACE::http::headers::HeadersString ToString() const;
 
   void AppendToString(USERVER_NAMESPACE::http::headers::HeadersString& os) const;
 

--- a/core/include/userver/server/http/http_response_cookie.hpp
+++ b/core/include/userver/server/http/http_response_cookie.hpp
@@ -9,8 +9,8 @@
 #include <string>
 #include <unordered_map>
 
-#include <userver/utils/small_string.hpp>
 #include <userver/utils/str_icase.hpp>
+#include <userver/http/predefined_header.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -64,8 +64,7 @@ class Cookie final {
   std::string ToString() const;
 
   void AppendToString(std::string& os) const;
-  template <std::size_t N>
-  void AppendToString(utils::SmallString<N>& os) const;
+  void AppendToString(userver::http::headers::HeadersString& os) const;
 
  private:
   class CookieData;

--- a/core/include/userver/server/http/http_response_cookie.hpp
+++ b/core/include/userver/server/http/http_response_cookie.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <unordered_map>
 
+#include <userver/utils/small_string.hpp>
 #include <userver/utils/str_icase.hpp>
 
 USERVER_NAMESPACE_BEGIN
@@ -63,6 +64,8 @@ class Cookie final {
   std::string ToString() const;
 
   void AppendToString(std::string& os) const;
+  template <std::size_t N>
+  void AppendToString(utils::SmallString<N>& os) const;
 
  private:
   class CookieData;

--- a/core/include/userver/server/http/http_response_cookie.hpp
+++ b/core/include/userver/server/http/http_response_cookie.hpp
@@ -64,7 +64,7 @@ class Cookie final {
   std::string ToString() const;
 
   void AppendToString(std::string& os) const;
-  void AppendToString(userver::http::headers::HeadersString& os) const;
+  void AppendToString(USERVER_NAMESPACE::http::headers::HeadersString& os) const;
 
  private:
   class CookieData;

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -15,6 +15,7 @@
 #include <userver/tracing/span.hpp>
 #include <userver/utils/assert.hpp>
 #include <userver/utils/datetime/wall_coarse_clock.hpp>
+#include <userver/utils/small_string.hpp>
 
 #include <server/http/http_cached_date.hpp>
 

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -90,24 +90,6 @@ namespace server::http {
 
 namespace impl {
 
-void OutputHeader(std::string& header, std::string_view key,
-                  std::string_view val) {
-  const auto old_size = header.size();
-  header.resize(old_size + key.size() + kKeyValueHeaderSeparator.size() +
-                val.size() + kCrlf.size());
-
-  char* append_position = header.data() + old_size;
-  const auto append = [&append_position](std::string_view what) {
-    std::memcpy(append_position, what.data(), what.size());
-    append_position += what.size();
-  };
-
-  append(key);
-  append(kKeyValueHeaderSeparator);
-  append(val);
-  append(kCrlf);
-}
-
 void OutputHeader(USERVER_NAMESPACE::http::headers::HeadersString& header,
                   std::string_view key, std::string_view val) {
   const auto old_size = header.size();

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -286,7 +286,7 @@ void HttpResponse::SendResponse(engine::io::RwBase& socket) {
                 .
                 operator std::string_view()
                 .size() +
-            kKeyValueHeaderSeparator.size() + kCrlf.size(),
+            kKeyValueHeaderSeparator.size(),
         [&](char* data, std::size_t size) {
           data += old_size;
           AppendToCharArray(data, USERVER_NAMESPACE::http::headers::kSetCookie);
@@ -296,9 +296,7 @@ void HttpResponse::SendResponse(engine::io::RwBase& socket) {
 
     cookie.second.AppendToString(header);
 
-    char* append_position = header.data() + header.size() - kCrlf.size();
-
-    AppendToCharArray(append_position, kCrlf);
+    header.append(kCrlf);
   }
 
   std::size_t sent_bytes{};

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -297,9 +297,8 @@ void HttpResponse::SendResponse(engine::io::RwBase& socket) {
 
     header.resize_and_overwrite(
         old_size +
-            USERVER_NAMESPACE::http::headers::kSetCookie
-                .
-                operator std::string_view()
+            static_cast<std::string_view>(
+                USERVER_NAMESPACE::http::headers::kSetCookie)
                 .size() +
             kKeyValueHeaderSeparator.size(),
         [&](char* data, std::size_t size) {
@@ -367,8 +366,8 @@ std::size_t HttpResponse::SetBodyStreamed(
 
   // send HTTP headers
   size_t sent_bytes = socket.WriteAll(header.data(), header.size(), {});
-  header.clear();  // free memory before time-consuming operation
-  header.shrink_to_fit();
+  header.clear();
+  header.shrink_to_fit();  // free memory before time-consuming operation
 
   // Transmit HTTP response body
   std::string body_part;

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -90,8 +90,7 @@ namespace server::http {
 
 namespace impl {
 
-template <std::size_t N>
-void OutputHeader(utils::SmallString<N>& header, std::string_view key,
+void OutputHeader(userver::http::headers::HeadersString& header, std::string_view key,
                   std::string_view val) {
   const auto old_size = header.size();
 
@@ -106,6 +105,12 @@ void OutputHeader(utils::SmallString<N>& header, std::string_view key,
         AppendToCharArray(data, kCrlf);
         return size;
       });
+}
+
+void OutputHeader(std::string& header, std::string_view key, std::string_view val) {
+  userver::http::headers::HeadersString header_small_str;
+  OutputHeader(header_small_str, key, val);
+  header.append(header_small_str);
 }
 
 }  // namespace impl

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -99,16 +99,10 @@ void OutputHeader(utils::SmallString<N>& header, std::string_view key,
       old_size + key.size() + kKeyValueHeaderSeparator.size() + val.size() +
           kCrlf.size(),
       [&](char* data, std::size_t size) {
-        char* append_position = data + old_size;
-        const auto append = [&append_position](std::string_view what) {
-          std::memcpy(append_position, what.data(), what.size());
-          append_position += what.size();
-        };
-
-        append(key);
-        append(kKeyValueHeaderSeparator);
-        append(val);
-        append(kCrlf);
+        AppendToCharArray(data, key);
+        AppendToCharArray(data, kKeyValueHeaderSeparator);
+        AppendToCharArray(data, val);
+        AppendToCharArray(data, kCrlf);
         return size;
       });
 }

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -90,8 +90,8 @@ namespace server::http {
 
 namespace impl {
 
-void OutputHeader(userver::http::headers::HeadersString& header, std::string_view key,
-                  std::string_view val) {
+void OutputHeader(USERVER_NAMESPACE::http::headers::HeadersString& header,
+                  std::string_view key, std::string_view val) {
   const auto old_size = header.size();
 
   header.resize_and_overwrite(
@@ -105,12 +105,6 @@ void OutputHeader(userver::http::headers::HeadersString& header, std::string_vie
         AppendToCharArray(data, kCrlf);
         return size;
       });
-}
-
-void OutputHeader(std::string& header, std::string_view key, std::string_view val) {
-  userver::http::headers::HeadersString header_small_str;
-  OutputHeader(header_small_str, key, val);
-  header.append(header_small_str);
 }
 
 }  // namespace impl
@@ -248,7 +242,8 @@ void HttpResponse::SetHeadersEnd() { headers_end_.Send(); }
 bool HttpResponse::WaitForHeadersEnd() { return headers_end_.WaitForEvent(); }
 
 void HttpResponse::SendResponse(engine::io::RwBase& socket) {
-  utils::SmallString<userver::http::headers::kTypicalHeadersSize> header;
+  utils::SmallString<USERVER_NAMESPACE::http::headers::kTypicalHeadersSize>
+      header;
 
   const std::string_view http_string = "HTTP/";
   const std::string protocol_and_status =
@@ -318,8 +313,9 @@ void HttpResponse::SendResponse(engine::io::RwBase& socket) {
   SetSent(sent_bytes, std::chrono::steady_clock::now());
 }
 
-std::size_t HttpResponse::SetBodyNotStreamed(engine::io::RwBase& socket,
-                                             userver::http::headers::HeadersString& header) {
+std::size_t HttpResponse::SetBodyNotStreamed(
+    engine::io::RwBase& socket,
+    USERVER_NAMESPACE::http::headers::HeadersString& header) {
   const bool is_body_forbidden = IsBodyForbiddenForStatus(status_);
   const bool is_head_request = request_.GetMethod() == HttpMethod::kHead;
   const auto& data = GetData();
@@ -356,8 +352,9 @@ std::size_t HttpResponse::SetBodyNotStreamed(engine::io::RwBase& socket,
   return sent_bytes;
 }
 
-std::size_t HttpResponse::SetBodyStreamed(engine::io::RwBase& socket,
-                                          userver::http::headers::HeadersString& header) {
+std::size_t HttpResponse::SetBodyStreamed(
+    engine::io::RwBase& socket,
+    USERVER_NAMESPACE::http::headers::HeadersString& header) {
   impl::OutputHeader(
       header, USERVER_NAMESPACE::http::headers::kTransferEncoding, "chunked");
 

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -90,7 +90,8 @@ namespace server::http {
 
 namespace impl {
 
-void OutputHeader(std::string& header, std::string_view key, std::string_view val) {
+void OutputHeader(std::string& header, std::string_view key,
+                  std::string_view val) {
   const auto old_size = header.size();
   header.resize(old_size + key.size() + kKeyValueHeaderSeparator.size() +
                 val.size() + kCrlf.size());

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -90,6 +90,23 @@ namespace server::http {
 
 namespace impl {
 
+void OutputHeader(std::string& header, std::string_view key, std::string_view val) {
+  const auto old_size = header.size();
+  header.resize(old_size + key.size() + kKeyValueHeaderSeparator.size() +
+                val.size() + kCrlf.size());
+
+  char* append_position = header.data() + old_size;
+  const auto append = [&append_position](std::string_view what) {
+    std::memcpy(append_position, what.data(), what.size());
+    append_position += what.size();
+  };
+
+  append(key);
+  append(kKeyValueHeaderSeparator);
+  append(val);
+  append(kCrlf);
+}
+
 void OutputHeader(USERVER_NAMESPACE::http::headers::HeadersString& header,
                   std::string_view key, std::string_view val) {
   const auto old_size = header.size();

--- a/core/src/server/http/http_response_benchmark.cpp
+++ b/core/src/server/http/http_response_benchmark.cpp
@@ -6,6 +6,7 @@
 #include <userver/http/common_headers.hpp>
 #include <userver/server/http/http_response.hpp>
 #include <userver/server/http/http_status.hpp>
+#include <userver/utils/small_string.hpp>
 
 USERVER_NAMESPACE_BEGIN
 

--- a/core/src/server/http/http_response_cookie.cpp
+++ b/core/src/server/http/http_response_cookie.cpp
@@ -442,10 +442,10 @@ Cookie& Cookie::SetSameSite(std::string value) {
   return *this;
 }
 
-USERVER_NAMESPACE::http::headers::HeadersString Cookie::ToString() const {
+std::string Cookie::ToString() const {
   USERVER_NAMESPACE::http::headers::HeadersString os;
   data_->AppendToString(os);
-  return os;
+  return std::string(os);
 }
 
 void Cookie::AppendToString(

--- a/core/src/server/http/http_response_cookie.cpp
+++ b/core/src/server/http/http_response_cookie.cpp
@@ -451,6 +451,19 @@ void Cookie::AppendToString(std::string& os) const {
   data_->AppendToString(os);
 }
 
+template <std::size_t N>
+void Cookie::AppendToString(utils::SmallString<N>& os) const {
+  std::string data_to_append;
+  data_->AppendToString(data_to_append);
+  std::size_t old_size = os.size();
+  os.resize_and_overwrite(
+      old_size + data_to_append.size(), [&](char* data, std::size_t size) {
+        std::memcpy(data + old_size, std::move(data_to_append.data()),
+                    data_to_append.size());
+        return size;
+      });
+}
+
 }  // namespace server::http
 
 USERVER_NAMESPACE_END

--- a/core/src/server/http/http_response_cookie.cpp
+++ b/core/src/server/http/http_response_cookie.cpp
@@ -10,6 +10,7 @@
 #include <userver/logging/log.hpp>
 #include <userver/utils/datetime.hpp>
 #include <userver/utils/trivial_map.hpp>
+#include <userver/utils/small_string.hpp>
 
 USERVER_NAMESPACE_BEGIN
 

--- a/core/src/server/http/http_response_cookie.cpp
+++ b/core/src/server/http/http_response_cookie.cpp
@@ -445,7 +445,7 @@ Cookie& Cookie::SetSameSite(std::string value) {
 USERVER_NAMESPACE::http::headers::HeadersString Cookie::ToString() const {
   USERVER_NAMESPACE::http::headers::HeadersString os;
   data_->AppendToString(os);
-  return USERVER_NAMESPACE::http::headers::HeadersString(os);
+  return os;
 }
 
 void Cookie::AppendToString(

--- a/core/src/server/http/http_response_cookie.cpp
+++ b/core/src/server/http/http_response_cookie.cpp
@@ -442,18 +442,10 @@ Cookie& Cookie::SetSameSite(std::string value) {
   return *this;
 }
 
-USERVER_NAMESPACE::http::headers::HeadersString Cookie::ToSmallString() const {
+USERVER_NAMESPACE::http::headers::HeadersString Cookie::ToString() const {
   USERVER_NAMESPACE::http::headers::HeadersString os;
   data_->AppendToString(os);
   return USERVER_NAMESPACE::http::headers::HeadersString(os);
-}
-
-std::string Cookie::ToString() const {
-  USERVER_NAMESPACE::http::headers::HeadersString small_os;
-  std::string os;
-  data_->AppendToString(small_os);
-  os.append(small_os);
-  return os;
 }
 
 void Cookie::AppendToString(

--- a/core/src/server/http/http_response_cookie.cpp
+++ b/core/src/server/http/http_response_cookie.cpp
@@ -456,12 +456,6 @@ std::string Cookie::ToString() const {
   return os;
 }
 
-void Cookie::AppendToString(std::string& os) const {
-  USERVER_NAMESPACE::http::headers::HeadersString small_os;
-  data_->AppendToString(small_os);
-  os.append(small_os);
-}
-
 void Cookie::AppendToString(
     USERVER_NAMESPACE::http::headers::HeadersString& os) const {
   data_->AppendToString(os);

--- a/core/src/server/http/http_response_cookie.cpp
+++ b/core/src/server/http/http_response_cookie.cpp
@@ -451,7 +451,8 @@ void Cookie::AppendToString(std::string& os) const {
   data_->AppendToString(os);
 }
 
-void Cookie::AppendToString(userver::http::headers::HeadersString& os) const {
+void Cookie::AppendToString(
+    USERVER_NAMESPACE::http::headers::HeadersString& os) const {
   std::string data_to_append;
   data_->AppendToString(data_to_append);
   std::size_t old_size = os.size();

--- a/core/src/server/http/http_response_cookie.cpp
+++ b/core/src/server/http/http_response_cookie.cpp
@@ -451,8 +451,7 @@ void Cookie::AppendToString(std::string& os) const {
   data_->AppendToString(os);
 }
 
-template <std::size_t N>
-void Cookie::AppendToString(utils::SmallString<N>& os) const {
+void Cookie::AppendToString(userver::http::headers::HeadersString& os) const {
   std::string data_to_append;
   data_->AppendToString(data_to_append);
   std::size_t old_size = os.size();

--- a/universal/include/userver/http/header_map.hpp
+++ b/universal/include/userver/http/header_map.hpp
@@ -9,6 +9,7 @@
 #include <userver/formats/parse/to.hpp>
 #include <userver/http/predefined_header.hpp>
 #include <userver/utils/fast_pimpl.hpp>
+#include <userver/utils/small_string.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -258,7 +259,8 @@ class HeaderMap final {
   /// ...
   /// @endcode
   /// resizing buffer as needed.
-  void OutputInHttpFormat(std::string& buffer) const;
+  template<std::size_t N>
+  void OutputInHttpFormat(utils::SmallString<N>& buffer) const;
 
  private:
   friend class TestsHelper;

--- a/universal/include/userver/http/header_map.hpp
+++ b/universal/include/userver/http/header_map.hpp
@@ -9,7 +9,6 @@
 #include <userver/formats/parse/to.hpp>
 #include <userver/http/predefined_header.hpp>
 #include <userver/utils/fast_pimpl.hpp>
-#include <userver/utils/small_string.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -259,8 +258,7 @@ class HeaderMap final {
   /// ...
   /// @endcode
   /// resizing buffer as needed.
-  template<std::size_t N>
-  void OutputInHttpFormat(utils::SmallString<N>& buffer) const;
+  void OutputInHttpFormat(HeadersString& buffer) const;
 
  private:
   friend class TestsHelper;

--- a/universal/include/userver/http/predefined_header.hpp
+++ b/universal/include/userver/http/predefined_header.hpp
@@ -14,8 +14,7 @@ namespace http::headers {
 
 // According to https://www.chromium.org/spdy/spdy-whitepaper/
 // "typical header sizes of 700-800 bytes is common"
-// Adjusting it to 1KiB to fit jemalloc size class
-static constexpr std::size_t kTypicalHeadersSize = 1024;
+inline constexpr std::size_t kTypicalHeadersSize = 1024;
 using HeadersString = utils::SmallString<kTypicalHeadersSize>;
 
 namespace impl {

--- a/universal/include/userver/http/predefined_header.hpp
+++ b/universal/include/userver/http/predefined_header.hpp
@@ -6,7 +6,7 @@
 #include <fmt/core.h>
 
 #include <userver/utils/trivial_map.hpp>
-#include <userver/utils/small_string.hpp>
+#include <userver/utils/small_string_fwd.hpp>
 
 USERVER_NAMESPACE_BEGIN
 

--- a/universal/include/userver/http/predefined_header.hpp
+++ b/universal/include/userver/http/predefined_header.hpp
@@ -6,10 +6,17 @@
 #include <fmt/core.h>
 
 #include <userver/utils/trivial_map.hpp>
+#include <userver/utils/small_string.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
 namespace http::headers {
+
+// According to https://www.chromium.org/spdy/spdy-whitepaper/
+// "typical header sizes of 700-800 bytes is common"
+// Adjusting it to 1KiB to fit jemalloc size class
+static constexpr std::size_t kTypicalHeadersSize = 1024;
+using HeadersString = utils::SmallString<kTypicalHeadersSize>;
 
 namespace impl {
 

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -257,11 +257,9 @@ void SmallString<N>::push_back(char c) {
 
 template <std::size_t N>
 void SmallString<N>::append(std::string_view str) {
-  const std::size_t old_size = data_.size();
-  resize_and_overwrite(old_size + str.size(), [&](char* data, std::size_t size) {
-    std::memcpy(data + old_size, str.begin(), str.size());
-    return size;
-  });
+  std::size_t old_size = data_.size();
+  data_.resize(old_size + str.size(), boost::container::default_init);
+  std::memcpy(data_.data() + old_size, str.data(), str.size());
 }
 
 template <std::size_t N>

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -10,6 +10,8 @@
 
 #include <boost/container/small_vector.hpp>
 
+#include <userver/utils/assert.hpp>
+
 USERVER_NAMESPACE_BEGIN
 
 namespace utils {
@@ -262,6 +264,7 @@ template <class Operation>
 void SmallString<N>::resize_and_overwrite(std::size_t size, Operation op) {
   data_.resize(size, boost::container::default_init);
   data_.resize(std::move(op)(data_.data(), size), boost::container::default_init);
+  UASSERT(data_.size() <= size);
 }
 
 template <std::size_t N>

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -285,6 +285,11 @@ void SmallString<N>::reserve(std::size_t n) {
   return data_.reserve(n);
 }
 
+template <std::size_t N>
+void SmallString<N>::clear() noexcept {
+  data_.clear();
+}
+
 }  // namespace utils
 
 USERVER_NAMESPACE_END

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -31,7 +31,7 @@ class SmallString final {
   SmallString() = default;
 
   /// @brief Create a string from another one.
-  explicit SmallString(const SmallString<N>&) = default;
+  SmallString(const SmallString<N>&) = default;
 
   /// @brief Create a string from another one.
   explicit SmallString(SmallString<N>&&) noexcept = default;

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -258,7 +258,7 @@ void SmallString<N>::push_back(char c) {
 template <std::size_t N>
 void SmallString<N>::append(std::string_view str) {
   const std::size_t old_size = data_.size();
-  resize_and_overwrite(data_.size() + str.size(), [&](char* data, std::size_t size) {
+  resize_and_overwrite(old_size + str.size(), [&](char* data, std::size_t size) {
     std::memcpy(data + old_size, str.begin(), str.size());
     return size;
   });

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -123,6 +123,9 @@ class SmallString final {
   /// @brief Append a character to the string.
   void push_back(char c);
 
+  /// @brief Append contents of a string_view to the string.
+  void append(std::string_view str);
+
   /// @brief Remove the last character from the string.
   void pop_back();
 
@@ -250,6 +253,15 @@ const char& SmallString<N>::back() const {
 template <std::size_t N>
 void SmallString<N>::push_back(char c) {
   data_.push_back(c);
+}
+
+template <std::size_t N>
+void SmallString<N>::append(std::string_view str) {
+  const std::size_t old_size = data_.size();
+  resize_and_overwrite(data_.size() + str.size(), [&](char* data, std::size_t size) {
+    std::memcpy(data + old_size, str.begin(), str.size());
+    return size;
+  });
 }
 
 template <std::size_t N>

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -93,6 +93,9 @@ class SmallString final {
   template <class Operation>
   void resize_and_overwrite(std::size_t size, Operation op);
 
+  /// @brief Shrink the string's size to fit all contents
+  void shrink_to_fit();
+
   /// @brief Get current capacity.
   std::size_t capacity() const noexcept;
 
@@ -265,6 +268,11 @@ void SmallString<N>::resize_and_overwrite(std::size_t size, Operation op) {
   data_.resize(size, boost::container::default_init);
   data_.resize(std::move(op)(data_.data(), size), boost::container::default_init);
   UASSERT(data_.size() <= size);
+}
+
+template <std::size_t N>
+void SmallString<N>::shrink_to_fit() {
+  data_.shrink_to_fit();
 }
 
 template <std::size_t N>

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -258,8 +258,7 @@ void SmallString<N>::push_back(char c) {
 template <std::size_t N>
 void SmallString<N>::append(std::string_view str) {
   std::size_t old_size = data_.size();
-  data_.resize(old_size + str.size(), boost::container::default_init);
-  std::memcpy(data_.data() + old_size, str.data(), str.size());
+  data_.insert(data_.begin() + old_size, str.begin(), str.end());
 }
 
 template <std::size_t N>

--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -261,7 +261,7 @@ template <std::size_t N>
 template <class Operation>
 void SmallString<N>::resize_and_overwrite(std::size_t size, Operation op) {
   data_.resize(size, boost::container::default_init);
-  data_.resize(std::move(op)(data_.data(), size));
+  data_.resize(std::move(op)(data_.data(), size), boost::container::default_init);
 }
 
 template <std::size_t N>

--- a/universal/include/userver/utils/small_string_fwd.hpp
+++ b/universal/include/userver/utils/small_string_fwd.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace utils {
+  // Forward declaration
+  template <std::size_t N>
+  class SmallString;
+}
+
+USERVER_NAMESPACE_END

--- a/universal/src/http/header_map.cpp
+++ b/universal/src/http/header_map.cpp
@@ -234,8 +234,7 @@ bool HeaderMap::operator==(const HeaderMap& other) const noexcept {
   return *impl_ == *other.impl_;
 }
 
-template <std::size_t N>
-void HeaderMap::OutputInHttpFormat(utils::SmallString<N>& buffer) const {
+void HeaderMap::OutputInHttpFormat(HeadersString& buffer) const {
   impl_->OutputInHttpFormat(buffer);
 }
 

--- a/universal/src/http/header_map.cpp
+++ b/universal/src/http/header_map.cpp
@@ -134,8 +134,8 @@ HeaderMap::Iterator HeaderMap::find(const PredefinedHeader& key) noexcept {
   return HeaderMap::Iterator{impl_->Find(key)};
 }
 
-HeaderMap::ConstIterator HeaderMap::find(const PredefinedHeader& key) const
-    noexcept {
+HeaderMap::ConstIterator HeaderMap::find(
+    const PredefinedHeader& key) const noexcept {
   return HeaderMap::ConstIterator{impl_->Find(key)};
 }
 
@@ -234,7 +234,8 @@ bool HeaderMap::operator==(const HeaderMap& other) const noexcept {
   return *impl_ == *other.impl_;
 }
 
-void HeaderMap::OutputInHttpFormat(std::string& buffer) const {
+template <std::size_t N>
+void HeaderMap::OutputInHttpFormat(utils::SmallString<N>& buffer) const {
   impl_->OutputInHttpFormat(buffer);
 }
 

--- a/universal/src/http/header_map/map.cpp
+++ b/universal/src/http/header_map/map.cpp
@@ -1,4 +1,5 @@
 #include <http/header_map/map.hpp>
+#include <userver/utils/small_string.hpp>
 
 // Inspired by
 // https://github.com/hyperium/http/blob/f0ba97fe20054d6ef83834f92a0842be947996bd/src/header/map.rs

--- a/universal/src/http/header_map/map.cpp
+++ b/universal/src/http/header_map/map.cpp
@@ -683,8 +683,7 @@ bool Map::operator==(const Map& other) const noexcept {
   return true;
 }
 
-template <std::size_t N>
-void Map::OutputInHttpFormat(utils::SmallString<N>& buffer) const {
+void Map::OutputInHttpFormat(HeadersString& buffer) const {
   static constexpr std::string_view kCrlf = "\r\n";
   static constexpr std::string_view kKeyValueHeaderSeparator = ": ";
 

--- a/universal/src/http/header_map/map.hpp
+++ b/universal/src/http/header_map/map.hpp
@@ -6,6 +6,7 @@
 
 #include <userver/http/header_map.hpp>
 #include <userver/http/predefined_header.hpp>
+#include <userver/utils/small_string.hpp>
 #include <userver/utils/str_icase.hpp>
 
 #include <http/header_map/danger.hpp>
@@ -94,7 +95,8 @@ class Map final {
 
   bool operator==(const Map& other) const noexcept;
 
-  void OutputInHttpFormat(std::string& buffer) const;
+  template <std::size_t N>
+  void OutputInHttpFormat(utils::SmallString<N>& buffer) const;
 
  private:
   friend class http::headers::TestsHelper;

--- a/universal/src/http/header_map/map.hpp
+++ b/universal/src/http/header_map/map.hpp
@@ -6,7 +6,6 @@
 
 #include <userver/http/header_map.hpp>
 #include <userver/http/predefined_header.hpp>
-#include <userver/utils/small_string.hpp>
 #include <userver/utils/str_icase.hpp>
 
 #include <http/header_map/danger.hpp>
@@ -95,8 +94,7 @@ class Map final {
 
   bool operator==(const Map& other) const noexcept;
 
-  template <std::size_t N>
-  void OutputInHttpFormat(utils::SmallString<N>& buffer) const;
+  void OutputInHttpFormat(HeadersString& buffer) const;
 
  private:
   friend class http::headers::TestsHelper;

--- a/universal/src/utils/small_string_benchmark.cpp
+++ b/universal/src/utils/small_string_benchmark.cpp
@@ -141,4 +141,22 @@ BENCHMARK(SmallStringResizeThenOverwrite)
     ->Range(2, 2 << 10)
     ->Unit(benchmark::kMicrosecond);
 
+static void SmallStringAppend(benchmark::State& state) {
+  auto s = GenerateString(state.range(0));
+  std::array<utils::SmallString<1000>, kArraySize> str;
+  std::array<utils::SmallString<1>, kArraySize> str2;
+  for (auto& x : str) x = s;
+  for ([[maybe_unused]] auto _ : state) {
+    for (size_t i = 0; i < str.size(); i++) {
+      str2[i].append(str[i]);
+    }
+    state.PauseTiming();
+    str2.fill({});
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(SmallStringAppend)
+    ->Range(2, 2 << 10)
+    ->Unit(benchmark::kMicrosecond);
+
 USERVER_NAMESPACE_END

--- a/universal/src/utils/small_string_test.cpp
+++ b/universal/src/utils/small_string_test.cpp
@@ -100,6 +100,14 @@ TEST(SmallString, ResizeAndOverwriteRvalueCall) {
   small_str.resize_and_overwrite(16, CheckRvalueCall());
 }
 
+TEST(SmallString, InvalidOpReturnValue) {
+  utils::SmallString<4> small_str("abcd");
+  ASSERT_DEBUG_DEATH(small_str.resize_and_overwrite(
+      16, [&]([[maybe_unused]] char* data, [[maybe_unused]] std::size_t size) {
+        return 20;
+      }), "");
+}
+
 TEST(SmallString, Assign) {
   utils::SmallString<10> str("abcd");
   utils::SmallString<10> str2;

--- a/universal/src/utils/small_string_test.cpp
+++ b/universal/src/utils/small_string_test.cpp
@@ -58,6 +58,17 @@ TEST(SmallString, PushBack) {
   EXPECT_EQ(str, "a");
 }
 
+TEST(SmallString, Append) {
+  utils::SmallString<2> str("a");
+
+  str.append("b");
+  EXPECT_EQ(str, "ab");
+  str.append("cd");
+  EXPECT_EQ(str, "abcd");
+  str.append(str);
+  EXPECT_EQ(str, "abcdabcd");
+}
+
 TEST(SmallString, SizeCapacity) {
   utils::SmallString<10> str("abcd");
   str.resize(3, '1');


### PR DESCRIPTION
Оптимизация HttpResponse::SendResponse с помощью замены std::string header на userver::utils::SmallString (#407)
```
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
http_headers_serialization_inplace           72.5 ns         72.4 ns      9808811
http_headers_serialization_no_ostreams        264 ns          264 ns      2481104
http_headers_serialization_ostreams           755 ns          755 ns       923180

```