### PR TITLE
fix: add missing check for mongodb

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -145,7 +145,7 @@ class UserverConan(ConanFile):
             )
 
     def validate(self):
-        if self.dependencies['mongo-c-driver'].options.with_sasl != 'cyrus':
+        if self.options.with_mongodb and self.dependencies['mongo-c-driver'].options.with_sasl != 'cyrus':
             raise errors.ConanInvalidConfiguration(
                 f'{self.ref} requires mongo-c-driver with_sasl cyrus',
             )


### PR DESCRIPTION
There was an error when I created userver package:
```bash
conan create \
    . \
    --build=missing \
    -pr:b=default \
    -s build_type=Release \
    -o userver:shared=False \
    -o userver:fPIC=True \
    -o userver:lto=True \
    -o userver:with_jemalloc=True \
    -o userver:with_mongodb=False \
    -o userver:with_postgresql=False \
    -o userver:with_postgresql_extra=False \
    -o userver:with_redis=False \
    -o userver:with_grpc=True \
    -o userver:with_clickhouse=False \
    -o userver:with_rabbitmq=False \
    -o userver:with_utest=True
```

```
ERROR: userver/1.0.0: Error in validate() method, line 148
	if self.dependencies['mongo-c-driver'].options.with_sasl != 'cyrus':
	KeyError: {'ref': mongo-c-driver/unknown@unknown/unknown, 'build': False, 'direct': True, 'test': False, 'visible': True}
```

The package builds successfully with this patch:
```
userver/1.0.0: Package 'f3b5a9314d5c7fe7ae4a85e24462b1f400f83d8d' created
userver/1.0.0: Created package revision db3d8d666ab7f36e737ac91b7746dccd
```

I guess it came from [!387](https://github.com/userver-framework/userver/pull/387)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/