### PR TITLE
Optimize Http::Cookie::ToString()

### DIFF
--- a/core/src/server/http/http_response_cookie.cpp
+++ b/core/src/server/http/http_response_cookie.cpp
@@ -289,9 +289,9 @@ void Cookie::CookieData::AppendToString(
   constexpr std::string_view kSameSite = "; SameSite=";
   constexpr std::string_view kHttpOnly = "; HttpOnly";
 
-  const std::size_t kOldSize = os.size();
+  const std::size_t old_size = os.size();
 
-  std::size_t new_size = kOldSize + name_.size() + value_.size() +
+  std::size_t new_size = old_size + name_.size() + value_.size() +
                          domain_.size() + path_.size() + same_site_.size() +
                          kEquals.size() + kDomain.size() + kPath.size() +
                          kExpires.size() + kMaxAge.size() + kSecure.size() +
@@ -310,7 +310,7 @@ void Cookie::CookieData::AppendToString(
 
   os.resize_and_overwrite(new_size, [&](char* data, std::size_t) {
     char* old_data_pointer = data;
-    data += kOldSize;
+    data += old_size;
     auto append = [&data](const std::string_view what) {
       std::memcpy(data, what.begin(), what.size());
       data += what.size();

--- a/core/src/server/http/http_response_cookie_benchmark.cpp
+++ b/core/src/server/http/http_response_cookie_benchmark.cpp
@@ -1,120 +1,21 @@
 #include <benchmark/benchmark.h>
 
-#include <fmt/compile.h>
-
-#include <userver/http/common_headers.hpp>
 #include <userver/server/http/http_response.hpp>
 #include <userver/server/http/http_status.hpp>
-#include <userver/utils/datetime.hpp>
 #include <userver/utils/small_string.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
-namespace {
-
-const std::string kTimeFormat = "%a, %d %b %Y %H:%M:%S %Z";
-
-std::string name_ = "name1";
-std::string value_ = "value1";
-std::string path_ = "path1";
-std::string domain_ = "domain1";
-std::string same_site_ = "same_site1";
-
-bool secure_{true};
-bool http_only_{true};
-std::optional<std::chrono::system_clock::time_point> expires_{
-    std::chrono::seconds{1560358305}};
-std::optional<std::chrono::seconds> max_age_{std::chrono::seconds{3600}};
-
-const int kArraySize = 1000;
-}  // namespace
-
-void http_cookie_serialization_resize_and_overwrite(benchmark::State& state) {
+void http_cookie_serialization(benchmark::State& state) {
+  auto cookie = server::http::Cookie::FromString("name1=value1; Domain=domain.com; Path=/; Expires=Wed, 12 Jun 2019 "
+                                    "16:51:45 GMT; Max-Age=3600; Secure; SameSite=None; HttpOnly");
   USERVER_NAMESPACE::http::headers::HeadersString os;
   for ([[maybe_unused]] auto _ : state) {
+    cookie.value().AppendToString(os);
     os.clear();
-    os.resize_and_overwrite(
-        USERVER_NAMESPACE::http::headers::kTypicalHeadersSize,
-        [](char* data, std::size_t) {
-          auto append = [&data](const std::string_view what) {
-            std::memcpy(data, what.begin(), what.size());
-            data += what.size();
-          };
-          char* old_data_pointer = data;
-          append(name_);
-          append("=");
-          append(value_);
-          if (!domain_.empty()) {
-            append("; Domain=");
-            append(domain_);
-          }
-          if (!path_.empty()) {
-            append("; Path=");
-            append(path_);
-          }
-          if (expires_.has_value()) {
-            append("; Expires=");
-            append(utils::datetime::Timestring(expires_.value(), "GMT",
-                                               kTimeFormat));
-          }
-          if (max_age_.has_value()) {
-            append("; Max-Age=");
-            append(fmt::format(FMT_COMPILE("{}"), max_age_.value().count()));
-          }
-          if (secure_) {
-            append("; Secure");
-          }
-          if (!same_site_.empty()) {
-            append("; SameSite=");
-            append(same_site_);
-          }
-          if (http_only_) {
-            append("; HttpOnly");
-          }
-          return data - old_data_pointer;
-        });
   }
 }
 
-void http_cookie_serialization_append(benchmark::State& state) {
-  USERVER_NAMESPACE::http::headers::HeadersString os;
-  for ([[maybe_unused]] auto _ : state) {
-    os.clear();
-    os.append(name_);
-    os.append("=");
-    os.append(value_);
-
-    if (!domain_.empty()) {
-      os.append("; Domain=");
-      os.append(domain_);
-    }
-    if (!path_.empty()) {
-      os.append("; Path=");
-      os.append(path_);
-    }
-    if (expires_.has_value()) {
-      os.append("; Expires=");
-      os.append(
-          utils::datetime::Timestring(expires_.value(), "GMT", kTimeFormat));
-    }
-    if (max_age_.has_value()) {
-      os.append("; Max-Age=");
-      os.append(fmt::format(FMT_COMPILE("{}"), max_age_.value().count()));
-    }
-    if (secure_) {
-      os.append("; Secure");
-    }
-    if (!same_site_.empty()) {
-      os.append("; SameSite=");
-      os.append(same_site_);
-    }
-    if (http_only_) {
-      os.append("; HttpOnly");
-    }
-  }
-}
-
-BENCHMARK(http_cookie_serialization_append);
-BENCHMARK(http_cookie_serialization_resize_and_overwrite);
+BENCHMARK(http_cookie_serialization);
 
 USERVER_NAMESPACE_END

--- a/core/src/server/http/http_response_cookie_benchmark.cpp
+++ b/core/src/server/http/http_response_cookie_benchmark.cpp
@@ -1,0 +1,120 @@
+#include <benchmark/benchmark.h>
+
+#include <fmt/compile.h>
+
+#include <userver/http/common_headers.hpp>
+#include <userver/server/http/http_response.hpp>
+#include <userver/server/http/http_status.hpp>
+#include <userver/utils/datetime.hpp>
+#include <userver/utils/small_string.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace {
+
+const std::string kTimeFormat = "%a, %d %b %Y %H:%M:%S %Z";
+
+std::string name_ = "name1";
+std::string value_ = "value1";
+std::string path_ = "path1";
+std::string domain_ = "domain1";
+std::string same_site_ = "same_site1";
+
+bool secure_{true};
+bool http_only_{true};
+std::optional<std::chrono::system_clock::time_point> expires_{
+    std::chrono::seconds{1560358305}};
+std::optional<std::chrono::seconds> max_age_{std::chrono::seconds{3600}};
+
+const int kArraySize = 1000;
+}  // namespace
+
+void http_cookie_serialization_resize_and_overwrite(benchmark::State& state) {
+  USERVER_NAMESPACE::http::headers::HeadersString os;
+  for ([[maybe_unused]] auto _ : state) {
+    os.clear();
+    os.resize_and_overwrite(
+        USERVER_NAMESPACE::http::headers::kTypicalHeadersSize,
+        [](char* data, std::size_t) {
+          auto append = [&data](const std::string_view what) {
+            std::memcpy(data, what.begin(), what.size());
+            data += what.size();
+          };
+          char* old_data_pointer = data;
+          append(name_);
+          append("=");
+          append(value_);
+          if (!domain_.empty()) {
+            append("; Domain=");
+            append(domain_);
+          }
+          if (!path_.empty()) {
+            append("; Path=");
+            append(path_);
+          }
+          if (expires_.has_value()) {
+            append("; Expires=");
+            append(utils::datetime::Timestring(expires_.value(), "GMT",
+                                               kTimeFormat));
+          }
+          if (max_age_.has_value()) {
+            append("; Max-Age=");
+            append(fmt::format(FMT_COMPILE("{}"), max_age_.value().count()));
+          }
+          if (secure_) {
+            append("; Secure");
+          }
+          if (!same_site_.empty()) {
+            append("; SameSite=");
+            append(same_site_);
+          }
+          if (http_only_) {
+            append("; HttpOnly");
+          }
+          return data - old_data_pointer;
+        });
+  }
+}
+
+void http_cookie_serialization_append(benchmark::State& state) {
+  USERVER_NAMESPACE::http::headers::HeadersString os;
+  for ([[maybe_unused]] auto _ : state) {
+    os.clear();
+    os.append(name_);
+    os.append("=");
+    os.append(value_);
+
+    if (!domain_.empty()) {
+      os.append("; Domain=");
+      os.append(domain_);
+    }
+    if (!path_.empty()) {
+      os.append("; Path=");
+      os.append(path_);
+    }
+    if (expires_.has_value()) {
+      os.append("; Expires=");
+      os.append(
+          utils::datetime::Timestring(expires_.value(), "GMT", kTimeFormat));
+    }
+    if (max_age_.has_value()) {
+      os.append("; Max-Age=");
+      os.append(fmt::format(FMT_COMPILE("{}"), max_age_.value().count()));
+    }
+    if (secure_) {
+      os.append("; Secure");
+    }
+    if (!same_site_.empty()) {
+      os.append("; SameSite=");
+      os.append(same_site_);
+    }
+    if (http_only_) {
+      os.append("; HttpOnly");
+    }
+  }
+}
+
+BENCHMARK(http_cookie_serialization_append);
+BENCHMARK(http_cookie_serialization_resize_and_overwrite);
+
+USERVER_NAMESPACE_END

--- a/core/src/server/http/http_response_cookie_test.cpp
+++ b/core/src/server/http/http_response_cookie_test.cpp
@@ -3,6 +3,7 @@
 #include <sys/param.h>
 
 #include <userver/server/http/http_response_cookie.hpp>
+#include <userver/utils/small_string.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -187,6 +188,24 @@ TEST(HttpCookie, FromString) {
     auto cookie = server::http::Cookie::FromString(cookie_as_str);
     EXPECT_FALSE(equal(cookie.value().ToString(), cookie_as_str));
   }
+}
+
+TEST(HttpCookie, AppendToString) {
+  auto cookie = server::http::Cookie::FromString(
+      "name1=value1; Domain=domain.com; Path=/; Expires=Wed, 12 Jun 2019 "
+      "16:51:45 GMT; Max-Age=3600; Secure; SameSite=None; HttpOnly");
+  utils::SmallString<http::headers::kTypicalHeadersSize> str{
+      "*Previous string content *"};
+  cookie->AppendToString(str);
+  EXPECT_EQ(str,
+            "*Previous string content *name1=value1; Domain=domain.com; "
+            "Path=/; Expires=Wed, 12 Jun 2019 "
+            "16:51:45 GMT; Max-Age=3600; Secure; SameSite=None; HttpOnly");
+  str.clear();
+  cookie->AppendToString(str);
+  EXPECT_EQ(str,
+            "name1=value1; Domain=domain.com; Path=/; Expires=Wed, 12 Jun 2019 "
+            "16:51:45 GMT; Max-Age=3600; Secure; SameSite=None; HttpOnly");
 }
 
 USERVER_NAMESPACE_END

--- a/core/src/server/http/http_response_cookie_test.cpp
+++ b/core/src/server/http/http_response_cookie_test.cpp
@@ -206,6 +206,17 @@ TEST(HttpCookie, AppendToString) {
   EXPECT_EQ(str,
             "name1=value1; Domain=domain.com; Path=/; Expires=Wed, 12 Jun 2019 "
             "16:51:45 GMT; Max-Age=3600; Secure; SameSite=None; HttpOnly");
+  str.clear();
+  const std::string large_name(2048, 'a');
+  cookie = server::http::Cookie::FromString(
+      "name1=" + large_name +
+      "; Domain=domain.com; Path=/; Expires=Wed, 12 Jun 2019 "
+      "16:51:45 GMT; Max-Age=3600; Secure; SameSite=None; HttpOnly");
+  cookie->AppendToString(str);
+  EXPECT_EQ(str,
+            "name1=" + large_name +
+                "; Domain=domain.com; Path=/; Expires=Wed, 12 Jun 2019 "
+                "16:51:45 GMT; Max-Age=3600; Secure; SameSite=None; HttpOnly");
 }
 
 USERVER_NAMESPACE_END

--- a/universal/src/utils/small_string_test.cpp
+++ b/universal/src/utils/small_string_test.cpp
@@ -111,6 +111,26 @@ TEST(SmallString, ResizeAndOverwriteRvalueCall) {
   small_str.resize_and_overwrite(16, CheckRvalueCall());
 }
 
+TEST(SmallString, ResizeAndOverwriteDynamicAllocations) {
+  utils::SmallString<4> small_str("abcd");
+
+  small_str.resize_and_overwrite(2000, [](char*, std::size_t size){
+    return size;
+  });
+  small_str.resize_and_overwrite(2001, [](char*, std::size_t size){
+    return size;
+  });
+  EXPECT_GT(small_str.capacity(), 2001);
+  small_str.resize_and_overwrite(2002, [](char*, std::size_t size){
+    return size;
+  });
+  EXPECT_GT(small_str.capacity(), 2002);
+  small_str.resize_and_overwrite(2003, [](char*, std::size_t size){
+    return size;
+  });
+  EXPECT_GT(small_str.capacity(), 2003);
+}
+
 TEST(SmallString, InvalidOpReturnValue) {
   utils::SmallString<4> small_str("abcd");
   ASSERT_DEBUG_DEATH(


### PR DESCRIPTION
Оптимизация отправки cookies с помощью SmallString::resize_and_overwrite().
До:
```
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
http_cookie_serialization        635 ns          635 ns      1320608
```
После:
```
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
http_cookie_serialization        502 ns          502 ns      1374006

```
