### PR TITLE
feat formats: automatic serialization/deserialization based on Boost.PFR

### DIFF
--- a/universal/include/userver/formats/parse/try_parse.hpp
+++ b/universal/include/userver/formats/parse/try_parse.hpp
@@ -15,79 +15,81 @@ USERVER_NAMESPACE_BEGIN
 namespace formats::parse {
 
 namespace impl {
-
-template <typename T, typename Value>
-constexpr inline bool Is(Value&& value) {
-  if constexpr(std::is_same_v<T, bool>) {
-    return value.IsBool();
-  } else if constexpr(meta::kIsInteger<T>) {
-    return (std::is_unsigned_v<T> && sizeof(T) == sizeof(std::uint64_t)) ? value.IsUInt64() : value.IsInt64();
-  } else if constexpr(std::is_convertible_v<T, std::string>) {
-    return value.IsString();
-  } else if constexpr(std::is_convertible_v<T, double>) {
-    return value.IsDouble();
-  } else if constexpr(meta::kIsRange<T>) {
-    return value.IsArray();
-  } else {
-    return value.IsObject();
-  }
-}
 bool CheckInBounds(const auto& x, const auto& min, const auto& max) {
   if (x < min || x > max) {
     return false;
   };
   return true;
 };
-inline constexpr utils::impl::TypeList<bool, double, std::string> kBaseTypes;
 
 } // namespace impl
 
-
-template <typename T, typename Value>
-constexpr inline std::enable_if_t<
-        utils::impl::AnyOf(utils::impl::IsSameCarried<T>(), impl::kBaseTypes) ||
-        meta::kIsInteger<T>, std::optional<T>>
-TryParse(Value&& value, userver::formats::parse::To<T>) {
-  if(!impl::Is<T>(value)) {
+template <typename Value, typename T>
+inline constexpr std::optional<T> TryParse(Value&& value, To<T>) {
+  if(!value.IsObject()) {
     return std::nullopt;
   }
   return value.template As<T>();
 }
 
-template <typename T, typename Value>
-constexpr inline std::optional<std::optional<T>> TryParse(Value&& value, userver::formats::parse::To<std::optional<T>>) {
-  return TryParse(std::forward<Value>(value), userver::formats::parse::To<T>{});
+template <typename Value>
+inline constexpr std::optional<bool> TryParse(Value&& value, To<bool>) {
+  if(!value.IsBool()) {
+    return std::nullopt;
+  }
+  return value.template As<bool>();
 }
 template <typename Value>
-constexpr inline std::optional<float> TryParse(Value&& value, userver::formats::parse::To<float>) {
+inline constexpr std::optional<double> TryParse(Value&& value, To<double>) {
+  if(!value.IsDouble()) {
+    return std::nullopt;
+  }
+  return value.template As<double>();
+}
+template <typename Value>
+inline constexpr std::optional<std::string> TryParse(Value&& value, To<std::string>) {
+  if(!value.IsString()) {
+    return std::nullopt;
+  }
+  return value.template As<std::string>();
+}
+
+template <typename Value, typename T>
+inline constexpr std::optional<T> TryParse(Value&& value, To<T>) requires meta::kIsInteger<T> {
+  if(!((std::is_unsigned_v<T> && sizeof(T) == sizeof(std::uint64_t)) ? value.IsUInt64() : value.IsInt64())) {
+    return std::nullopt;
+  }
+  return value.template As<T>();
+}
+template <typename Value, typename T>
+inline constexpr std::optional<std::vector<T>> TryParse(Value&& value, To<std::vector<T>>) {
+  if(!value.IsArray()) {
+    return std::nullopt;
+  }
+  std::vector<T> response;
+  response.reserve(value.GetSize());
+  for(const auto& item : value) {
+    auto insert = TryParse(item, To<T>{});
+    if(!insert) {
+      return std::nullopt;
+    }
+    response.push_back(std::move(*insert));
+  }
+  return response;
+}
+
+template <typename T, typename Value>
+constexpr inline std::optional<std::optional<T>> TryParse(Value&& value, To<std::optional<T>>) {
+  return TryParse(std::forward<Value>(value), To<T>{});
+}
+template <typename Value>
+constexpr inline std::optional<float> TryParse(Value&& value, To<float>) {
   auto response = value.template As<double>();
   if(impl::CheckInBounds(response, std::numeric_limits<float>::lowest(),
                         std::numeric_limits<float>::max())) {
     return static_cast<float>(response);
-  };
+  }
   return std::nullopt;
-};
-
-template <typename T, typename Value>
-constexpr inline std::enable_if_t<meta::kIsRange<T> && !meta::kIsMap<T> &&
-                     !std::is_same_v<T, boost::uuids::uuid> &&
-                     !utils::impl::AnyOf(utils::impl::IsConvertableCarried<T>(), impl::kBaseTypes) &&
-                     !std::is_convertible_v<
-                         T&, utils::impl::strong_typedef::StrongTypedefTag&>,
-                 std::optional<T>>
-TryParse(Value&& from, To<T>) {
-  T response;
-  auto inserter = std::inserter(response, response.end());
-  using ValueType = meta::RangeValueType<T>;
-  for(const auto& item : from) {
-    auto insert = TryParse(item, userver::formats::parse::To<ValueType>{});
-    if(!insert) {
-      return std::nullopt;
-    };
-    *inserter = *insert;
-    ++inserter;
-  };
-  return response;
 }
 
 

--- a/universal/include/userver/formats/parse/try_parse.hpp
+++ b/universal/include/userver/formats/parse/try_parse.hpp
@@ -1,0 +1,97 @@
+#pragma once
+#include <type_traits>
+#include <string>
+#include <cstdint>
+#include <limits>
+#include <userver/formats/parse/to.hpp>
+#include <userver/utils/meta.hpp>
+#include <userver/utils/impl/type_list.hpp>
+#include <userver/formats/common/meta.hpp>
+#include <userver/formats/parse/common_containers.hpp>
+
+
+USERVER_NAMESPACE_BEGIN
+
+namespace formats::parse {
+
+namespace impl {
+
+template <typename T, typename Value>
+constexpr inline bool Is(Value&& value) {
+  if constexpr(std::is_same_v<T, bool>) {
+    return value.IsBool();
+  } else if constexpr(meta::kIsInteger<T>) {
+    return (std::is_unsigned_v<T> && sizeof(T) == sizeof(std::uint64_t)) ? value.IsUInt64() : value.IsInt64();
+  } else if constexpr(std::is_convertible_v<T, std::string>) {
+    return value.IsString();
+  } else if constexpr(std::is_convertible_v<T, double>) {
+    return value.IsDouble();
+  } else if constexpr(meta::kIsRange<T>) {
+    return value.IsArray();
+  } else {
+    return value.IsObject();
+  }
+}
+bool CheckInBounds(const auto& x, const auto& min, const auto& max) {
+  if (x < min || x > max) {
+    return false;
+  };
+  return true;
+};
+inline constexpr utils::impl::TypeList<bool, double, std::string> kBaseTypes;
+
+} // namespace impl
+
+
+template <typename T, typename Value>
+constexpr inline std::enable_if_t<
+        utils::impl::AnyOf(utils::impl::IsSameCarried<T>(), impl::kBaseTypes) ||
+        meta::kIsInteger<T>, std::optional<T>>
+TryParse(Value&& value, userver::formats::parse::To<T>) {
+  if(!impl::Is<T>(value)) {
+    return std::nullopt;
+  }
+  return value.template As<T>();
+}
+
+template <typename T, typename Value>
+constexpr inline std::optional<std::optional<T>> TryParse(Value&& value, userver::formats::parse::To<std::optional<T>>) {
+  return TryParse(std::forward<Value>(value), userver::formats::parse::To<T>{});
+}
+template <typename Value>
+constexpr inline std::optional<float> TryParse(Value&& value, userver::formats::parse::To<float>) {
+  auto response = value.template As<double>();
+  if(impl::CheckInBounds(response, std::numeric_limits<float>::lowest(),
+                        std::numeric_limits<float>::max())) {
+    return static_cast<float>(response);
+  };
+  return std::nullopt;
+};
+
+template <typename T, typename Value>
+constexpr inline std::enable_if_t<meta::kIsRange<T> && !meta::kIsMap<T> &&
+                     !std::is_same_v<T, boost::uuids::uuid> &&
+                     !utils::impl::AnyOf(utils::impl::IsConvertableCarried<T>(), impl::kBaseTypes) &&
+                     !std::is_convertible_v<
+                         T&, utils::impl::strong_typedef::StrongTypedefTag&>,
+                 std::optional<T>>
+TryParse(Value&& from, To<T>) {
+  T response;
+  auto inserter = std::inserter(response, response.end());
+  using ValueType = meta::RangeValueType<T>;
+  for(const auto& item : from) {
+    auto insert = TryParse(item, userver::formats::parse::To<ValueType>{});
+    if(!insert) {
+      return std::nullopt;
+    };
+    *inserter = *insert;
+    ++inserter;
+  };
+  return response;
+}
+
+
+
+} // namespace formats::parse
+
+USERVER_NAMESPACE_END

--- a/universal/include/userver/formats/parse/try_parse.hpp
+++ b/universal/include/userver/formats/parse/try_parse.hpp
@@ -56,18 +56,21 @@ inline constexpr std::optional<std::string> TryParse(Value&& value, To<std::stri
 
 template <typename Value, typename T>
 inline constexpr std::optional<T> TryParse(Value&& value, To<T>) requires meta::kIsInteger<T> {
+  constexpr auto f = [](auto response){
+    return impl::CheckInBounds(response, std::numeric_limits<T>::min(), std::numeric_limits<T>::max()) ? std::optional{static_cast<T>(response)} : std::nullopt;
+  };
   if constexpr(std::is_unsigned_v<T>) {
-    if(!((sizeof(T) == sizeof(std::uint64_t)) ? value.IsUInt64() : value.IsInt64())) {
+    if(!value.IsUInt64()) {
       return std::nullopt;
     }
     auto response = value.template As<std::uint64_t>();
-    return impl::CheckInBounds(response, std::numeric_limits<T>::min(), std::numeric_limits<T>::max()) ? std::optional{static_cast<T>(response)} : std::nullopt;
+    return f(std::move(response));
   } else {
     if(!value.IsInt64()) {
       return std::nullopt;
     }
     auto response = value.template As<std::int64_t>();
-    return impl::CheckInBounds(response, std::numeric_limits<T>::min(), std::numeric_limits<T>::max()) ? std::optional{static_cast<T>(response)} : std::nullopt;
+    return f(std::move(response));
   }
 }
 template <typename Value, typename T>

--- a/universal/include/userver/formats/universal/common_containers.hpp
+++ b/universal/include/userver/formats/universal/common_containers.hpp
@@ -19,16 +19,6 @@ struct Max : public impl::Param<T> {
     }
     return this->Error(value);
   }
-  template <typename Value>
-  inline constexpr auto Check(const Value& value) const -> std::optional<std::string>
-        requires meta::kIsRange<Value> {
-    for(const auto& element : value) {
-      if(element > this->value) {
-        return this->Error(element);
-      }
-    }
-    return std::nullopt;
-  }
   inline constexpr std::string Error(const T& value) const {
     return std::format("{} > {}", value, this->value);
   }
@@ -50,6 +40,21 @@ struct MinElements : public impl::Param<std::size_t> {
     return "Error";
   }
 };
+struct MaxElements : public impl::Param<std::size_t> {
+  inline constexpr MaxElements(const std::size_t& value) :
+      impl::Param<std::size_t>(value) {}
+  template <typename Value>
+  inline constexpr auto Check(const Value& value) const -> std::optional<std::string> {
+    if(value.size() <= this->value) {
+      return std::nullopt;
+    }
+    return this->Error(value);
+  }
+  template <typename Value>
+  inline constexpr auto Error(const Value&) const {
+    return "Error";
+  }
+};
 
 template <typename T>
 struct Min : public impl::Param<T> {
@@ -60,16 +65,6 @@ struct Min : public impl::Param<T> {
       return std::nullopt;
     }
     return this->Error(value);
-  }
-  template <typename Value>
-  inline constexpr auto Check(const Value& value) const -> std::optional<std::string>
-        requires meta::kIsRange<Value> {
-    for(const auto& element : value) {
-      if(element < this->value) {
-        return this->Error(element);
-      }
-    }
-    return std::nullopt;
   }
   inline constexpr auto Error(const T& value) const {
     return std::format("{} < {}", value, this->value);

--- a/universal/include/userver/formats/universal/common_containers.hpp
+++ b/universal/include/userver/formats/universal/common_containers.hpp
@@ -97,6 +97,9 @@ template <>
 struct Default<std::string, void> : public impl::EmptyCheck, private impl::Param<std::string_view> {
   inline constexpr Default(std::string_view value) :
       impl::Param<std::string_view>(value) {}
+  template <std::size_t N>
+  inline constexpr Default(const char(&value)[N]) :
+      impl::Param<std::string_view>(value) {}
   inline constexpr auto value() const -> std::string {
     return static_cast<std::string>(static_cast<const impl::Param<std::string_view>&>(*this).value);
   }

--- a/universal/include/userver/formats/universal/common_containers.hpp
+++ b/universal/include/userver/formats/universal/common_containers.hpp
@@ -1,0 +1,296 @@
+#pragma once
+#include <userver/formats/universal/universal.hpp>
+#include <userver/formats/common/items.hpp>
+#include <userver/formats/parse/try_parse.hpp>
+#include <format>
+#include <userver/utils/regex.hpp>
+
+USERVER_NAMESPACE_BEGIN
+namespace formats::universal {
+template <typename T>
+struct Max : public impl::Param<T> {
+  inline constexpr Max(const T& value) :
+      impl::Param<T>(value) {}
+  inline constexpr std::string Check(const T& value) const {
+    return value <= this->value ? "" : this->Error(value);
+  }
+  template <typename Value>
+  inline constexpr std::enable_if_t<meta::kIsRange<Value>, std::string>
+  Check(const Value& value) const {
+    for(const auto& element : value) {
+      if(element > this->value) {
+        return this->Error(element);
+      }
+    }
+    return "";
+  }
+  inline constexpr std::string Error(const T& value) const {
+    return std::format("{} > {}", value, this->value);
+  }
+};
+
+struct MinElements : public impl::Param<std::size_t> {
+  inline constexpr MinElements(const std::size_t& value) :
+      impl::Param<std::size_t>(value) {}
+  template <typename Value>
+  inline constexpr std::string Check(const Value& value) const {
+    if(value.size() >= this->value) {
+      return "";
+    }
+    return this->Error(value);
+  }
+  template <typename Value>
+  inline constexpr auto Error(const Value&) const {
+    return "Error";
+  }
+};
+
+template <typename T>
+struct Min : public impl::Param<T> {
+  inline constexpr Min(const T& value) :
+      impl::Param<T>(value) {}
+  inline constexpr std::string Check(const T& value) const {
+    return value >= this->value ? "" : this->Error(value);
+  };
+  template <typename Value>
+  inline constexpr std::enable_if_t<meta::kIsRange<Value>, std::string>
+  Check(const Value& value) const {
+    for(const auto& element : value) {
+      if(element < this->value) {
+        return this->Error(element);
+      }
+    }
+    return "";
+  }
+  inline constexpr auto Error(const T& value) const {
+    return std::format("{} < {}", value, this->value);
+  };
+};
+template <typename T>
+struct Default : public impl::EmptyCheck, public impl::Param<T> {
+  inline constexpr Default(const T& value) :
+      impl::Param<T>(value) {}
+};
+template <utils::ConstexprString Pattern>
+static const utils::regex kRegex(Pattern);
+
+struct Pattern : public impl::EmptyCheck, public impl::Param<const utils::regex*> {
+  constexpr inline Pattern(const utils::regex& regex) :
+      impl::Param<const utils::regex*>(&regex) {}
+  constexpr inline std::string Check(std::string_view str) const {
+    return utils::regex_match(str, *this->value) ? "" : this->Error(str);
+  }
+  constexpr inline std::string Error(std::string_view) const {
+    return "Error";
+  }
+};
+struct Additional : public impl::EmptyCheck, public impl::Param<bool> {
+  constexpr inline Additional(const bool& value) :
+      impl::Param<bool>(value) {}
+};
+template <>
+struct FieldConfig<int> {
+  std::optional<Max<int>> Maximum;
+  std::optional<Min<int>> Minimum;
+  template <typename MainClass, auto I, typename Value>
+  constexpr int Read(Value&& value) const {
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    return value[name].template As<int>();
+  };
+  template <typename MainClass, auto I, typename Value>
+  constexpr std::optional<int> TryRead(Value&& value) const {
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    return parse::TryParse(value[name], parse::To<int>{});
+  };
+  constexpr auto Write(const int& value, std::string_view fieldName, const auto&, auto& builder) const {
+    builder[static_cast<std::string>(fieldName)] = value;
+  };
+  inline constexpr std::string_view Check(const int&) const {
+    return "";
+  }
+
+};
+template <>
+struct FieldConfig<std::optional<std::string>> {
+  std::optional<Pattern> Pattern;
+  std::optional<Default<std::string>> Default;
+  template <typename MainClass, auto I, typename Value>
+  constexpr std::optional<std::string> Read(Value&& value) const {
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    if(!value.HasMember(name)) {
+      return std::nullopt;
+    };
+    return value[name].template As<std::string>();
+  };
+  template <typename MainClass, auto I, typename Value>
+  constexpr std::optional<std::optional<std::string>> TryRead(Value&& value) const {
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    auto response = parse::TryParse(value[name], parse::To<std::string>{});
+    if(response) {
+      return response;
+    }
+    if(this->Default) {
+      return this->Default->value;
+    }
+    return std::nullopt;
+  }
+  constexpr auto Write(const std::optional<std::string>& value, std::string_view fieldName, const auto&, auto& builder) const {
+    if(value) {
+      builder[static_cast<std::string>(fieldName)] = *value;
+    };
+  };
+  inline constexpr std::string_view Check(const std::string&) const {
+    return "";
+  }
+
+};
+template <>
+struct FieldConfig<std::string> {
+  std::optional<Pattern> Pattern;
+  template <typename MainClass, auto I, typename Value>
+  constexpr std::string Read(Value&& value) const {
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    return value[name].template As<std::string>();
+  };
+  template <typename MainClass, auto I, typename Value>
+  constexpr std::optional<std::string> TryRead(Value&& value) const {
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    return parse::TryParse(value[name], parse::To<std::string>{});
+  };
+  constexpr auto Write(std::string_view value, std::string_view fieldName, const auto&, auto& builder) const {
+    builder[static_cast<std::string>(fieldName)] = value;
+  };
+  inline constexpr std::string_view Check(std::string_view) const {
+    return "";
+  }
+
+};
+
+template <>
+struct FieldConfig<std::optional<int>> {
+  std::optional<Max<int>> Maximum;
+  std::optional<Min<int>> Minimum;
+  std::optional<Default<int>> Default;
+  template <typename MainClass, auto I, typename Value>
+  constexpr std::optional<int> Read(Value&& value) const {
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    if(value.HasMember(name)) {
+      return value[name].template As<int>();
+    }
+    if(this->Default) {
+      return this->Default->value;
+    }
+    return std::nullopt;
+  }
+  template <typename MainClass, auto I, typename Value>
+  constexpr std::optional<std::optional<int>> TryRead(Value&& value) const {
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    auto response = parse::TryParse(value[name], parse::To<int>{});
+    if(response) {
+      return response;
+    }
+    if(this->Default) {
+      return this->Default->value;
+    }
+    return {{}};
+  }
+  constexpr auto Write(const std::optional<int>& value, std::string_view fieldName, const auto&, auto& builder) const {
+    if(value) {
+      builder[static_cast<std::string>(fieldName)] = *value;
+      return;
+    }
+    if(this->Default) {
+      builder[static_cast<std::string>(fieldName)] = this->Default->value;
+    }
+  }
+
+  inline constexpr std::string_view Check(const std::optional<int>&) const {
+    return "";
+  }
+
+};
+template <typename Value>
+struct FieldConfig<std::unordered_map<std::string, Value>> {
+  std::optional<Additional> Additional;
+  using kType = std::unordered_map<std::string, Value>;
+  template <typename MainClass, auto I, typename Value2>
+  inline constexpr kType Read(Value2&& value) const {
+    if(!this->Additional) {
+      throw std::runtime_error("Invalid Flags");
+    }
+    kType response;
+    constexpr auto fields = boost::pfr::names_as_array<MainClass>();
+    for(const auto& [name, value2] : userver::formats::common::Items(std::forward<Value2>(value))) {
+      auto it = std::find(fields.begin(), fields.end(), name);
+      if(it == fields.end()) {
+        response.emplace(name, value2.template As<Value>());
+      }
+    }
+    return response;
+  }
+  template <typename MainClass, auto I, typename Value2>
+  inline constexpr std::optional<kType> TryRead(Value2&& value) const {
+    if(!this->Additional) {
+      throw std::runtime_error("Invalid Flags");
+    }
+    kType response;
+    constexpr auto fields = boost::pfr::names_as_array<MainClass>();
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    for(const auto& [name2, value2] : userver::formats::common::Items(std::forward<Value2>(value))) {
+      if(std::find(fields.begin(), fields.end(), name2) == fields.end()) {
+        auto New = parse::TryParse(value2, parse::To<Value>{});
+        if(!New) {
+          return std::nullopt;
+        };
+        response.emplace(name, *New);
+      }
+    }
+    return response;
+  }
+  inline constexpr std::string_view Check(const kType&) const {
+    return "";
+  }
+  constexpr auto Write(const kType& value, std::string_view, const auto&, auto& builder) const {
+    for(const auto& [name, value2] : value) {
+      builder[name] = value2;
+    };
+  };
+};
+template <typename Element>
+struct FieldConfig<std::vector<Element>> {
+  std::optional<MinElements> MinimalElements;
+  FieldConfig<Element> Items;
+  template <typename MainClass, auto I, typename Value>
+  inline constexpr auto Read(Value&& value) const {
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    std::vector<Element> response;
+    for(const auto& element : value[name]) {
+      auto New = element.template As<Element>();
+      response.push_back(std::move(New));
+    }
+    return response;
+  }
+  template <typename MainClass, auto I, typename Value>
+  inline constexpr std::optional<std::vector<Element>> TryRead(Value&& value) const {
+    std::vector<Element> response;
+    constexpr auto name = boost::pfr::get_name<I, MainClass>();
+    for(const auto& element : value[name]) {
+      auto New = parse::TryParse(element, parse::To<Element>{});
+      if(!New) {
+        return std::nullopt;
+      }
+      response.push_back(std::move(*New));
+    }
+    return response;
+  }
+  inline constexpr std::string Check(const std::vector<Element>& obj) const {
+    std::string error;
+    for(const auto& element : obj) {
+      error += impl::UniversalCheckField(element, this->Items);
+    }
+    return error;
+  }
+
+};
+} // namespace formats::universal
+USERVER_NAMESPACE_END

--- a/universal/include/userver/formats/universal/universal.hpp
+++ b/universal/include/userver/formats/universal/universal.hpp
@@ -209,7 +209,6 @@ class SerializationConfig {
     template <utils::ConstexprString fieldName>
     inline constexpr auto& With(FieldConfig<impl::kFieldTypeOnIndex<T, impl::getFieldIndexByName<T>(fieldName)>>&& field_config) {
       constexpr auto Index = impl::getFieldIndexByName<T>(fieldName);
-      static_assert(Index != boost::pfr::tuple_size_v<T>, "Field Not Found");
       std::get<Index>(this->fields_config) = std::move(field_config);
       return *this;
     }
@@ -235,8 +234,9 @@ class SerializationConfig<std::variant<Ts...>> {
     inline constexpr auto& With(FieldConfig<T>&& field_config) {
       return this->With<Find<T>(utils::impl::TypeList<Ts...>{})>(std::move(field_config));
     }
+    inline constexpr SerializationConfig() = default;
   private:
-    std::tuple<FieldConfig<Ts>...> variant_config;
+    std::tuple<FieldConfig<Ts>...> variant_config = {};
 };
 
 

--- a/universal/include/userver/formats/universal/universal.hpp
+++ b/universal/include/userver/formats/universal/universal.hpp
@@ -185,7 +185,7 @@ template <typename T>
 impl::Disabled kSerialization;
 
 template <typename T>
-auto kDeserialization = kSerialization<T>;
+inline constexpr auto kDeserialization = kSerialization<T>;
 
 
 template <typename T>
@@ -222,7 +222,7 @@ struct SerializationConfig {
 namespace formats::parse {
 
 template <typename Value, typename T>
-inline constexpr std::enable_if_t<!std::is_same_v<decltype(universal::kDeserialization<T>), universal::impl::Disabled>, T>
+inline constexpr std::enable_if_t<!std::is_same_v<std::remove_cvref_t<decltype(universal::kDeserialization<T>)>, universal::impl::Disabled>, T>
 Parse(Value&& value, To<T>) {
   return [&]<auto... I>(std::index_sequence<I...>){
     auto config = universal::kSerialization<T>;
@@ -231,7 +231,7 @@ Parse(Value&& value, To<T>) {
 }
 
 template <typename Value, typename T>
-inline constexpr std::enable_if_t<!std::is_same_v<decltype(universal::kDeserialization<T>), universal::impl::Disabled>, std::optional<T>>
+inline constexpr std::enable_if_t<!std::is_same_v<std::remove_cvref_t<decltype(universal::kDeserialization<T>)>, universal::impl::Disabled>, std::optional<T>>
 TryParse(Value&& value, To<T>) {
   return [&]<auto... I>(std::index_sequence<I...>) -> std::optional<T> {
     auto config = universal::kSerialization<T>;

--- a/universal/include/userver/formats/universal/universal.hpp
+++ b/universal/include/userver/formats/universal/universal.hpp
@@ -79,7 +79,7 @@ inline constexpr std::optional<std::string> Add(Arg&& arg, Args&&... args) {
 template <typename T, typename TT>
 inline constexpr auto checkCaller(T&& response, TT&& check) 
         requires (requires{FieldConfig<std::remove_cvref_t<T>>::Checker(check, response);} 
-                ? true : requires{check.Check(std::forward<T>(response));}) {
+                || requires{check.Check(std::forward<T>(response));}) {
   using Type = FieldConfig<std::remove_cvref_t<T>>;
   if constexpr(requires{Type::Checker(check, response);}) {
     return Type::Checker(std::forward<TT>(check), response);

--- a/universal/include/userver/formats/universal/universal.hpp
+++ b/universal/include/userver/formats/universal/universal.hpp
@@ -1,0 +1,235 @@
+#pragma once
+#include <userver/utils/constexpr_string.hpp>
+#include <userver/formats/parse/to.hpp>
+#include <userver/formats/serialize/to.hpp>
+#include <userver/utils/meta.hpp>
+#include <type_traits>
+#include <boost/pfr.hpp>
+
+
+USERVER_NAMESPACE_BEGIN
+
+namespace formats::universal {
+
+
+template <typename T>
+struct FieldConfig {
+  constexpr inline std::string_view Check(const T&) const {
+    return "";
+  }
+};
+namespace impl {
+
+template <typename T, std::size_t I>
+using kFieldTypeOnIndex = std::remove_reference_t<decltype(boost::pfr::get<I>(std::declval<T>()))>;
+
+template <typename T>
+consteval std::size_t getFieldIndexByName(std::string_view fieldName) {
+  constexpr auto names = boost::pfr::names_as_array<T>();
+  return std::find(names.begin(), names.end(), fieldName) - names.begin();
+};
+
+struct Disabled {};
+
+
+template <typename T>
+struct Param {
+  T value;
+  constexpr Param(const T& value) :
+      value(value) {};
+};
+
+template <auto Value>
+struct Wrapper {
+  static constexpr auto kValue = Value;
+};
+
+
+
+template <typename T>
+inline constexpr auto RemoveOptional(const std::optional<T>& value) {
+  auto response = *value;
+  if constexpr(meta::kIsOptional<decltype(response)>) {
+    return RemoveOptional(response);
+  } else {
+    return response;
+  }
+}
+template <typename T>
+inline constexpr auto RemoveOptional(const T& value) {
+  return value;
+}
+
+
+template <typename T, typename T2, typename = void>
+struct HasCheck : public std::false_type {};
+
+template <typename T, typename T2>
+struct HasCheck<T, T2, std::void_t<decltype(std::declval<T&>().Check(std::declval<T2&>()))>> : public std::true_type {};
+
+template <typename Result, typename... T>
+inline constexpr Result add(T&&... args) {
+  if constexpr(sizeof...(T) != 0) {
+    return (args + ...);
+  } else {
+    return {};
+  }
+}
+
+
+
+template <typename T, typename FieldConfigType>
+inline constexpr std::string UniversalCheckField(
+          T&& response,
+          FieldConfig<FieldConfigType> config) {
+  using FieldType = std::remove_cvref_t<decltype(response)>;
+  auto error = [&]<auto... Is>(std::index_sequence<Is...>) -> std::string {
+    auto f = [&]<auto II>(Wrapper<II>) -> std::string {
+      auto check = boost::pfr::get<II>(config);
+      if constexpr(HasCheck<decltype(RemoveOptional(check)), decltype(RemoveOptional(response))>::value) {
+        if constexpr(meta::kIsOptional<FieldType>) {
+          if(response && check && !check->Check(RemoveOptional(response)).empty()) {
+            return check->Check(RemoveOptional(response));
+          }
+        } else {
+          if(check && !check->Check(response).empty()) {
+            return check->Check(response);
+          }
+        }
+      }
+      return "";
+    };
+    return add<std::string>(f(Wrapper<Is>{})...);
+  }(std::make_index_sequence<boost::pfr::tuple_size_v<decltype(config)>>());
+  if constexpr(meta::kIsOptional<std::remove_cvref_t<T>>) {
+    if(response) {
+      error += config.Check(*response);
+    }
+  } else {
+    error += config.Check(std::forward<T>(response));
+  }
+  return error;
+}
+
+
+template <typename MainClass, auto I, typename T>
+inline constexpr auto UniversalParseField(
+          T&& value,
+          FieldConfig<kFieldTypeOnIndex<MainClass, I>> config) {
+  auto response = config.template Read<MainClass, I>(value);
+  const auto error = UniversalCheckField(response, config);
+  if(!error.empty()) {
+    throw std::runtime_error(error);
+  }
+  return response;
+}
+
+template <typename MainClass, auto I, typename T>
+inline constexpr auto UniversalTryParseField(
+          T&& value,
+          FieldConfig<kFieldTypeOnIndex<MainClass, I>> config) {
+  auto response = config.template TryRead<MainClass, I>(value);
+  return [&]() -> decltype(response) {
+    if(UniversalCheckField(response, std::move(config)).empty()) {
+      return response;
+    }
+    return std::nullopt;
+  }();
+}
+
+template <typename MainClass, auto I, typename T, typename Builder>
+inline constexpr auto UniversalSerializeField(
+        T&& value,
+        Builder& builder,
+        FieldConfig<kFieldTypeOnIndex<MainClass, I>> config) {
+  UniversalCheckField(value, config);
+  config.template Write(std::forward<T>(value), boost::pfr::get_name<I, MainClass>(), boost::pfr::names_as_array<MainClass>(), builder);
+}
+struct EmptyCheck {
+  template <typename Value>
+  inline constexpr std::string Check(Value&&) const {
+    return "";
+  }
+};
+} // namespace impl
+
+template <typename T>
+impl::Disabled kSerialization;
+
+template <typename T>
+auto kDeserialization = kSerialization<T>;
+
+
+template <typename T>
+struct SerializationConfig {
+  using kFieldsConfigType = decltype([]<auto... I>(std::index_sequence<I...>){
+    return std::type_identity<std::tuple<FieldConfig<impl::kFieldTypeOnIndex<T, I>>...>>();
+  }(std::make_index_sequence<boost::pfr::tuple_size_v<T>>()))::type;
+
+  public:
+    template <utils::ConstexprString fieldName>
+    inline constexpr auto& With(FieldConfig<impl::kFieldTypeOnIndex<T, impl::getFieldIndexByName<T>(fieldName)>>&& fieldConfig) {
+      constexpr auto Index = impl::getFieldIndexByName<T>(fieldName);
+      static_assert(Index != boost::pfr::tuple_size_v<T>, "Field Not Found");
+      std::get<Index>(this->fieldsConfig) = std::move(fieldConfig);
+      return *this;
+    }
+    constexpr SerializationConfig() : fieldsConfig({}) {};
+
+    template <std::size_t I>
+    constexpr auto Get() const {
+      return std::get<I>(this->fieldsConfig);
+    };
+  private:
+    kFieldsConfigType fieldsConfig;
+
+};
+
+
+
+} // namespace formats::universal
+
+
+
+namespace formats::parse {
+
+template <typename Value, typename T>
+inline constexpr std::enable_if_t<!std::is_same_v<decltype(universal::kDeserialization<T>), universal::impl::Disabled>, T>
+Parse(Value&& value, To<T>) {
+  return [&]<auto... I>(std::index_sequence<I...>){
+    auto config = universal::kSerialization<T>;
+    return T{universal::impl::UniversalParseField<T, I>(value, config.template Get<I>())...};
+  }(std::make_index_sequence<boost::pfr::tuple_size_v<T>>());
+}
+
+template <typename Value, typename T>
+inline constexpr std::enable_if_t<!std::is_same_v<decltype(universal::kDeserialization<T>), universal::impl::Disabled>, std::optional<T>>
+TryParse(Value&& value, To<T>) {
+  return [&]<auto... I>(std::index_sequence<I...>) -> std::optional<T> {
+    auto config = universal::kSerialization<T>;
+    auto tup = std::make_tuple(universal::impl::UniversalTryParseField<T, I>(value, config.template Get<I>())...);
+    if((std::get<I>(tup) && ...)) {
+      return T{*std::get<I>(tup)...};
+    };
+    return std::nullopt;
+  }(std::make_index_sequence<boost::pfr::tuple_size_v<T>>());
+}
+
+} // namespace formats::parse
+namespace formats::serialize {
+
+template <typename Value, typename T>
+inline constexpr std::enable_if_t<!std::is_same_v<decltype(universal::kSerialization<std::remove_cvref_t<T>>), universal::impl::Disabled>, Value>
+Serialize(T&& obj, To<Value>) {
+  using Type = std::remove_cvref_t<T>;
+  return [&]<auto... I>(std::index_sequence<I...>){
+    typename Value::Builder builder;
+    auto config = universal::kSerialization<Type>;
+    (universal::impl::UniversalSerializeField<Type, I>(boost::pfr::get<I>(obj), builder, config.template Get<I>()), ...);
+    return builder.ExtractValue();
+  }(std::make_index_sequence<boost::pfr::tuple_size_v<Type>>());
+}
+
+} // namespace formats::serialize
+
+USERVER_NAMESPACE_END

--- a/universal/include/userver/formats/universal/universal.hpp
+++ b/universal/include/userver/formats/universal/universal.hpp
@@ -61,21 +61,20 @@ template <auto Value>
 struct Wrapper {
   static constexpr auto kValue = Value;
 };
-template <typename... Args>
-inline constexpr std::optional<std::string> Add(Args&&...) {
-  return std::nullopt;
-}
 
-template <typename Arg, typename... Args>
-inline constexpr std::optional<std::string> Add(Arg&& arg, Args&&... args) {
-  if(arg) {
-    auto toAdd = Add(std::forward<Args>(args)...);
-    if(toAdd) {
-      return *arg + *toAdd;
+template <typename... Args>
+inline constexpr std::optional<std::string> Add(Args&&... args) {
+  std::optional<std::string> result;
+  ([&]<typename T>(T&& arg){
+    if(arg) {
+      if(!result) {
+        result.emplace(*std::forward<T>(arg));
+        return;
+      }
+      result->append(*std::forward<T>(arg));
     }
-    return *arg;
-  }
-  return Add(std::forward<Arg>(args)...);
+  }(std::forward<Args>(args)), ...);
+  return result;
 }
 
 template <typename T, typename TT>

--- a/universal/include/userver/utils/constexpr_string.hpp
+++ b/universal/include/userver/utils/constexpr_string.hpp
@@ -1,0 +1,59 @@
+#pragma once
+#include <algorithm>
+#include <string>
+USERVER_NAMESPACE_BEGIN
+
+namespace utils {
+
+template <std::size_t Size>
+struct ConstexprString {
+
+  static constexpr auto kSize = Size;
+  constexpr operator std::string_view() const {
+    return std::string_view{this->contents_.data(), Size - 1};
+  };
+  constexpr auto c_str() const -> const char* {
+    return this->contents_.data();
+  };
+  constexpr std::size_t size() const {
+    return Size - 1;
+  };
+  constexpr const char* data() const {
+    return this->contents_.begin();
+  };
+
+  constexpr operator char&() const {
+    return this->contents_.data();
+  };
+
+  friend constexpr bool operator==(const ConstexprString& string, const char* other) {
+    return std::string_view(string) == std::string_view(other);
+  };
+  template <typename Stream>
+  friend constexpr auto& operator<<(Stream& stream, const ConstexprString& string) {
+    stream << static_cast<std::string_view>(string);
+    return stream;
+  };
+
+  constexpr ConstexprString(const char (&str)[Size]) noexcept {
+    std::copy_n(str, Size, std::begin(this->contents_));
+  };
+  constexpr ConstexprString(std::array<char, Size> data) noexcept : contents_(data) {};
+  template <std::size_t OtherSize>
+  constexpr ConstexprString<Size + OtherSize> operator+(const ConstexprString<OtherSize>& other) const noexcept {
+    return
+        [&]<auto... I, auto... I2>(std::index_sequence<I...>, std::index_sequence<I2...>){
+      return ConstexprString<Size + OtherSize>({this->contents_[I]..., other.contents_[I2]...});
+    }(std::make_index_sequence<Size>(), std::make_index_sequence<OtherSize>());
+  };
+  template <std::size_t OtherSize>
+  constexpr ConstexprString<Size + OtherSize> operator+(const char(&str)[OtherSize]) const noexcept {
+    return *this + ConstexprString<OtherSize>{str};
+  };
+  std::array<char, Size> contents_;
+};
+template <std::size_t n>
+ConstexprString(char const (&)[n]) -> ConstexprString<n>;
+} // namespace utils
+USERVER_NAMESPACE_END
+

--- a/universal/include/userver/utils/constexpr_string.hpp
+++ b/universal/include/userver/utils/constexpr_string.hpp
@@ -1,6 +1,9 @@
+#if __cplusplus >= 202002L
 #pragma once
 #include <algorithm>
 #include <string>
+#include <array>
+
 USERVER_NAMESPACE_BEGIN
 
 namespace utils {
@@ -56,4 +59,4 @@ template <std::size_t n>
 ConstexprString(char const (&)[n]) -> ConstexprString<n>;
 } // namespace utils
 USERVER_NAMESPACE_END
-
+#endif

--- a/universal/include/userver/utils/impl/type_list.hpp
+++ b/universal/include/userver/utils/impl/type_list.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include <type_traits>
+
+
+USERVER_NAMESPACE_BEGIN
+
+namespace utils::impl {
+
+template <typename... T>
+struct TypeList {};
+
+
+template <typename... Ts>
+consteval auto size(TypeList<Ts...>) {
+  return sizeof...(Ts);
+}
+
+
+template <template <typename...> typename Check, typename... Ts>
+consteval auto anyOf(TypeList<Ts...>) {
+  return (Check<Ts>::value || ...);
+}
+
+
+template <typename Check, typename... Ts>
+constexpr auto AnyOf(Check check, TypeList<Ts...>) {
+  return (check(std::type_identity<Ts>()) || ...);
+}
+
+template <typename T>
+consteval auto IsSameCarried() {
+  return []<typename T2>(std::type_identity<T2>){
+    return std::is_same_v<T, T2>;
+  };
+}
+template <typename T>
+consteval auto IsConvertableCarried() {
+  return []<typename T2>(std::type_identity<T2>){
+    return std::is_convertible_v<T, T2>;
+  };
+}
+
+} // namespace utils::impl
+
+USERVER_NAMESPACE_END
+

--- a/universal/include/userver/utils/impl/type_list.hpp
+++ b/universal/include/userver/utils/impl/type_list.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <type_traits>
-
+#include <utility>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -11,13 +11,12 @@ struct TypeList {};
 
 
 template <typename... Ts>
-consteval auto size(TypeList<Ts...>) {
+consteval auto Size(TypeList<Ts...>) {
   return sizeof...(Ts);
 }
 
-
 template <template <typename...> typename Check, typename... Ts>
-consteval auto anyOf(TypeList<Ts...>) {
+consteval auto AnyOf(TypeList<Ts...>) {
   return (Check<Ts>::value || ...);
 }
 
@@ -39,6 +38,19 @@ consteval auto IsConvertableCarried() {
     return std::is_convertible_v<T, T2>;
   };
 }
+
+struct Caster {
+  inline constexpr Caster(auto) {}
+  inline constexpr Caster() = default;
+};
+
+template <std::size_t... Is, typename T>
+consteval auto Get(std::index_sequence<Is...>, decltype(Is, Caster())..., T&& arg, ...) -> T; 
+
+template <std::size_t I, typename... Ts>
+consteval auto Get(const TypeList<Ts...>&) -> decltype(Get(std::make_index_sequence<I>(), std::declval<Ts>()...));
+
+
 
 } // namespace utils::impl
 

--- a/universal/src/formats/json/universal_test.cpp
+++ b/universal/src/formats/json/universal_test.cpp
@@ -82,7 +82,7 @@ struct SomeStruct3 {
 template <>
 inline constexpr auto formats::universal::kSerialization<SomeStruct3> =
     SerializationConfig<SomeStruct3>()
-    .With<"field">({.Additional = true});
+    .With<"field">({.AdditionalProperties = true});
 
 TEST(Serialize, Additional) {
   std::unordered_map<std::string, int> value;

--- a/universal/src/formats/json/universal_test.cpp
+++ b/universal/src/formats/json/universal_test.cpp
@@ -52,13 +52,13 @@ template <>
 inline constexpr auto formats::universal::kSerialization<SomeStruct2> =
     SerializationConfig<SomeStruct2>()
     .With<"field1">({.Default = 114})
-    .With<"field4">({.Default = {{"42"}}});
+    .With<"field4">({.Default = "42"});
 
 
 TEST(Serialize, Optional) {
   SomeStruct2 a{.field2 = 100};
   const auto json = formats::json::ValueBuilder(a).ExtractValue();
-  EXPECT_EQ(json, userver::formats::json::FromString(R"({"field1":114,"field2":100,"field4":"42"})"));
+  EXPECT_EQ(json, formats::json::FromString(R"({"field1":114,"field2":100,"field4":"42"})"));
 };
 TEST(Parse, Optional) {
   SomeStruct2 valid{.field1 = 114, .field4 = {{"42"}}};

--- a/universal/src/formats/json/universal_test.cpp
+++ b/universal/src/formats/json/universal_test.cpp
@@ -1,0 +1,202 @@
+#include <gtest/gtest.h>
+#include <userver/formats/universal/common_containers.hpp>
+#include <userver/formats/json.hpp>
+
+
+USERVER_NAMESPACE_BEGIN
+
+struct SomeStruct {
+  int field1;
+  int field2;
+  constexpr auto operator==(const SomeStruct& other) const noexcept {
+    return (this->field1 == other.field1) && (this->field2 == other.field2);
+  };
+};
+
+template <>
+inline constexpr auto formats::universal::kSerialization<SomeStruct> =
+    SerializationConfig<SomeStruct>();
+
+TEST(Serialize, Basic) {
+  SomeStruct a{10, 100};
+  const auto json = formats::json::ValueBuilder(a).ExtractValue();
+  EXPECT_EQ(formats::json::ToString(json), "{\"field1\":10,\"field2\":100}");
+};
+
+TEST(Parse, Basic) {
+  const auto json = formats::json::FromString("{\"field1\":10,\"field2\":100}");
+  const auto fromJson = json.As<SomeStruct>();
+  constexpr SomeStruct valid{10, 100};
+  EXPECT_EQ(fromJson, valid);
+};
+
+TEST(TryParse, Basic) {
+  const auto json =  formats::json::FromString("{\"field1\":10,\"field2\":100}");
+  const auto json2 = formats::json::FromString("{\"field1\":10,\"field3\":100}");
+  const auto json3 = formats::json::FromString("{\"field1\":10,\"field2\":\"100\"}");
+  EXPECT_EQ((bool)formats::parse::TryParse(json,  formats::parse::To<SomeStruct>{}), true);
+  EXPECT_EQ((bool)formats::parse::TryParse(json2, formats::parse::To<SomeStruct>{}), false);
+  EXPECT_EQ((bool)formats::parse::TryParse(json3, formats::parse::To<SomeStruct>{}), false);
+};
+
+
+struct SomeStruct2 {
+  std::optional<int> field1;
+  std::optional<int> field2;
+  std::optional<int> field3;
+  constexpr bool operator==(const SomeStruct2& other) const noexcept {
+    return this->field1 == other.field1 && this->field2 == other.field2 && this->field3 == other.field3;
+  };
+};
+
+template <>
+inline constexpr auto formats::universal::kSerialization<SomeStruct2> =
+    SerializationConfig<SomeStruct2>()
+    .With<"field1">({.Maximum = {}, .Minimum = {}, .Default = 114});
+
+
+TEST(Serialize, Optional) {
+  SomeStruct2 a{{}, 100, {}};
+  const auto json = formats::json::ValueBuilder(a).ExtractValue();
+  EXPECT_EQ(json, formats::json::FromString("{\"field1\":114,\"field2\":100}"));
+};
+
+TEST(Parse, Optional) {
+  constexpr SomeStruct2 valid{{114}, {}, {}};
+  const auto json = formats::json::FromString("{}");
+  EXPECT_EQ(json.As<SomeStruct2>(), valid);
+};
+
+TEST(TryParse, Optional) {
+  const auto json = formats::json::FromString("{}");
+  constexpr SomeStruct2 valid{{114}, {}, {}};
+  EXPECT_EQ(formats::parse::TryParse(json, formats::parse::To<SomeStruct2>{}), valid);
+};
+
+
+struct SomeStruct3 {
+  std::unordered_map<std::string, int> field;
+  auto operator==(const SomeStruct3& other) const noexcept {
+    return this->field == other.field;
+  };
+};
+
+
+template <>
+inline constexpr auto formats::universal::kSerialization<SomeStruct3> =
+    SerializationConfig<SomeStruct3>()
+    .With<"field">({.Additional = true});
+
+TEST(Serialize, Additional) {
+  std::unordered_map<std::string, int> value;
+  value["data1"] = 1;
+  value["data2"] = 2;
+  SomeStruct3 a{value};
+  const auto json = formats::json::ValueBuilder(a).ExtractValue();
+  EXPECT_EQ(json, formats::json::FromString("{\"data1\":1,\"data2\":2}"));
+};
+
+TEST(Parse, Additional) {
+  std::unordered_map<std::string, int> value;
+  value["data1"] = 1;
+  value["data2"] = 2;
+  SomeStruct3 valid{value};
+  const auto json = formats::json::FromString("{\"data1\":1,\"data2\":2}");
+  const auto fromJson = json.As<SomeStruct3>();
+  EXPECT_EQ(valid, fromJson);
+};
+
+TEST(TryParse, Additional) {
+  const auto json = formats::json::FromString("{\"data1\":1,\"data2\":2}");
+  EXPECT_EQ((bool)formats::parse::TryParse(json, formats::parse::To<SomeStruct3>{}), true);
+};
+
+struct SomeStruct4 {
+  int field;
+};
+
+template <>
+inline constexpr auto formats::universal::kSerialization<SomeStruct4> =
+    SerializationConfig<SomeStruct4>()
+    .With<"field">({.Maximum = 120, .Minimum = 10});
+
+
+
+
+TEST(TryParse, MinMax) {
+  const auto json = formats::json::FromString("{\"field\":1}");
+  const auto json2 = formats::json::FromString("{\"field\":11}");
+  const auto json3 = formats::json::FromString("{\"field\":121}");
+
+  EXPECT_EQ((bool)formats::parse::TryParse(json, formats::parse::To<SomeStruct4>{}), false);
+  EXPECT_EQ((bool)formats::parse::TryParse(json2, formats::parse::To<SomeStruct4>{}), true);
+  EXPECT_EQ((bool)formats::parse::TryParse(json3, formats::parse::To<SomeStruct4>{}), false);
+};
+
+
+
+struct SomeStruct5 {
+  std::string field;
+};
+
+template <>
+inline constexpr auto formats::universal::kSerialization<SomeStruct5> =
+    SerializationConfig<SomeStruct5>()
+    .With<"field">({.Pattern = kRegex<"^[0-9]+$">});
+
+TEST(TryParse, Pattern) {
+  const auto json = formats::json::FromString(R"({"field":"1234412"})");
+  const auto json2 = formats::json::FromString(R"({"field":"abcdefgh"})");
+  EXPECT_EQ((bool)formats::parse::TryParse(json, formats::parse::To<SomeStruct5>{}), true);
+  EXPECT_EQ((bool)formats::parse::TryParse(json2, formats::parse::To<SomeStruct5>{}), false);
+};
+
+
+
+TEST(TryParse, null) {
+  const auto json = formats::json::FromString("null");
+  EXPECT_EQ((bool)formats::parse::TryParse(json, formats::parse::To<std::optional<int>>{}), true);
+};
+
+struct SomeStruct6 {
+  std::vector<std::vector<int>> field;
+};
+
+template <>
+inline constexpr auto formats::universal::kSerialization<SomeStruct6> =
+    SerializationConfig<SomeStruct6>()
+    .With<"field">({.MinimalElements = 2, .Items = {.MinimalElements = 1, .Items = {.Maximum = {}, .Minimum = 10}}});
+
+TEST(TryParse, Arrays) {
+  const auto json =  formats::json::FromString(R"({"field":[[10], [20]]})");
+  const auto json2 = formats::json::FromString(R"({"field":[["10"], [20]]})");
+  const auto json3 = formats::json::FromString(R"({"field":[[9], [20]]})");
+  const auto json4 = formats::json::FromString(R"({"field":[[], []]})");
+  EXPECT_EQ((bool)formats::parse::TryParse(json,  formats::parse::To<SomeStruct6>{}),  true);
+  EXPECT_EQ((bool)formats::parse::TryParse(json2, formats::parse::To<SomeStruct6>{}), false);
+  EXPECT_EQ((bool)formats::parse::TryParse(json3, formats::parse::To<SomeStruct6>{}), false);
+  EXPECT_EQ((bool)formats::parse::TryParse(json4, formats::parse::To<SomeStruct6>{}), false);
+};
+
+struct SomeStruct7  {
+  int value;
+  std::vector<SomeStruct7> children;
+  inline bool operator==(const SomeStruct7& other) const {
+    return this->value == other.value && this->children == other.children;
+  };
+};
+
+template <>
+inline constexpr auto formats::universal::kSerialization<SomeStruct7> =
+    SerializationConfig<SomeStruct7>();
+
+
+TEST(Parse, Recursive) {
+  SomeStruct7 valid{1, {{2, {}}}};
+  const auto json = formats::json::FromString(R"({"value":1,"children":[{"value":2,"children":[]}]})");
+  const auto fromJson = json.As<SomeStruct7>();
+  EXPECT_EQ(fromJson, valid);
+};
+
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
Example
```cpp
#include <userver/formats/json.hpp>
#include <userver/formats/universal/universal.hpp>
#include <userver/formats/universal/common_containers.hpp>
#include <iostream>


struct SomeStruct {
  std::optional<int> field;
  std::string field2;
};

template <>
inline constexpr auto userver::formats::universal::kSerialization<SomeStruct> =
  SerializationConfig<SomeStruct>()
  .With<"field">({.Maximum = 1221, .Minimum = 12, .Default = 124})
  .With<"field2">({.Pattern = kPattern<"^[0-9]+$">});

int main() {
  userver::formats::json::ValueBuilder builder(SomeStruct{{}, "121"});
  auto json = builder.ExtractValue();
  std::cout << userver::formats::json::ToString(json) << std::endl; // {"field":124,"field2":"121"}
  std::cout << json.As<SomeStruct>().field << std::endl; // 124
};
```