### PR TITLE
feat userver: allow creating custom implicit options

### DIFF
--- a/core/include/userver/server/handlers/implicit_options.hpp
+++ b/core/include/userver/server/handlers/implicit_options.hpp
@@ -66,7 +66,7 @@ namespace server::handlers {
 /// Provide an optional query parameter `body` to get the bodies of all the
 /// in-flight requests.
 // clang-format on
-class ImplicitOptions final : public HttpHandlerBase {
+class ImplicitOptions : public HttpHandlerBase {
  public:
   /// @ingroup userver_component_names
   /// @brief The default name of server::handlers::ImplicitOptions component


### PR DESCRIPTION
Usage example:
```c++
class CustomImplicitOptions final : public userver::server::handlers::ImplicitOptions {
 public:
    CustomImplicitOptions(const userver::components::ComponentConfig& config,
                          const userver::components::ComponentContext& context,
                          bool is_monitor = false) : ImplicitOptions(config, context, is_monitor) {}

    std::string HandleRequestThrow(const userver::server::http::HttpRequest& request,
                                   userver::server::request::RequestContext& context) const override {
    request.GetHttpResponse().SetHeader(static_cast<std::string>("Access-Control-Allow-Origin"), "*");
    request.GetHttpResponse().SetHeader(static_cast<std::string>("Access-Control-Allow-Headers"), "*");

    return ImplicitOptions::HandleRequestThrow(request, context);
}
};
```