### PR TITLE
feat http: flush headers in streaming

### DIFF
--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -381,8 +381,9 @@ std::size_t HttpResponse::SetBodyStreamed(
       continue;
     }
 
-    auto size = fmt::format(fst_chunk_processed ? "\r\n{:x}\r\n" : "{:x}\r\n",
-                            body_part.size());
+    auto size = fst_chunk_processed
+                    ? fmt::format("\r\n{:x}\r\n", body_part.size())
+                    : fmt::format("{:x}\r\n", body_part.size());
     sent_bytes += socket.WriteAll(
         {{size.data(), size.size()}, {body_part.data(), body_part.size()}},
         engine::Deadline{});
@@ -390,10 +391,15 @@ std::size_t HttpResponse::SetBodyStreamed(
     fst_chunk_processed = true;
   }
 
-  const std::string_view terminating_chunk{fst_chunk_processed ? "\r\n0\r\n\r\n"
-                                                               : "0\r\n\r\n"};
-  sent_bytes +=
-      socket.WriteAll(terminating_chunk.data(), terminating_chunk.size(), {});
+  if (fst_chunk_processed) {
+    constexpr std::string_view terminating_chunk{"\r\n0\r\n\r\n"};
+    sent_bytes +=
+        socket.WriteAll(terminating_chunk.data(), terminating_chunk.size(), {});
+  } else {
+    constexpr std::string_view terminating_chunk{"0\r\n\r\n"};
+    sent_bytes +=
+        socket.WriteAll(terminating_chunk.data(), terminating_chunk.size(), {});
+  }
 
   // TODO: exceptions?
   body_stream_producer_.reset();

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -358,10 +358,6 @@ std::size_t HttpResponse::SetBodyStreamed(
   impl::OutputHeader(
       header, USERVER_NAMESPACE::http::headers::kTransferEncoding, "chunked");
 
-  if (is_body_forbidden) {
-    header.append(kCrlf);
-  }
-
   // send HTTP headers
   size_t sent_bytes = socket.WriteAll(header.data(), header.size(), {});
   header.clear();

--- a/core/src/server/http/http_response.cpp
+++ b/core/src/server/http/http_response.cpp
@@ -391,15 +391,10 @@ std::size_t HttpResponse::SetBodyStreamed(
     fst_chunk_processed = true;
   }
 
-  if (fst_chunk_processed) {
-    constexpr std::string_view terminating_chunk{"\r\n0\r\n\r\n"};
-    sent_bytes +=
-        socket.WriteAll(terminating_chunk.data(), terminating_chunk.size(), {});
-  } else {
-    constexpr std::string_view terminating_chunk{"0\r\n\r\n"};
-    sent_bytes +=
-        socket.WriteAll(terminating_chunk.data(), terminating_chunk.size(), {});
-  }
+  const std::string_view terminating_chunk{fst_chunk_processed ? "\r\n0\r\n\r\n"
+                                                               : "0\r\n\r\n"};
+  sent_bytes +=
+      socket.WriteAll(terminating_chunk.data(), terminating_chunk.size(), {});
 
   // TODO: exceptions?
   body_stream_producer_.reset();


### PR DESCRIPTION
Имеет смысл всегда добавлять kcrlf после хедеров, чтобы клиенты получили их раньше, чем первый потенциальный чанк body