### PR TITLE
add a dependency for arch-based distributions

### DIFF
--- a/scripts/docs/en/deps/arch.md
+++ b/scripts/docs/en/deps/arch.md
@@ -30,3 +30,4 @@ yaml-cpp
 zlib
 makepkg|cctz
 makepkg|libbacktrace-git
+boost-stacktrace-backtrace


### PR DESCRIPTION
In this commit, the 'boost-stacktrace-backtrace' dependency has been added, which is necessary for the correct assembly and operation of USERVER_FEATURE_STACKTRACE