### PR TITLE
Movable clients::http::Form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@
 .cores/
 /build*/
 /cmake-build-*/
+/cmake/cmake_generated/
 /docs/
+/third_party/
 CMakeLists.txt.user
 compile_commands.json
 tags

--- a/core/include/userver/clients/http/form.hpp
+++ b/core/include/userver/clients/http/form.hpp
@@ -17,9 +17,9 @@ class Form final {
   ~Form();
 
   Form(const Form&) = delete;
-  Form(Form&&) = delete;
+  Form(Form&&) noexcept;
   Form& operator=(const Form&) = delete;
-  Form& operator=(Form&&) = delete;
+  Form& operator=(Form&&) noexcept;
 
   void AddContent(std::string_view key, std::string_view content);
   void AddContent(std::string_view key, std::string_view content,
@@ -31,10 +31,11 @@ class Form final {
                  const std::shared_ptr<std::string>& buffer,
                  const std::string& content_type);
 
-  const std::shared_ptr<curl::form>& GetNative() const;
+  // @brief Call of this method will invalidate the form
+  std::unique_ptr<curl::form> GetNative();
 
  private:
-  std::shared_ptr<curl::form> impl_;
+  std::unique_ptr<curl::form> impl_;
 };
 
 }  // namespace clients::http

--- a/core/include/userver/clients/http/request.hpp
+++ b/core/include/userver/clients/http/request.hpp
@@ -121,8 +121,8 @@ class Request final {
   Request& post(const std::string& url, std::string data = {}) &;
   Request post(const std::string& url, std::string data = {}) &&;
   /// POST request with url and multipart/form-data
-  Request& post(const std::string& url, const Form& form) &;
-  Request post(const std::string& url, const Form& form) &&;
+  Request& post(const std::string& url, Form&& form) &;
+  Request post(const std::string& url, Form&& form) &&;
   /// PUT request
   Request& put() &;
   Request put() &&;
@@ -158,8 +158,8 @@ class Request final {
   Request& data(std::string data) &;
   Request data(std::string data) &&;
   /// form for POST request
-  Request& form(const Form& form) &;
-  Request form(const Form& form) &&;
+  Request& form(Form&& form) &;
+  Request form(Form&& form) &&;
   /// Headers for request as map
   Request& headers(const Headers& headers) &;
   Request headers(const Headers& headers) &&;

--- a/core/src/clients/http/form.cpp
+++ b/core/src/clients/http/form.cpp
@@ -6,8 +6,10 @@ USERVER_NAMESPACE_BEGIN
 
 namespace clients::http {
 
-Form::Form() : impl_(std::make_shared<curl::form>()) {}
+Form::Form() : impl_(std::make_unique<curl::form>()) {}
 Form::~Form() = default;
+Form::Form(Form&&) noexcept = default;
+Form& Form::operator=(Form&&) noexcept = default;
 
 void Form::AddContent(std::string_view key, std::string_view content) {
   impl_->add_content(key, content);
@@ -29,7 +31,7 @@ void Form::AddBuffer(const std::string& key, const std::string& file_name,
   impl_->add_buffer(key, file_name, buffer, content_type);
 }
 
-const std::shared_ptr<curl::form>& Form::GetNative() const { return impl_; }
+std::unique_ptr<curl::form> Form::GetNative() { return std::move(impl_); }
 
 }  // namespace clients::http
 

--- a/core/src/clients/http/request.cpp
+++ b/core/src/clients/http/request.cpp
@@ -375,14 +375,14 @@ Request Request::data(std::string data) && {
   return std::move(this->data(std::move(data)));
 }
 
-Request& Request::form(const Form& form) & {
+Request& Request::form(Form&& form) & {
   pimpl_->easy().set_http_post(form.GetNative());
   pimpl_->easy().add_header(kHeaderExpect, "",
                             curl::easy::EmptyHeaderAction::kDoNotSend);
   return *this;
 }
-Request Request::form(const Form& form) && {
-  return std::move(this->form(form));
+Request Request::form(Form&& form) && {
+  return std::move(this->form(std::forward<Form>(form)));
 }
 
 Request& Request::headers(const Headers& headers) & {
@@ -550,11 +550,11 @@ Request Request::head(const std::string& url) && {
   return std::move(this->head(url));
 }
 
-Request& Request::post(const std::string& url, const Form& form) & {
-  return this->url(url).form(form);
+Request& Request::post(const std::string& url, Form&& form) & {
+  return this->url(url).form(std::forward<Form>(form));
 }
-Request Request::post(const std::string& url, const Form& form) && {
-  return std::move(this->post(url, form));
+Request Request::post(const std::string& url, Form&& form) && {
+  return std::move(this->post(url, std::forward<Form>(form)));
 }
 
 Request& Request::post(const std::string& url, std::string data) & {

--- a/core/src/curl-ev/easy.cpp
+++ b/core/src/curl-ev/easy.cpp
@@ -356,13 +356,13 @@ void easy::set_post_fields(std::string&& post_fields, std::error_code& ec) {
         static_cast<native::curl_off_t>(post_fields_.length()), ec);
 }
 
-void easy::set_http_post(std::shared_ptr<form> form) {
+void easy::set_http_post(std::unique_ptr<form> form) {
   std::error_code ec;
   set_http_post(std::move(form), ec);
   throw_error(ec, "set_http_post");
 }
 
-void easy::set_http_post(std::shared_ptr<form> form, std::error_code& ec) {
+void easy::set_http_post(std::unique_ptr<form> form, std::error_code& ec) {
   form_ = std::move(form);
 
   if (form_) {

--- a/core/src/curl-ev/easy.hpp
+++ b/core/src/curl-ev/easy.hpp
@@ -443,8 +443,8 @@ class easy final : public std::enable_shared_from_this<easy> {
                         native::CURLOPT_POSTFIELDSIZE_LARGE,
                         native::curl_off_t);
 
-  void set_http_post(std::shared_ptr<form> form);
-  void set_http_post(std::shared_ptr<form> form, std::error_code& ec);
+  void set_http_post(std::unique_ptr<form> form);
+  void set_http_post(std::unique_ptr<form> form, std::error_code& ec);
 
   IMPLEMENT_CURL_OPTION_STRING(set_referer, native::CURLOPT_REFERER);
   IMPLEMENT_CURL_OPTION_STRING(set_user_agent, native::CURLOPT_USERAGENT);


### PR DESCRIPTION
closes #410

After merging this PR a banch of code might need to be refactored. I mean code of final users. However, this seems ok, as  the change is simple.