### PR TITLE
fix: disable lto by default in conan recipe

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -44,7 +44,7 @@ class UserverConan(ConanFile):
     default_options = {
         'shared': False,
         'fPIC': True,
-        'lto': True,
+        'lto': False,
         'with_jemalloc': True,
         'with_mongodb': True,
         'with_postgresql': True,


### PR DESCRIPTION
Disable lto by default

https://github.com/userver-framework/userver/issues/242

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/