### PR TITLE
feat crypto: support wolfssl library, help wanted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 /cmake-build-*/
 /cmake/cmake_generated/
 /docs/
-/third_party/
 CMakeLists.txt.user
 compile_commands.json
 tags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ else()
   set(JEMALLOC_DEFAULT ON)
 endif()
 option(USERVER_FEATURE_JEMALLOC "Enable linkage with jemalloc memory allocator" ${JEMALLOC_DEFAULT})
+option(USERVER_FEATURE_WOLFSSL "Enable usage of WolfSSL library instead of OpenSSL" OFF)
 
 option(USERVER_DISABLE_PHDR_CACHE "Disable caching of dl_phdr_info items, which interferes with dlopen" OFF)
 
@@ -171,6 +172,13 @@ option(USERVER_FEATURE_RABBITMQ "Provide asynchronous driver for RabbitMQ" "${US
 option(USERVER_FEATURE_MYSQL "Provide asynchronous driver for MariaDB/MySQL" "${USERVER_LIB_ENABLED_DEFAULT}")
 
 option(USERVER_FEATURE_UBOOST_CORO "Use vendored boost context instead of a system one" ON)
+
+if (USERVER_FEATURE_WOLFSSL)
+  include(cmake/SetupWolfSSL.cmake)
+  add_compile_definitions("OPENSSL_EXTRA=1")
+  add_compile_definitions("OPENSSL_ALL=1")
+  add_compile_definitions("USERVER_FEATURE_WOLFSSL=1")
+endif()
 
 if (USERVER_FEATURE_GRPC)
   include(cmake/SetupProtobuf.cmake)

--- a/cmake/SetupWolfSSL.cmake
+++ b/cmake/SetupWolfSSL.cmake
@@ -1,0 +1,45 @@
+if (TARGET wolfssl)
+    return()
+endif()
+
+option(
+    USERVER_DOWNLOAD_PACKAGE_WOLFSSL
+    "Download and setup WolfSSL if no WolfSSL of matching version was found"
+    ${USERVER_DOWNLOAD_PACKAGES}
+)
+
+if (NOT USERVER_FORCE_DOWNLOAD_PACKAGES)
+  if (USERVER_DOWNLOAD_PACKAGE_WOLFSSL)
+      find_package(wolfssl QUIET)
+  else()
+      find_package(wolfssl REQUIRED)
+  endif()
+
+  if (wolfssl_FOUND)
+      return()
+  endif()
+endif()
+
+include(DownloadUsingCPM)
+
+find_package(Patch REQUIRED)
+message(STATUS "${wolfssl_parent_directory}")
+message(STATUS "${CMAKE_CURRENT_LIST_DIR}")
+CPMAddPackage(
+    NAME WolfSSL
+    VERSION 5.7.0
+    GITHUB_REPOSITORY wolfSSL/wolfssl
+    GIT_TAG v5.7.0-stable
+    PATCH_COMMAND
+        "${Patch_EXECUTABLE}" --merge -p1 < "${CMAKE_CURRENT_LIST_DIR}/patches/wolfssl-0001-build-fixes.patch"
+    OPTIONS
+    "BUILD_SHARED_LIBS OFF"
+    "WOLFSSL_BUILD_TESTING OFF"
+    "CMAKE_C_FLAGS -Wall -Wextra -O2 -DOPENSSL_ALL -DOPENSSL_EXTRA"
+)
+
+#add_library(WolfSSL INTERFACE)
+#target_link_libraries(WolfSSL INTERFACE wolfssl)
+#get_filename_component(wolfssl_parent_directory "${WolfSSL_SOURCE_DIR}" DIRECTORY)
+#target_include_directories(WolfSSL INTERFACE "${wolfssl_parent_directory}/wolfssl")
+#target_compile_options(WolfSSL PRIVATE "-O2")

--- a/cmake/install/userver-universal-config.cmake
+++ b/cmake/install/userver-universal-config.cmake
@@ -14,7 +14,11 @@ find_package(Boost REQUIRED COMPONENTS
     stacktrace_backtrace
 )
 find_package(Iconv REQUIRED)
-find_package(OpenSSL REQUIRED)
+if(USERVER_FEATURE_WOLFSSL)
+  find_package(WolfSSL REQUIRED)
+else()
+  find_package(OpenSSL REQUIRED)
+endif()
 find_package(fmt "8.1.1" REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/..")

--- a/cmake/patches/wolfssl-0001-build-fixes.patch
+++ b/cmake/patches/wolfssl-0001-build-fixes.patch
@@ -1,0 +1,189 @@
+diff --git a/src/bio.c b/src/bio.c
+index 2dab43e..d26a03b 100644
+--- a/src/bio.c
++++ b/src/bio.c
+@@ -2336,7 +2336,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
+ 
+         if (b->ptr != NULL) {
+             int rc = wolfSSL_shutdown((WOLFSSL*)b->ptr);
+-            if (rc == SSL_SHUTDOWN_NOT_DONE) {
++            if (rc == WOLFSSL_SHUTDOWN_NOT_DONE) {
+                 /* In this case, call again to give us a chance to read the
+                  * close notify alert from the other end. */
+                 wolfSSL_shutdown((WOLFSSL*)b->ptr);
+diff --git a/src/pk.c b/src/pk.c
+index d7d32dd..c91aaa8 100644
+--- a/src/pk.c
++++ b/src/pk.c
+@@ -25,7 +25,7 @@
+ 
+ #include <wolfssl/wolfcrypt/settings.h>
+ 
+- #include <wolfssl/internal.h>
++#include <wolfssl/internal.h>
+ #ifndef WC_NO_RNG
+     #include <wolfssl/wolfcrypt/random.h>
+ #endif
+@@ -45,10 +45,12 @@
+     #endif
+ #else
+ 
+-#ifndef NO_RSA
++#ifdef OPENSSL_EXTRA
+     #include <wolfssl/wolfcrypt/rsa.h>
+ #endif
+ 
++#ifndef NO_RSA
++
+ #if defined(OPENSSL_EXTRA) && !defined(NO_BIO) && defined(WOLFSSL_KEY_GEN) && \
+     (defined(HAVE_ECC) || (!defined(NO_DSA) && !defined(HAVE_SELFTEST)))
+ /* Forward declaration for wolfSSL_PEM_write_bio_DSA_PUBKEY.
+@@ -57,6 +59,8 @@
+ static int pem_write_bio_pubkey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key);
+ #endif
+ 
++#endif
++
+ /*******************************************************************************
+  * COMMON FUNCTIONS
+  ******************************************************************************/
+@@ -137,7 +141,9 @@ static int pem_mem_to_der(const char* pem, int pemSz, wc_pem_password_cb* cb,
+ 
+     return ret;
+ }
+-#endif
++#endif /* 
++  (!NO_FILESYSTEM && (OPENSSL_EXTRA || OPENSSL_ALL)) || (!NO_BIO && OPENSSL_EXTRA)
++*/
+ 
+ #if !defined(NO_RSA) || !defined(WOLFCRYPT_ONLY)
+ #ifndef NO_BIO
+@@ -217,7 +223,7 @@ static int pem_read_file_key(XFILE fp, wc_pem_password_cb* cb, void* pass,
+     return ret;
+ }
+ #endif /* !NO_FILESYSTEM */
+-#endif
++#endif /* !NO_RSA || !WOLFCRYPT_ONLY */
+ 
+ #if defined(OPENSSL_EXTRA) && ((!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)) \
+     || !defined(WOLFCRYPT_ONLY))
+@@ -294,7 +300,7 @@ static int der_write_to_bio_as_pem(const unsigned char* der, int derSz,
+     XFREE(pem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+     return ret;
+ }
+-#endif
++#endif /* !NO_BIO */
+ #endif
+ 
+ #if (!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)) || \
+diff --git a/src/ssl.c b/src/ssl.c
+index ea66e42..8bede43 100644
+--- a/src/ssl.c
++++ b/src/ssl.c
+@@ -27200,7 +27200,7 @@ int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey)
+         /* ptr for WOLFSSL_EVP_PKEY struct is expected to be DER format */
+         return wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+                                        (const unsigned char*)pkey->pkey.ptr,
+-                                       pkey->pkey_sz, SSL_FILETYPE_ASN1);
++                                       pkey->pkey_sz, WOLFSSL_FILETYPE_ASN1);
+     }
+ 
+     WOLFSSL_MSG("wolfSSL private key not set");
+@@ -27861,7 +27861,7 @@ int wolfSSL_CTX_use_RSAPrivateKey(WOLFSSL_CTX* ctx, WOLFSSL_RSA* rsa)
+         return WOLFSSL_FAILURE;
+     }
+     ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, (const unsigned char*)maxDerBuf,
+-                                                    derSize, SSL_FILETYPE_ASN1);
++                                                    derSize, WOLFSSL_FILETYPE_ASN1);
+     if (ret != WOLFSSL_SUCCESS) {
+         WOLFSSL_MSG("wolfSSL_CTX_USE_PrivateKey_buffer() failure");
+         XFREE(maxDerBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+diff --git a/src/x509.c b/src/x509.c
+index eefa69c..4d5244c 100644
+--- a/src/x509.c
++++ b/src/x509.c
+@@ -37,6 +37,7 @@
+ #ifndef NO_CERTS
+ 
+ #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
++    #include <wolfssl/openssl/rsa.h>
+     #include <wolfssl/openssl/x509v3.h>
+ #endif
+ 
+@@ -11549,7 +11550,7 @@ err:
+ #ifndef NO_FILESYSTEM
+     WOLF_STACK_OF(WOLFSSL_X509_INFO)* wolfSSL_PEM_X509_INFO_read(
+             XFILE fp, WOLF_STACK_OF(WOLFSSL_X509_INFO)* sk,
+-            pem_password_cb* cb, void* u)
++            wc_pem_password_cb* cb, void* u)
+     {
+         WOLFSSL_BIO* fileBio = wolfSSL_BIO_new_fp(fp, BIO_NOCLOSE);
+         WOLF_STACK_OF(WOLFSSL_X509_INFO)* ret = NULL;
+diff --git a/wolfcrypt/src/evp.c b/wolfcrypt/src/evp.c
+index a365ff6..44dc74c 100644
+--- a/wolfcrypt/src/evp.c
++++ b/wolfcrypt/src/evp.c
+@@ -44,6 +44,7 @@
+ 
+ #include <wolfssl/openssl/ecdsa.h>
+ #include <wolfssl/openssl/evp.h>
++#include <wolfssl/openssl/rsa.h>
+ #include <wolfssl/openssl/kdf.h>
+ #include <wolfssl/wolfcrypt/wolfmath.h>
+ 
+@@ -8791,11 +8792,11 @@ WOLFSSL_DSA* wolfSSL_EVP_PKEY_get1_DSA(WOLFSSL_EVP_PKEY* key)
+ 
+     if (key->type == EVP_PKEY_DSA) {
+         if (wolfSSL_DSA_LoadDer(local, (const unsigned char*)key->pkey.ptr,
+-                    key->pkey_sz) != SSL_SUCCESS) {
++                    key->pkey_sz) != WOLFSSL_SUCCESS) {
+             /* now try public key */
+             if (wolfSSL_DSA_LoadDer_ex(local,
+                         (const unsigned char*)key->pkey.ptr, key->pkey_sz,
+-                        WOLFSSL_DSA_LOAD_PUBLIC) != SSL_SUCCESS) {
++                        WOLFSSL_DSA_LOAD_PUBLIC) != WOLFSSL_SUCCESS) {
+                 wolfSSL_DSA_free(local);
+                 local = NULL;
+             }
+@@ -8986,7 +8987,7 @@ WOLFSSL_DH* wolfSSL_EVP_PKEY_get1_DH(WOLFSSL_EVP_PKEY* key)
+                 return NULL;
+             }
+             if (wolfSSL_DH_LoadDer(local, (const unsigned char*)key->pkey.ptr,
+-                        key->pkey_sz) != SSL_SUCCESS) {
++                        key->pkey_sz) != WOLFSSL_SUCCESS) {
+                 wolfSSL_DH_free(local);
+                 WOLFSSL_MSG("Error wolfSSL_DH_LoadDer");
+                 local = NULL;
+diff --git a/wolfssl/openssl/cms.h b/wolfssl/openssl/cms.h
+index 5355c61..9e4585b 100644
+--- a/wolfssl/openssl/cms.h
++++ b/wolfssl/openssl/cms.h
+@@ -22,5 +22,4 @@
+ #ifndef WOLFSSL_CMS_H_
+ #define WOLFSSL_CMS_H_
+ 
+-
+ #endif /* WOLFSSL_CMS_H_ */
+diff --git a/wolfssl/ssl.h b/wolfssl/ssl.h
+index 804ec44..0e28177 100644
+--- a/wolfssl/ssl.h
++++ b/wolfssl/ssl.h
+@@ -40,6 +40,9 @@
+ 
+ /* For the types */
+ #include <wolfssl/openssl/compat_types.h>
++#ifdef OPENSSL_EXTRA
++#include <wolfssl/openssl/bn.h>
++#endif
+ 
+ #ifdef HAVE_WOLF_EVENT
+     #include <wolfssl/wolfcrypt/wolfevent.h>
+@@ -4481,7 +4484,7 @@ WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
+ #ifndef NO_FILESYSTEM
+ WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_INFO)* wolfSSL_PEM_X509_INFO_read(
+         XFILE fp, WOLF_STACK_OF(WOLFSSL_X509_INFO)* sk,
+-        pem_password_cb* cb, void* u);
++        wc_pem_password_cb* cb, void* u);
+ #endif
+ WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_INFO)* wolfSSL_PEM_X509_INFO_read_bio(
+         WOLFSSL_BIO* bio, WOLF_STACK_OF(WOLFSSL_X509_INFO)* sk,

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -58,7 +58,11 @@ find_package(Boost REQUIRED COMPONENTS
 find_package_required(ZLIB "zlib1g-dev")
 
 find_package(Iconv REQUIRED)
-find_package_required(OpenSSL "libssl-dev")
+if (USERVER_FEATURE_WOLFSSL)
+  find_package_required(WolfSSL "wolfssl-dev")
+else()
+  find_package_required(OpenSSL "libssl-dev")
+endif()
 
 if (USERVER_CONAN)
     find_package(c-ares REQUIRED)
@@ -108,10 +112,21 @@ target_link_libraries(${PROJECT_NAME}
     Boost::iostreams
     Boost::regex
     Iconv::Iconv
-    OpenSSL::Crypto
-    OpenSSL::SSL
     ZLIB::ZLIB
 )
+
+if (USERVER_FEATURE_WOLFSSL)
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      wolfssl
+  )
+else()
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      OpenSSL::Crypto
+      OpenSSL::SSL
+  )
+endif()
 
 add_subdirectory(${USERVER_THIRD_PARTY_DIRS}/llhttp llhttp)
 

--- a/external-deps/WolfSSL.yaml
+++ b/external-deps/WolfSSL.yaml
@@ -1,0 +1,39 @@
+common-name: WolfSSL
+partials:
+  - name: Crypto
+    package-name: WolfSSL
+
+    debian-names:
+      - wolfssl-dev
+    formula-name: wolfssl
+    rpm-names:
+      - wolfssl-devel
+    pacman-names:
+      - wolfssl
+    pkg-config-names:
+      - wolfssl
+
+    libraries:
+        enabled: false
+
+    includes:
+        enabled: false
+  - name: SSL
+    package-name: WolfSSL
+
+    debian-names:
+      - wolfssl-dev
+    formula-name: wolfssl
+    rpm-names:
+      - wolfssl-devel
+    pacman-names:
+      - wolfssl
+    pkg-config-names:
+      - wolfssl
+
+    libraries:
+        enabled: false
+
+    includes:
+        enabled: false
+

--- a/universal/CMakeLists.txt
+++ b/universal/CMakeLists.txt
@@ -53,7 +53,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(Iconv REQUIRED)
-find_package_required(OpenSSL "libssl-dev")
+if (USERVER_FEATURE_WOLFSSL)
+  find_package_required(WolfSSL "wolfssl")
+else()
+  find_package_required(OpenSSL "libssl-dev")
+endif()
 
 if (USERVER_CONAN)
   find_package(cryptopp REQUIRED)
@@ -232,9 +236,20 @@ target_link_libraries(${PROJECT_NAME}
     Boost::filesystem
     Boost::program_options
     Boost::regex
-    OpenSSL::Crypto
-    OpenSSL::SSL
 )
+
+if (USERVER_FEATURE_WOLFSSL)
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      wolfssl
+  )
+else()
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      OpenSSL::Crypto
+      OpenSSL::SSL
+  )
+endif()
 
 if (USERVER_CONAN)
   target_link_libraries(${PROJECT_NAME}

--- a/universal/include/userver/crypto/basic_types.hpp
+++ b/universal/include/userver/crypto/basic_types.hpp
@@ -7,18 +7,27 @@
 
 #include <userver/crypto/exception.hpp>
 
+#ifdef USERVER_FEATURE_WOLFSSL
+#include <wolfssl/openssl/evp.h>
+#else
 /// @cond
 struct evp_pkey_st;
 struct x509_st;
 /// @endcond
+#endif
 
 USERVER_NAMESPACE_BEGIN
 
 namespace crypto {
 
 /// @cond
+#ifdef USERVER_FEATURE_WOLFSSL
+using EVP_PKEY = WOLFSSL_EVP_PKEY;
+using X509 = WOLFSSL_X509;
+#else
 using EVP_PKEY = struct evp_pkey_st;
 using X509 = struct x509_st;
+#endif
 /// @endcond
 
 /// SHA digest size in bits

--- a/universal/src/crypto/certificate.cpp
+++ b/universal/src/crypto/certificate.cpp
@@ -36,23 +36,10 @@ std::optional<std::string> Certificate::GetPemString() const {
 
   std::string result;
   result.resize(BIO_pending(membio.get()));
-#ifdef USERVER_FEATURE_WOLFSSL
-#warning "BIO_read_ex does not supported by wolfSSL"
   if (1 != BIO_read(membio.get(), result.data(), result.size())) {
     throw SerializationError(
         FormatSslError("Error transferring PEM to string"));
   }
-#else
-  size_t readbytes = 0;
-  if (1 !=
-      BIO_read_ex(membio.get(), result.data(), result.size(), &readbytes)) {
-    throw SerializationError(
-        FormatSslError("Error transferring PEM to string"));
-  }
-  if (readbytes != result.size()) {
-    throw SerializationError("Error transferring PEM to string");
-  }
-#endif
   return result;
 }
 

--- a/universal/src/crypto/helpers.hpp
+++ b/universal/src/crypto/helpers.hpp
@@ -4,8 +4,13 @@
 #include <string>
 #include <string_view>
 
+#ifdef USERVER_FEATURE_WOLFSSL
+#include <wolfssl/openssl/bio.h>
+#include <wolfssl/openssl/evp.h>
+#else
 #include <openssl/bio.h>
 #include <openssl/evp.h>
+#endif
 
 #include <userver/crypto/basic_types.hpp>
 #include <userver/crypto/hash.hpp>

--- a/universal/src/crypto/private_key.cpp
+++ b/universal/src/crypto/private_key.cpp
@@ -48,23 +48,10 @@ std::optional<std::string> GetPemStringImpl(EVP_PKEY* key,
 
   std::string result;
   result.resize(BIO_pending(membio.get()));
-#ifdef USERVER_FEATURE_WOLFSSL
-#warning "BIO_read_ex does not supported by wolfSSL"
   if (1 != BIO_read(membio.get(), result.data(), result.size())) {
     throw SerializationError(
         FormatSslError("Error transferring PEM to string"));
   }
-#else
-  size_t readbytes = 0;
-  if (1 !=
-      BIO_read_ex(membio.get(), result.data(), result.size(), &readbytes)) {
-    throw SerializationError(
-        FormatSslError("Error transferring PEM to string"));
-  }
-  if (readbytes != result.size()) {
-    throw SerializationError("Error transferring PEM to string");
-  }
-#endif
   return result;
 }
 

--- a/universal/src/crypto/signers.cpp
+++ b/universal/src/crypto/signers.cpp
@@ -3,10 +3,19 @@
 #include <climits>
 
 #include <cryptopp/dsa.h>
+#ifdef USERVER_FEATURE_WOLFSSL
+#include <wolfssl/openssl/bio.h>
+#include <wolfssl/openssl/cms.h>
+#include <wolfssl/openssl/crypto.h>
+#include <wolfssl/openssl/evp.h>
+#include <wolfssl/openssl/rsa.h>
+#include <wolfssl/openssl/ssl.h>
+#else
 #include <openssl/cms.h>
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
+#endif
 
 #include <crypto/helpers.hpp>
 #include <crypto/openssl.hpp>

--- a/universal/src/crypto/verifiers.cpp
+++ b/universal/src/crypto/verifiers.cpp
@@ -2,6 +2,16 @@
 
 #include <cryptopp/dsa.h>
 
+#ifdef USERVER_FEATURE_WOLFSSL
+#include <wolfssl/openssl/pem.h>
+// keep these two headers in this order
+#include <wolfssl/openssl/cms.h>
+
+#include <wolfssl/openssl/crypto.h>
+#include <wolfssl/openssl/evp.h>
+#include <wolfssl/openssl/stack.h>
+#include <wolfssl/openssl/x509.h>
+#else
 #include <openssl/pem.h>
 // keep these two headers in this order
 #include <openssl/cms.h>
@@ -9,6 +19,7 @@
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>
+#endif
 
 #include <crypto/helpers.hpp>
 #include <crypto/openssl.hpp>


### PR DESCRIPTION
closes #498

_Currently, this PR won't build by the reason described below._

This PR provides minimal changes which replaces internal usage of openssl. It does not checked for other libraries used in userver. Some openssl features does not implemented by wolfssl itself. _(has found some typos during investigation, see https://github.com/wolfSSL/wolfssl/pull/7423)._


BTW, wolfssl v5.7.0-stable requires few small patches which also included into the PR.

Finally, "short path" to support wolfssl is not available, because of the lib does not implements some of used functions. It also does not provide `ENGINE_*`, but have not been tried with wolfengine lib yet.
Worst thing is that wolfssl does not provides any [CMS_* analogue](https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/openssl/cms.h) to soft migrate onto this library, so, need some code branching using available functions in wolfssl.

PR is building with commands:
```sh
mkdir -p build_debug
cd build_debug

cmake \
  -Wdev \
  -DCMAKE_CXX_COMPILER=clang++-17 \
  -DUSERVER_FEATURE_WOLFSSL=ON \
  -DUSERVER_DOWNLOAD_PACKAGE_WOLFSSL=ON \
  -DUSERVER_FEATURE_GRPC=OFF \
  -DUSERVER_FEATURE_POSTGRESQL=OFF \
  -DUSERVER_FEATURE_MYSQL=OFF \
  -DUSERVER_FEATURE_STACKTRACE=OFF \
  -DUSERVER_FEATURE_CLICKHOUSE=OFF \
  -DUSERVER_USE_LD=lld \
  ..
```

Patch might be re-applied with command:
```(test -d build_debug/_deps/wolfssl-src && cd build_debug/_deps/wolfssl-src && git checkout -- .)```

Current errors will be attached in comments to this PR.
Help needed with re-implementation of current crypto's features using wolfssl.

_In my opinion, wolfssl is not production ready yet because of a lot of issues https://github.com/wolfSSL/wolfssl/labels/bug_