### PR TITLE
fix docs: generic telegram links

### DIFF
--- a/scripts/docs/en/landing.md
+++ b/scripts/docs/en/landing.md
@@ -28,7 +28,7 @@
               documentation
             </a>
             <a
-              class="button button_outline"
+              class="button button_outline generic_tg_link"
               title="Go to the userver Telegram"
               href="https://t.me/userver_en"
             >

--- a/scripts/docs/footer.html
+++ b/scripts/docs/footer.html
@@ -31,7 +31,7 @@ $generatedby <a href="https://www.doxygen.org/index.html">Doxygen</a> $doxygenve
           <a href="https://github.com/userver-framework/" rel="noopener" target="_blank" class="titlelink">
               <img src="$relpath^github_logo.svg" alt="Github" class="gh-logo"/> 
           </a>
-          <a href="https://t.me/userver_en" rel="noopener" id='telegram_channel' target="_blank" class="titlelink">
+          <a href="https://t.me/userver_en" rel="noopener" id='telegram_channel' target="_blank" class="titlelink generic_tg_link">
               <img src="$relpath^telegram_logo.svg" alt="Telegram"/>
           </a>
       `

--- a/scripts/docs/scripts/telegramLanguage.js
+++ b/scripts/docs/scripts/telegramLanguage.js
@@ -7,7 +7,7 @@ function changeTelegramChannelLanguageForRussianSpeakingUser() {
 }
 
 function getAllTelegramLinkElements() {
-  return Array.from(document.querySelectorAll("a[href='https://t.me/userver_en']"));
+  return Array.from(document.querySelectorAll("a.generic_tg_link"));
 }
 
 function isBrowserUseRussianLanguage() {

--- a/scripts/docs/scripts/telegramLanguage.js
+++ b/scripts/docs/scripts/telegramLanguage.js
@@ -3,10 +3,10 @@ function changeTelegramChannelLanguageForRussianSpeakingUser() {
     return;
   }
 
-  getAllTelegramLinkElements().map(element => element.href = "https://t.me/userver_ru");
+  getGenericTelegramLinkElements().map(element => element.href = "https://t.me/userver_ru");
 }
 
-function getAllTelegramLinkElements() {
+function getGenericTelegramLinkElements() {
   return Array.from(document.querySelectorAll("a.generic_tg_link"));
 }
 


### PR DESCRIPTION
For Russian-speaking users [docs/scripts/telegramLanguage.js](https://github.com/userver-framework/userver/blob/develop/scripts/docs/scripts/telegramLanguage.js#L6) replaces all links from the English-speaking telegram support chat to the Russian-speaking one. For this reason English-speaking links (e.g. on the [main page](https://userver.tech/de/d6a/md_en_2index.html) and [Roadmap and Changelog](https://userver.tech/da/d9a/md_en_2userver_2roadmap__and__changelog.html)) lead to the Russian-speaking chat. This PR solves this problem.