### PR TITLE
fix docs: incorrect @snippet links

### DIFF
--- a/core/src/components/common_server_component_list_test.cpp
+++ b/core/src/components/common_server_component_list_test.cpp
@@ -173,7 +173,6 @@ components_manager:
         method: GET,PUT
         task_processor: monitor-task-processor
 # /// [Sample handler log level component config]
-# /// [Sample handler inspect requests component config]
 # yaml
     handler-on-log-rotate:
         path: /service/on-log-rotate/

--- a/core/src/storages/secdist/secdist_test.cpp
+++ b/core/src/storages/secdist/secdist_test.cpp
@@ -95,7 +95,6 @@ TEST(SecdistYamlConfig, Sample) {
        std::nullopt}};
   storages::secdist::SecdistConfig secdist_config{{&provider}};
 
-  /// [Secdist Usage Sample - SecdistConfig]
   const auto& user_passwords = secdist_config.Get<UserPasswords>();
 
   const auto password = UserPasswords::Password{"drowssap"};
@@ -103,7 +102,6 @@ TEST(SecdistYamlConfig, Sample) {
   EXPECT_TRUE(user_passwords.IsMatching("username", password));
   EXPECT_FALSE(user_passwords.IsMatching("username2", password));
   EXPECT_TRUE(user_passwords.IsMatching("another username", another_password));
-  /// [Secdist Usage Sample - SecdistConfig]
 }
 
 UTEST(SecdistConfig, EnvironmentVariable) {

--- a/samples/digest_auth_service/static_config.yaml
+++ b/samples/digest_auth_service/static_config.yaml
@@ -15,7 +15,6 @@ components_manager:
             domains:
               - /v1/hello
             nonce-ttl: 1000s
-        # /// [digest config]
         auth-digest-checker-settings-proxy:
             algorithm: MD5
             qops:

--- a/universal/include/userver/utils/datetime.hpp
+++ b/universal/include/userver/utils/datetime.hpp
@@ -17,7 +17,7 @@ USERVER_NAMESPACE_BEGIN
 namespace utils::datetime {
 /// @snippet utils/datetime/from_string_saturating_test.cpp  kRfc3339Format
 inline const std::string kRfc3339Format = "%Y-%m-%dT%H:%M:%E*S%Ez";
-/// @snippet utils/datetime/datetime_test.cpp  kTaximeterFormat
+/// @snippet utils/datetime/from_string_saturating_test.cpp  kTaximeterFormat
 inline const std::string kTaximeterFormat = "%Y-%m-%dT%H:%M:%E6SZ";
 inline constexpr std::time_t kStartOfTheEpoch = 0;
 /// @snippet utils/datetime/datetime_test.cpp  kDefaultDriverTimezone
@@ -77,9 +77,13 @@ bool IsTimeBetween(int hour, int min, int hour_from, int min_from, int hour_to,
                    int min_to, bool include_time_to = false) noexcept;
 
 /// @brief Returns time in a string of specified format
+///
 /// @throws utils::datetime::TimezoneLookupError
+///
 /// Example:
+///
 /// @snippet utils/datetime/datetime_test.cpp  Timestring C time example
+///
 /// @see kRfc3339Format, kTaximeterFormat, kStartOfTheEpoch,
 /// kDefaultDriverTimezone, kDefaultTimezone, kDefaultFormat, kIsoFormat
 std::string Timestring(std::time_t timestamp,
@@ -94,7 +98,9 @@ std::string LocalTimezoneTimestring(std::time_t timestamp,
 
 /// @brief Returns time in a string of specified format
 /// @throws utils::datetime::TimezoneLookupError
+///
 /// Example:
+///
 /// @snippet utils/datetime/datetime_test.cpp Timestring example
 /// @see kRfc3339Format, kTaximeterFormat, kStartOfTheEpoch,
 /// kDefaultDriverTimezone, kDefaultTimezone, kDefaultFormat, kIsoFormat
@@ -111,7 +117,9 @@ std::string LocalTimezoneTimestring(std::chrono::system_clock::time_point tp,
 /// @brief Extracts time point from a string of a specified format
 /// @throws utils::datetime::DateParseError
 /// @throws utils::datetime::TimezoneLookupError
+///
 /// Example:
+///
 /// @snippet utils/datetime/datetime_test.cpp  Stringtime example
 /// @see kRfc3339Format, kTaximeterFormat, kStartOfTheEpoch,
 /// kDefaultDriverTimezone, kDefaultTimezone, kDefaultFormat, kIsoFormat
@@ -130,7 +138,9 @@ std::chrono::system_clock::time_point LocalTimezoneStringtime(
 /// @brief Extracts time point from a string, guessing the format
 /// @throws utils::datetime::DateParseError
 /// @throws utils::datetime::TimezoneLookupError
+///
 /// Example:
+///
 /// @snippet utils/datetime/datetime_test.cpp  GuessStringtime example
 std::chrono::system_clock::time_point GuessStringtime(
     const std::string& timestamp, const std::string& timezone);
@@ -141,8 +151,10 @@ std::chrono::system_clock::time_point GuessLocalTimezoneStringtime(
     const std::string& timestamp);
 
 /// @brief Returns optional time in a string of specified format
+///
 /// Example:
-/// @snippet utils/datetime/datetime_test.cpp OptionalTimestring example
+///
+/// @snippet utils/datetime/datetime_test.cpp OptionalStringtime example
 /// @see kRfc3339Format, kTaximeterFormat, kStartOfTheEpoch,
 /// kDefaultDriverTimezone, kDefaultTimezone, kDefaultFormat, kIsoFormat
 std::optional<std::chrono::system_clock::time_point> OptionalStringtime(
@@ -151,7 +163,9 @@ std::optional<std::chrono::system_clock::time_point> OptionalStringtime(
     const std::string& format = kDefaultFormat);
 
 /// @brief Converts time point to std::time_t
+///
 /// Example:
+///
 /// @snippet utils/datetime/datetime_test.cpp  Timestring C time example
 std::time_t Timestamp(std::chrono::system_clock::time_point tp) noexcept;
 
@@ -166,8 +180,10 @@ std::uint32_t ParseDayTime(const std::string& str);
 /// @brief Converts absolute time in std::chrono::system_clock::time_point to
 /// a civil time of a particular timezone.
 /// @throws utils::datetime::TimezoneLookupError
+///
 /// Example:
-/// @snippet utils/datetime/datetime_test.cpp  [Localize example]
+///
+/// @snippet utils/datetime/datetime_test.cpp  Localize example
 cctz::civil_second Localize(const std::chrono::system_clock::time_point& tp,
                             const std::string& timezone);
 
@@ -178,8 +194,10 @@ cctz::civil_second LocalTimezoneLocalize(
 
 /// @brief Converts a civil time in a specified timezone into an absolute time.
 /// @throws utils::datetime::TimezoneLookupError
+///
 /// Example:
-/// @snippet utils/datetime/datetime_test.cpp  [Localize example]
+///
+/// @snippet utils/datetime/datetime_test.cpp  Localize example
 std::time_t Unlocalize(const cctz::civil_second& local_tp,
                        const std::string& timezone);
 
@@ -193,7 +211,9 @@ std::string TimestampToString(std::time_t timestamp);
 /// @brief Convert time_point to DotNet ticks
 /// @param time point day time
 /// @return number of 100nanosec intervals between current date and 01/01/0001
+///
 /// Example:
+///
 /// @snippet utils/datetime/datetime_test.cpp  TimePointToTicks example
 std::int64_t TimePointToTicks(
     const std::chrono::system_clock::time_point& tp) noexcept;

--- a/universal/include/userver/utils/datetime/from_string_saturating.hpp
+++ b/universal/include/userver/utils/datetime/from_string_saturating.hpp
@@ -15,7 +15,7 @@ namespace utils::datetime {
 /// std::chrono::system_clock::time_point in UTC timezone and saturates on
 /// overflow
 /// Example:
-/// @snippet utils/datetime/from_string_saturating_test.cpp FromStringSaturation
+/// @snippet utils/datetime/from_string_saturating_test.cpp FromStringSaturation example
 std::chrono::system_clock::time_point FromRfc3339StringSaturating(
     const std::string& timestring);
 

--- a/universal/include/userver/utils/text_light.hpp
+++ b/universal/include/userver/utils/text_light.hpp
@@ -21,7 +21,7 @@ std::string Trim(std::string&& str);
 
 /// Split string by separators
 ///
-/// @snippet utils/text_test.cpp  SplitMultiple
+/// @snippet utils/text_light_test.cpp  SplitMultiple
 std::vector<std::string> Split(std::string_view str,
                                std::string_view separators);
 
@@ -29,7 +29,7 @@ std::vector<std::string> Split(std::string_view str,
 ///
 /// @warning Initial `str` should outlive the result of the function
 ///
-/// @snippet utils/text_test.cpp  SplitStringViewMultiple
+/// @snippet utils/text_light_test.cpp  SplitStringViewMultiple
 std::vector<std::string_view> SplitIntoStringViewVector(
     std::string_view str, std::string_view separators);
 


### PR DESCRIPTION
This PR fixes broken doxygen @<span></span>snippet links:
- In some files the [block_id] markers appear more than twice.
- Some @<span></span>snippet commands refer to the wrong [block_id] or \<file-name\>.
Because of this some links in the documentation appear as an empty block (e.g. one of the [SecdistConfig example usage](https://userver.tech/de/d15/classstorages_1_1secdist_1_1SecdistConfig.html) code blocks).