### PR TITLE
websocket_handler: Add handler to process non wesocket request

### DIFF
--- a/core/include/userver/server/websocket/websocket_handler.hpp
+++ b/core/include/userver/server/websocket/websocket_handler.hpp
@@ -57,6 +57,15 @@ class WebsocketHandlerBase : public server::handlers::HttpHandlerBase {
   static yaml_config::Schema GetStaticConfigSchema();
   /// @endcond
 
+  /// @brief If \a request isn't a websocket request the function handles a request.
+  virtual void HandleNonWebsocketRequest(
+      [[maybe_unused]] const server::http::HttpRequest& request,
+      [[maybe_unused]] server::request::RequestContext& context) const {
+      LOG_WARNING()
+          << "Not a GET 'Upgrade: websocket' and 'Connection: Upgrade' request";
+      throw server::handlers::ClientError();
+      }
+
  private:
   std::string HandleRequestThrow(
       const server::http::HttpRequest& request,

--- a/core/src/server/websocket/websocket_handler.cpp
+++ b/core/src/server/websocket/websocket_handler.cpp
@@ -37,9 +37,7 @@ std::string WebsocketHandlerBase::HandleRequestThrow(
           "websocket" ||
       request.GetHeader(USERVER_NAMESPACE::http::headers::kConnection) !=
           "Upgrade") {
-    LOG_WARNING()
-        << "Not a GET 'Upgrade: websocket' and 'Connection: Upgrade' request";
-    throw server::handlers::ClientError();
+    HandleNonWebsocketRequest(request, context);
   }
 
   const std::string& secWebsocketKey =


### PR DESCRIPTION
User's code can overload  HandleNonWebsocketRequest to change behavior of HandleRequestThrow if request isn't websocket request.

Relates userver-framework/userver#378