### PR TITLE
fix grpc: specify namespace only for non-global packages to avoid ambiguities in usrv proto plugin

### DIFF
--- a/grpc/CMakeLists.txt
+++ b/grpc/CMakeLists.txt
@@ -142,6 +142,7 @@ if (USERVER_IS_THE_ROOT_PROJECT)
       # As well as paths relative to CMAKE_CURRENT_SOURCE_DIR
       tests/messages.proto
       tests/same_service_and_method_name.proto
+      tests/global_package.proto
       INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/proto
   )
 

--- a/grpc/CMakeLists.txt
+++ b/grpc/CMakeLists.txt
@@ -143,6 +143,7 @@ if (USERVER_IS_THE_ROOT_PROJECT)
       tests/messages.proto
       tests/same_service_and_method_name.proto
       tests/global_package.proto
+      tests/repeating_word_in_package_name.proto
       INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/proto
   )
 

--- a/grpc/proto/tests/global_package.proto
+++ b/grpc/proto/tests/global_package.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+message Empty {
+}
+
+service ServiceName {
+  rpc MethodName(Empty) returns(Empty) {}
+}

--- a/grpc/proto/tests/repeating_word_in_package_name.proto
+++ b/grpc/proto/tests/repeating_word_in_package_name.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package ugrpc.proto.ugrpc;
+
+message Empty {
+}
+
+service ServiceName {
+  rpc MethodName(Empty) returns(Empty) {}
+}

--- a/scripts/grpc/templates/client.usrv.cpp.jinja
+++ b/scripts/grpc/templates/client.usrv.cpp.jinja
@@ -44,7 +44,7 @@ constexpr const auto& k{{service.name}}ClientQosConfig =
 {{service.name}}Client::{{service.name}}Client(
     USERVER_NAMESPACE::ugrpc::client::impl::ClientParams&& client_params)
     : impl_(std::move(client_params), GetMetadata(),
-            std::in_place_type<{{proto.namespace}}::{{service.name}}>) {
+            std::in_place_type<{{utils.namespace_with_colons(proto.namespace)}}::{{service.name}}>) {
     }
   {% for method in service.method %}
   {% set method_id = loop.index0 %}
@@ -61,8 +61,8 @@ constexpr const auto& k{{service.name}}ClientQosConfig =
         USERVER_NAMESPACE::ugrpc::client::impl::CreateCallParams(
           impl_, {{method_id}}, std::move(context), k{{service.name}}ClientQosConfig, qos
         ),
-        impl_.NextStub<{{proto.namespace}}::{{service.name}}>(),
-        &{{proto.namespace}}::{{service.name}}::Stub::PrepareAsync{{method.name}},
+        impl_.NextStub<{{utils.namespace_with_colons(proto.namespace)}}::{{service.name}}>(),
+        &{{utils.namespace_with_colons(proto.namespace)}}::{{service.name}}::Stub::PrepareAsync{{method.name}},
         {% if method.client_streaming %}
       };
         {% else %}
@@ -75,7 +75,7 @@ constexpr const auto& k{{service.name}}ClientQosConfig =
 USERVER_NAMESPACE::ugrpc::impl::StaticServiceMetadata
 {{ service.name }}Client::GetMetadata() {
   return USERVER_NAMESPACE::ugrpc::impl::MakeStaticServiceMetadata<
-      {{proto.namespace}}::{{service.name}}>(
+    {{utils.namespace_with_colons(proto.namespace)}}::{{service.name}}>(
       k{{service.name}}MethodNames);
 }
 {% endfor %}

--- a/scripts/grpc/templates/service.usrv.cpp.jinja
+++ b/scripts/grpc/templates/service.usrv.cpp.jinja
@@ -41,7 +41,7 @@ std::unique_ptr<USERVER_NAMESPACE::ugrpc::server::impl::ServiceWorker>
 {{service.name}}Base::MakeWorker(
     USERVER_NAMESPACE::ugrpc::server::impl::ServiceSettings&& settings) {
   return USERVER_NAMESPACE::ugrpc::server::impl::MakeServiceWorker<
-      {{proto.namespace}}::{{service.name}}>(
+      {{utils.namespace_with_colons(proto.namespace)}}::{{service.name}}>(
       std::move(settings), k{{service.name}}MethodNames, *this,
       {% for method in service.method %}
       &{{service.name}}Base::{{method.name}}{{ "," if not loop.last else ");" }}

--- a/scripts/grpc/templates/utils.inc.jinja
+++ b/scripts/grpc/templates/utils.inc.jinja
@@ -22,3 +22,7 @@ namespace {{ namespace }} {
 #pragma clang diagnostic pop
 #endif
 {%- endmacro %}
+
+{% macro namespace_with_colons(namespace) %}
+{% if namespace %}::{{namespace}}{% endif %}
+{%- endmacro %}


### PR DESCRIPTION
Related: #625 
Also improve unit tests coverage. 