### PR TITLE
fix docs: correct mobile header view

### DIFF
--- a/scripts/docs/customdoxygen.css
+++ b/scripts/docs/customdoxygen.css
@@ -474,7 +474,7 @@ a.titlelink:hover {
 
 /* Burger menu */
 .main-menu-btn {
-  margin-left: 7px;
+  margin-left: 5px;
 }
 
 .main-menu-btn-icon,
@@ -635,6 +635,19 @@ doxygen-awesome-dark-mode-toggle {
     transform: translate(-54px, 20px) !important;
   }
 
+  #links {
+    margin-left: 5px;
+  }
+
+  #telegram_channel {
+    display: none;
+  }
+
+  #github_header {
+    padding: 0;
+    order: 3;
+  }
+
   #navbar-main-menu {
     display: none;
     position: absolute;
@@ -689,8 +702,7 @@ doxygen-awesome-dark-mode-toggle {
   }
 
   .sm.sm-dox>li {
-    padding: 5px 70px;
-    /* TODO: adaptive width */
+    padding: 5px;
   }
 
   .sm.sm-dox>li:first-child {
@@ -702,13 +714,9 @@ doxygen-awesome-dark-mode-toggle {
   }
 
   .main-menu-btn {
-    order: 3;
+    order: 4;
     position: relative;
     top: 0px;
-  }
-
-  #links {
-    display: none;
   }
 }
 
@@ -753,8 +761,7 @@ doxygen-awesome-dark-mode-toggle {
   }
 
   .sm.sm-dox>li {
-    padding: 5px 70px;
-    /* TODO: adaptive width */
+    padding: 5px;
   }
 
   .sm.sm-dox>li:first-child {
@@ -823,17 +830,11 @@ doxygen-awesome-dark-mode-toggle {
   }
 
   .main-menu-btn {
-    position: relative;
-    top: 0px;
-  }
-
-  #links {
-    display: none;
+    width: 45px;
   }
 
   #MSearchCloseImg {
-    width: 34px;
-    transform: translate(-2px, -6px);
+    width: 16px;
   }
 }
 

--- a/scripts/docs/footer.html
+++ b/scripts/docs/footer.html
@@ -28,8 +28,8 @@ $generatedby <a href="https://www.doxygen.org/index.html">Doxygen</a> $doxygenve
       links.id = 'links';
 
       links.innerHTML = `
-          <a href="https://github.com/userver-framework/" rel="noopener" target="_blank" class="titlelink">
-              <img src="$relpath^github_logo.svg" alt="Github" class="gh-logo"/> 
+          <a href="https://github.com/userver-framework/" id='github_header' rel="noopener" target="_blank" class="titlelink">
+              <img src="$relpath^github_logo.svg" alt="Github" class="gh-logo"/>
           </a>
           <a href="https://t.me/userver_en" rel="noopener" id='telegram_channel' target="_blank" class="titlelink generic_tg_link">
               <img src="$relpath^telegram_logo.svg" alt="Telegram"/>


### PR DESCRIPTION
Fix [the appearance of the burger menu in the mobile version of the documentation site](https://github.com/userver-framework/userver/issues/633):
* fix burger menu style
* add github link in mobile version

<p align="center">
  <img src="https://github.com/userver-framework/userver/assets/29949782/a6ed46c6-b03f-4363-99da-db829d6693d3" height="600px" />
</p>