### PR TITLE
feat logs: fix for issue#676 separate otlp config for logs and traces

### DIFF
--- a/otlp/src/otlp/logs/component.cpp
+++ b/otlp/src/otlp/logs/component.cpp
@@ -74,7 +74,7 @@ LoggerComponent::LoggerComponent(const components::ComponentConfig& config,
   } else {
     try {
       default_logger = logging_component.GetLogger("default");
-    } catch (const std::exception&) {
+    } catch (const std::runtime_error&) {
       default_logger = nullptr;
     }
     if (!default_logger) {

--- a/otlp/src/otlp/logs/logger.cpp
+++ b/otlp/src/otlp/logs/logger.cpp
@@ -64,6 +64,11 @@ bool Logger::DoShouldLog(logging::Level level) const noexcept {
 }
 
 void Logger::Log(logging::Level level, std::string_view msg) {
+  if (def_logger_) {
+    def_logger_->Log(level, msg);
+    return;
+  }
+
   utils::encoding::TskvParser parser{msg};
 
   ::opentelemetry::proto::logs::v1::LogRecord log_record;
@@ -211,7 +216,7 @@ void Logger::SendingLoop(Queue::Consumer& consumer, LogClient& log_client,
           action);
     } while (consumer.Pop(action, deadline));
 
-    DoLog(log_request, log_client);
+    if (!def_logger_) DoLog(log_request, log_client);
     DoTrace(trace_request, trace_client);
   }
 }

--- a/otlp/src/otlp/logs/logger.cpp
+++ b/otlp/src/otlp/logs/logger.cpp
@@ -27,8 +27,8 @@ constexpr std::string_view kServiceName = "service.name";
 const std::string kTimestampFormat = "%Y-%m-%dT%H:%M:%E*S";
 }  // namespace
 
-SinkType Parse(const userver::yaml_config::YamlConfig& value,
-               userver::formats::parse::To<SinkType>) {
+SinkType Parse(const yaml_config::YamlConfig& value,
+               formats::parse::To<SinkType>) {
   auto destination = value.As<std::string>("otlp");
   if (destination == "both") {
     return SinkType::kBoth;

--- a/otlp/src/otlp/logs/logger.cpp
+++ b/otlp/src/otlp/logs/logger.cpp
@@ -29,7 +29,7 @@ const std::string kTimestampFormat = "%Y-%m-%dT%H:%M:%E*S";
 
 SinkType Parse(const userver::yaml_config::YamlConfig& value,
                userver::formats::parse::To<SinkType>) {
-  auto destination = value.As<std::string>();
+  auto destination = value.As<std::string>("otlp");
   if (destination == "both") {
     return SinkType::kBoth;
   }

--- a/otlp/src/otlp/logs/logger.cpp
+++ b/otlp/src/otlp/logs/logger.cpp
@@ -5,6 +5,7 @@
 
 #include <userver/engine/async.hpp>
 #include <userver/formats/parse/common_containers.hpp>
+#include <userver/formats/parse/to.hpp>
 #include <userver/logging/impl/tag_writer.hpp>
 #include <userver/logging/logger.hpp>
 #include <userver/tracing/span.hpp>
@@ -13,7 +14,6 @@
 #include <userver/utils/encoding/tskv_parser_read.hpp>
 #include <userver/utils/overloaded.hpp>
 #include <userver/utils/text_light.hpp>
-#include <userver/yaml_config/yaml_config.hpp>
 
 USERVER_NAMESPACE_BEGIN
 

--- a/otlp/src/otlp/logs/logger.hpp
+++ b/otlp/src/otlp/logs/logger.hpp
@@ -15,10 +15,13 @@ USERVER_NAMESPACE_BEGIN
 
 namespace otlp {
 
+enum class SinkType { kBoth, kDefault, kOtlp };
+
 struct LoggerConfig {
   size_t max_queue_size{10000};
   std::chrono::milliseconds max_batch_delay{};
-
+  SinkType logs_sink{SinkType::kOtlp};
+  SinkType tracing_sink{SinkType::kOtlp};
   std::string service_name;
   std::unordered_map<std::string, std::string> extra_attributes;
   std::unordered_map<std::string, std::string> attributes_mapping;
@@ -47,7 +50,9 @@ class Logger final : public logging::impl::LoggerBase {
 
   const logging::impl::LogStatistics& GetStatistics() const;
 
-  void setDefLogger(logging::LoggerPtr def_logger) { def_logger_ = def_logger; }
+  void setDefaultLogger(logging::LoggerPtr default_logger) {
+    default_logger_ = default_logger;
+  }
 
  protected:
   bool DoShouldLog(logging::Level level) const noexcept override;
@@ -77,7 +82,7 @@ class Logger final : public logging::impl::LoggerBase {
   const LoggerConfig config_;
   std::shared_ptr<Queue> queue_;
   Queue::MultiProducer queue_producer_;
-  logging::LoggerPtr def_logger_{};
+  logging::LoggerPtr default_logger_{};
   engine::Task sender_task_;  // Must be the last member
 };
 

--- a/otlp/src/otlp/logs/logger.hpp
+++ b/otlp/src/otlp/logs/logger.hpp
@@ -8,15 +8,18 @@
 
 #include <userver/concurrent/queue.hpp>
 #include <userver/engine/task/task.hpp>
+#include <userver/formats/yaml.hpp>
 #include <userver/logging/impl/log_stats.hpp>
 #include <userver/logging/impl/logger_base.hpp>
+#include <userver/yaml_config/fwd.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
 namespace otlp {
 
 enum class SinkType { kBoth, kDefault, kOtlp };
-
+SinkType Parse(const userver::yaml_config::YamlConfig& value,
+               userver::formats::parse::To<SinkType>);
 struct LoggerConfig {
   size_t max_queue_size{10000};
   std::chrono::milliseconds max_batch_delay{};
@@ -50,7 +53,7 @@ class Logger final : public logging::impl::LoggerBase {
 
   const logging::impl::LogStatistics& GetStatistics() const;
 
-  void setDefaultLogger(logging::LoggerPtr default_logger) {
+  void SetDefaultLogger(logging::LoggerPtr default_logger) {
     default_logger_ = default_logger;
   }
 

--- a/otlp/src/otlp/logs/logger.hpp
+++ b/otlp/src/otlp/logs/logger.hpp
@@ -19,8 +19,8 @@ namespace otlp {
 
 enum class SinkType { kBoth, kDefault, kOtlp };
 
-SinkType Parse(const userver::yaml_config::YamlConfig& value,
-               userver::formats::parse::To<SinkType>);
+SinkType Parse(const yaml_config::YamlConfig& value,
+               formats::parse::To<SinkType>);
 
 struct LoggerConfig {
   size_t max_queue_size{10000};

--- a/otlp/src/otlp/logs/logger.hpp
+++ b/otlp/src/otlp/logs/logger.hpp
@@ -47,6 +47,8 @@ class Logger final : public logging::impl::LoggerBase {
 
   const logging::impl::LogStatistics& GetStatistics() const;
 
+  void setDefLogger(logging::LoggerPtr def_logger) { def_logger_ = def_logger; }
+
  protected:
   bool DoShouldLog(logging::Level level) const noexcept override;
 
@@ -75,6 +77,7 @@ class Logger final : public logging::impl::LoggerBase {
   const LoggerConfig config_;
   std::shared_ptr<Queue> queue_;
   Queue::MultiProducer queue_producer_;
+  logging::LoggerPtr def_logger_{};
   engine::Task sender_task_;  // Must be the last member
 };
 

--- a/otlp/src/otlp/logs/logger.hpp
+++ b/otlp/src/otlp/logs/logger.hpp
@@ -18,8 +18,10 @@ USERVER_NAMESPACE_BEGIN
 namespace otlp {
 
 enum class SinkType { kBoth, kDefault, kOtlp };
+
 SinkType Parse(const userver::yaml_config::YamlConfig& value,
                userver::formats::parse::To<SinkType>);
+
 struct LoggerConfig {
   size_t max_queue_size{10000};
   std::chrono::milliseconds max_batch_delay{};

--- a/otlp/src/otlp/logs/logger.hpp
+++ b/otlp/src/otlp/logs/logger.hpp
@@ -11,7 +11,7 @@
 #include <userver/formats/yaml.hpp>
 #include <userver/logging/impl/log_stats.hpp>
 #include <userver/logging/impl/logger_base.hpp>
-#include <userver/yaml_config/fwd.hpp>
+#include <userver/yaml_config/yaml_config.hpp>
 
 USERVER_NAMESPACE_BEGIN
 


### PR DESCRIPTION
This is a proposal how to solve issue#676: Separate otlp config for logs and traces.

Motivation: in Kubernetes (while traces are sent efficiently through the push model) applications typically write their logs to `stdout/stderr` so that they are available for log collectors (they are stored in files on k8s nodes). This way, even in case of application failure, logs will be available.

A new `send-logs` option is added to the otlp-logger configuration. This option allows the user to control whether logs are sent via gRPC using the OTLP protocol or through the default logger from the logging component.

By default, `send-logs` is set to `true`. In this case, the OTLP logger will behave as before, sending both logs and traces using gRPC through the OTLP protocol.

If `send-logs` is set to `false`, the OTLP logger will try to use the 'default' logger from the logging component for logs.

Documentation for the new `send-logs` option and handling of exceptions for both cases were added as well.