### PR TITLE
Kafka client.id for producer and consumer

### DIFF
--- a/kafka/CMakeLists.txt
+++ b/kafka/CMakeLists.txt
@@ -51,4 +51,5 @@ _userver_directory_install(COMPONENT kafka FILES
 
 if (USERVER_IS_THE_ROOT_PROJECT)
   add_subdirectory(functional_tests)
+  # add_subdirectory(tests)
 endif()

--- a/kafka/functional_tests/integrational_tests/static_config.yaml
+++ b/kafka/functional_tests/integrational_tests/static_config.yaml
@@ -30,6 +30,7 @@ components_manager:
         # yaml
         kafka-consumer:
             group_id: test-group
+            client_id: test-client
             topics:
               - test-topic-send
               - test-topic-consume-1
@@ -48,6 +49,7 @@ components_manager:
         # /// [Kafka service sample - producer static config]
         # yaml
         kafka-producer-first:
+            client_id: test-client
             delivery_timeout: 3000ms
             queue_buffering_max: 100ms
             enable_idempotence: true

--- a/kafka/include/userver/kafka/consumer_component.hpp
+++ b/kafka/include/userver/kafka/consumer_component.hpp
@@ -39,7 +39,7 @@ class Consumer;
 /// Name                               | Description                                      | Default value
 /// ---------------------------------- | ------------------------------------------------ | ---------------
 /// group_id                           | consumer group id (name) | --
-/// client_id                          | An id string to pass to the server when making requests | --
+/// client_id                          | An id string to pass to the server when making requests | userver
 /// topics                             | list of topics consumer subscribes | --
 /// max_batch_size                     | maximum number of messages consumer waits for new message before calling a callback | 1
 /// poll_timeout                       | maximum amount of time consumer waits for messages for new messages before calling a callback | 1s

--- a/kafka/include/userver/kafka/consumer_component.hpp
+++ b/kafka/include/userver/kafka/consumer_component.hpp
@@ -39,6 +39,7 @@ class Consumer;
 /// Name                               | Description                                      | Default value
 /// ---------------------------------- | ------------------------------------------------ | ---------------
 /// group_id                           | consumer group id (name) | --
+/// client_id                          | An id string to pass to the server when making requests | --
 /// topics                             | list of topics consumer subscribes | --
 /// max_batch_size                     | maximum number of messages consumer waits for new message before calling a callback | 1
 /// poll_timeout                       | maximum amount of time consumer waits for messages for new messages before calling a callback | 1s

--- a/kafka/include/userver/kafka/producer_component.hpp
+++ b/kafka/include/userver/kafka/producer_component.hpp
@@ -31,6 +31,7 @@ namespace kafka {
 /// ## Static options:
 /// Name                         | Description                                      | Default value
 /// ---------------------------- | ------------------------------------------------ | ---------------
+/// client_id                    | An id string to pass to the server when making requests | --
 /// delivery_timeout             | time a produced message waits for successful delivery | --
 /// queue_buffering_max          | delay to wait for messages to be transmitted to broker | --
 /// enable_idempotence           | whether to make producer idempotent | false

--- a/kafka/include/userver/kafka/producer_component.hpp
+++ b/kafka/include/userver/kafka/producer_component.hpp
@@ -31,7 +31,7 @@ namespace kafka {
 /// ## Static options:
 /// Name                         | Description                                      | Default value
 /// ---------------------------- | ------------------------------------------------ | ---------------
-/// client_id                    | An id string to pass to the server when making requests | --
+/// client_id                    | An id string to pass to the server when making requests | userver
 /// delivery_timeout             | time a produced message waits for successful delivery | --
 /// queue_buffering_max          | delay to wait for messages to be transmitted to broker | --
 /// enable_idempotence           | whether to make producer idempotent | false

--- a/kafka/src/kafka/consumer_component.cpp
+++ b/kafka/src/kafka/consumer_component.cpp
@@ -74,7 +74,7 @@ properties:
     client_id:
         type: string
         description: An id string to pass to the server when making requests
-        defaultDescription: ''
+        defaultDescription: userver
     topics:
         type: array
         description: list of topics consumer subscribes

--- a/kafka/src/kafka/consumer_component.cpp
+++ b/kafka/src/kafka/consumer_component.cpp
@@ -71,6 +71,10 @@ properties:
             consumer group id.
             Topic partition evenly distributed
             between consumers with the same `group_id`
+    client_id:
+        type: string
+        description: An id string to pass to the server when making requests
+        defaultDescription: ''
     topics:
         type: array
         description: list of topics consumer subscribes

--- a/kafka/src/kafka/impl/configuration.cpp
+++ b/kafka/src/kafka/impl/configuration.cpp
@@ -93,7 +93,7 @@ CommonConfiguration Parse(const yaml_config::YamlConfig& config,
   common.metadata_max_age =
       config["metadata_max_age"].As<std::chrono::milliseconds>(
           common.metadata_max_age);
-  common.client_id = config["client_id"].As<std::string>("");
+  common.client_id = config["client_id"].As<std::string>(common.client_id);
 
   return common;
 }
@@ -245,8 +245,7 @@ void Configuration::SetCommon(const CommonConfiguration& common) {
             std::to_string(common.topic_metadata_refresh_interval.count()));
   SetOption("metadata.max.age.ms",
             std::to_string(common.metadata_max_age.count()));
-  if (!common.client_id.empty())
-    SetOption("client.id", common.client_id);
+  SetOption("client.id", common.client_id);
 }
 
 void Configuration::SetSecurity(const SecurityConfiguration& security,

--- a/kafka/src/kafka/impl/configuration.cpp
+++ b/kafka/src/kafka/impl/configuration.cpp
@@ -93,6 +93,7 @@ CommonConfiguration Parse(const yaml_config::YamlConfig& config,
   common.metadata_max_age =
       config["metadata_max_age"].As<std::chrono::milliseconds>(
           common.metadata_max_age);
+  common.client_id = config["client_id"].As<std::string>("");
 
   return common;
 }
@@ -244,6 +245,8 @@ void Configuration::SetCommon(const CommonConfiguration& common) {
             std::to_string(common.topic_metadata_refresh_interval.count()));
   SetOption("metadata.max.age.ms",
             std::to_string(common.metadata_max_age.count()));
+  if (!common.client_id.empty())
+    SetOption("client.id", common.client_id);
 }
 
 void Configuration::SetSecurity(const SecurityConfiguration& security,

--- a/kafka/src/kafka/impl/configuration.hpp
+++ b/kafka/src/kafka/impl/configuration.hpp
@@ -23,7 +23,7 @@ struct Secret;
 struct CommonConfiguration final {
   std::chrono::milliseconds topic_metadata_refresh_interval{300000};
   std::chrono::milliseconds metadata_max_age{900000};
-  std::string client_id;
+  std::string client_id{"userver"};
 };
 
 struct SecurityConfiguration final {

--- a/kafka/src/kafka/impl/configuration.hpp
+++ b/kafka/src/kafka/impl/configuration.hpp
@@ -23,6 +23,7 @@ struct Secret;
 struct CommonConfiguration final {
   std::chrono::milliseconds topic_metadata_refresh_interval{300000};
   std::chrono::milliseconds metadata_max_age{900000};
+  std::string client_id;
 };
 
 struct SecurityConfiguration final {

--- a/kafka/src/kafka/producer_component.cpp
+++ b/kafka/src/kafka/producer_component.cpp
@@ -44,6 +44,10 @@ type: object
 description: Kafka producer component
 additionalProperties: false
 properties:
+    client_id:
+        type: string
+        description: An id string to pass to the server when making requests
+        defaultDescription: ''
     delivery_timeout:
         type: string
         description: time a produced message waits for successful delivery

--- a/kafka/src/kafka/producer_component.cpp
+++ b/kafka/src/kafka/producer_component.cpp
@@ -47,7 +47,7 @@ properties:
     client_id:
         type: string
         description: An id string to pass to the server when making requests
-        defaultDescription: ''
+        defaultDescription: userver
     delivery_timeout:
         type: string
         description: time a produced message waits for successful delivery

--- a/kafka/tests/CMakeLists.txt
+++ b/kafka/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+file(GLOB_RECURSE UNIT_TEST_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp
+)
+
+add_executable(${PROJECT_NAME}-unittest ${UNIT_TEST_SOURCES})
+target_link_libraries(${PROJECT_NAME}-unittest PRIVATE userver::kafka userver::utest)
+target_include_directories(${PROJECT_NAME}-unittest PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+add_google_tests(${PROJECT_NAME}-unittest)

--- a/kafka/tests/configuration_test.cpp
+++ b/kafka/tests/configuration_test.cpp
@@ -26,7 +26,7 @@ UTEST_F(ConfigurationTest, Producer) {
       configuration.emplace(MakeProducerConfiguration("kafka-producer")));
 
   const kafka::impl::ProducerConfiguration default_producer{};
-  EXPECT_TRUE(configuration->GetOption("client.id").empty());
+  EXPECT_EQ(configuration->GetOption("client.id"), default_producer.common.client_id);
   EXPECT_EQ(
       configuration->GetOption("topic.metadata.refresh.interval.ms"),
       std::to_string(
@@ -97,7 +97,7 @@ UTEST_F(ConfigurationTest, Consumer) {
       configuration.emplace(MakeConsumerConfiguration("kafka-consumer")));
 
   const kafka::impl::ConsumerConfiguration default_consumer{};
-  EXPECT_TRUE(configuration->GetOption("client.id").empty());
+  EXPECT_EQ(configuration->GetOption("client.id"), default_consumer.common.client_id);
   EXPECT_EQ(
       configuration->GetOption("topic.metadata.refresh.interval.ms"),
       std::to_string(

--- a/kafka/tests/configuration_test.cpp
+++ b/kafka/tests/configuration_test.cpp
@@ -26,6 +26,7 @@ UTEST_F(ConfigurationTest, Producer) {
       configuration.emplace(MakeProducerConfiguration("kafka-producer")));
 
   const kafka::impl::ProducerConfiguration default_producer{};
+  EXPECT_TRUE(configuration->GetOption("client.id").empty());
   EXPECT_EQ(
       configuration->GetOption("topic.metadata.refresh.interval.ms"),
       std::to_string(
@@ -57,6 +58,7 @@ UTEST_F(ConfigurationTest, ProducerNonDefault) {
   kafka::impl::ProducerConfiguration producer_configuration{};
   producer_configuration.common.topic_metadata_refresh_interval = 10ms;
   producer_configuration.common.metadata_max_age = 30ms;
+  producer_configuration.common.client_id = "test-client";
   producer_configuration.delivery_timeout = 37ms;
   producer_configuration.queue_buffering_max = 7ms;
   producer_configuration.enable_idempotence = true;
@@ -72,6 +74,7 @@ UTEST_F(ConfigurationTest, ProducerNonDefault) {
   UEXPECT_NO_THROW(configuration.emplace(
       MakeProducerConfiguration("kafka-producer", producer_configuration)));
 
+  EXPECT_EQ(configuration->GetOption("client.id"), "test-client");
   EXPECT_EQ(configuration->GetOption("topic.metadata.refresh.interval.ms"),
             "10");
   EXPECT_EQ(configuration->GetOption("metadata.max.age.ms"), "30");
@@ -94,6 +97,7 @@ UTEST_F(ConfigurationTest, Consumer) {
       configuration.emplace(MakeConsumerConfiguration("kafka-consumer")));
 
   const kafka::impl::ConsumerConfiguration default_consumer{};
+  EXPECT_TRUE(configuration->GetOption("client.id").empty());
   EXPECT_EQ(
       configuration->GetOption("topic.metadata.refresh.interval.ms"),
       std::to_string(
@@ -111,6 +115,7 @@ UTEST_F(ConfigurationTest, ConsumerNonDefault) {
   kafka::impl::ConsumerConfiguration consumer_configuration{};
   consumer_configuration.common.topic_metadata_refresh_interval = 10ms;
   consumer_configuration.common.metadata_max_age = 30ms;
+  consumer_configuration.common.client_id = "test-client";
   consumer_configuration.auto_offset_reset = "largest";
   consumer_configuration.rd_kafka_options["socket.keepalive.enable"] = "true";
 
@@ -120,6 +125,7 @@ UTEST_F(ConfigurationTest, ConsumerNonDefault) {
 
   EXPECT_EQ(configuration->GetOption("topic.metadata.refresh.interval.ms"),
             "10");
+  EXPECT_EQ(configuration->GetOption("client.id"), "test-client");
   EXPECT_EQ(configuration->GetOption("metadata.max.age.ms"), "30");
   EXPECT_EQ(configuration->GetOption("security.protocol"), "plaintext");
   EXPECT_EQ(configuration->GetOption("group.id"), "test-group");

--- a/kafka/tests/test_utils.cpp
+++ b/kafka/tests/test_utils.cpp
@@ -27,6 +27,11 @@ kafka::impl::Secret MakeSecrets(std::string_view bootstrap_servers) {
 
 }  // namespace
 
+bool operator==(const Message& lhs, const Message& rhs) {
+  return lhs.topic == rhs.topic && lhs.key == rhs.key &&
+         lhs.payload == rhs.payload && lhs.partition == rhs.partition;
+}
+
 std::ostream& operator<<(std::ostream& out, const Message& message) {
   return out << fmt::format(
              "Message{{topic: '{}', key: '{}', payload: '{}', partition: "

--- a/kafka/tests/test_utils.hpp
+++ b/kafka/tests/test_utils.hpp
@@ -19,9 +19,9 @@ struct Message {
   std::string key;
   std::string payload;
   std::optional<std::uint32_t> partition;
-
-  bool operator==(const Message& other) const = default;
 };
+
+bool operator==(const Message& lhs, const Message& rhs);
 
 std::ostream& operator<<(std::ostream&, const Message&);
 


### PR DESCRIPTION
Add client.id for producer and consumer into `CommonConfiguration`.  From kafka documentations

> Optional, but you should set this property on each instance because it enables you to more easily correlate requests on the broker with the client instance which made it, which can be helpful in debugging and troubleshooting scenarios.

Default value set to `userver`, because librdkafka use `rdkafka` as default id.

I added unittests, but didn't enable it's. They required real kafka instance 