### PR TITLE
Kafka client.id for producer and consumer

### DIFF
--- a/kafka/CMakeLists.txt
+++ b/kafka/CMakeLists.txt
@@ -51,4 +51,5 @@ _userver_directory_install(COMPONENT kafka FILES
 
 if (USERVER_IS_THE_ROOT_PROJECT)
   add_subdirectory(functional_tests)
+  # add_subdirectory(tests)
 endif()

--- a/kafka/CMakeLists.txt
+++ b/kafka/CMakeLists.txt
@@ -51,5 +51,5 @@ _userver_directory_install(COMPONENT kafka FILES
 
 if (USERVER_IS_THE_ROOT_PROJECT)
   add_subdirectory(functional_tests)
-  # add_subdirectory(tests)
+  add_subdirectory(tests)
 endif()

--- a/kafka/functional_tests/integrational_tests/static_config.yaml
+++ b/kafka/functional_tests/integrational_tests/static_config.yaml
@@ -30,7 +30,6 @@ components_manager:
         # yaml
         kafka-consumer:
             group_id: test-group
-            client_id: test-client
             topics:
               - test-topic-send
               - test-topic-consume-1
@@ -49,7 +48,6 @@ components_manager:
         # /// [Kafka service sample - producer static config]
         # yaml
         kafka-producer-first:
-            client_id: test-client
             delivery_timeout: 3000ms
             queue_buffering_max: 100ms
             enable_idempotence: true
@@ -59,6 +57,7 @@ components_manager:
         # /// [Kafka service sample - producer static config]
 
         kafka-producer-second:
+            client_id: test-client
             delivery_timeout: 3000ms
             queue_buffering_max: 100ms
             enable_idempotence: true

--- a/kafka/functional_tests/integrational_tests/static_config.yaml
+++ b/kafka/functional_tests/integrational_tests/static_config.yaml
@@ -30,6 +30,7 @@ components_manager:
         # yaml
         kafka-consumer:
             group_id: test-group
+            client_id: test-client
             topics:
               - test-topic-send
               - test-topic-consume-1
@@ -48,6 +49,7 @@ components_manager:
         # /// [Kafka service sample - producer static config]
         # yaml
         kafka-producer-first:
+            client_id: test-client
             delivery_timeout: 3000ms
             queue_buffering_max: 100ms
             enable_idempotence: true

--- a/kafka/include/userver/kafka/consumer_component.hpp
+++ b/kafka/include/userver/kafka/consumer_component.hpp
@@ -39,7 +39,7 @@ class Consumer;
 /// Name                               | Description                                      | Default value
 /// ---------------------------------- | ------------------------------------------------ | ---------------
 /// group_id                           | consumer group id (name) | --
-/// client_id                          | An id string to pass to the server when making requests | userver
+/// client_id                          | Client identifier. May be an arbitrary string. Optional, but you should set this property on each instance because it enables you to more easily correlate requests on the broker with the client instance which made it, which can be helpful in debugging and troubleshooting scenarios.| userver
 /// topics                             | list of topics consumer subscribes | --
 /// max_batch_size                     | maximum number of messages consumer waits for new message before calling a callback | 1
 /// poll_timeout                       | maximum amount of time consumer waits for messages for new messages before calling a callback | 1s

--- a/kafka/include/userver/kafka/consumer_component.hpp
+++ b/kafka/include/userver/kafka/consumer_component.hpp
@@ -39,6 +39,7 @@ class Consumer;
 /// Name                               | Description                                      | Default value
 /// ---------------------------------- | ------------------------------------------------ | ---------------
 /// group_id                           | consumer group id (name) | --
+/// client_id                          | An id string to pass to the server when making requests | userver
 /// topics                             | list of topics consumer subscribes | --
 /// max_batch_size                     | maximum number of messages consumer waits for new message before calling a callback | 1
 /// poll_timeout                       | maximum amount of time consumer waits for messages for new messages before calling a callback | 1s

--- a/kafka/include/userver/kafka/producer_component.hpp
+++ b/kafka/include/userver/kafka/producer_component.hpp
@@ -31,6 +31,7 @@ namespace kafka {
 /// ## Static options:
 /// Name                         | Description                                      | Default value
 /// ---------------------------- | ------------------------------------------------ | ---------------
+/// client_id                    | An id string to pass to the server when making requests | userver
 /// delivery_timeout             | time a produced message waits for successful delivery | --
 /// queue_buffering_max          | delay to wait for messages to be transmitted to broker | --
 /// enable_idempotence           | whether to make producer idempotent | false

--- a/kafka/include/userver/kafka/producer_component.hpp
+++ b/kafka/include/userver/kafka/producer_component.hpp
@@ -31,7 +31,7 @@ namespace kafka {
 /// ## Static options:
 /// Name                         | Description                                      | Default value
 /// ---------------------------- | ------------------------------------------------ | ---------------
-/// client_id                    | An id string to pass to the server when making requests | userver
+/// client_id                    | Client identifier. May be an arbitrary string. Optional, but you should set this property on each instance because it enables you to more easily correlate requests on the broker with the client instance which made it, which can be helpful in debugging and troubleshooting scenarios.| userver
 /// delivery_timeout             | time a produced message waits for successful delivery | --
 /// queue_buffering_max          | delay to wait for messages to be transmitted to broker | --
 /// enable_idempotence           | whether to make producer idempotent | false

--- a/kafka/src/kafka/consumer_component.cpp
+++ b/kafka/src/kafka/consumer_component.cpp
@@ -71,6 +71,10 @@ properties:
             consumer group id.
             Topic partition evenly distributed
             between consumers with the same `group_id`
+    client_id:
+        type: string
+        description: An id string to pass to the server when making requests
+        defaultDescription: userver
     topics:
         type: array
         description: list of topics consumer subscribes

--- a/kafka/src/kafka/consumer_component.cpp
+++ b/kafka/src/kafka/consumer_component.cpp
@@ -73,7 +73,10 @@ properties:
             between consumers with the same `group_id`
     client_id:
         type: string
-        description: An id string to pass to the server when making requests
+        description: |
+            Client identifier.
+            May be an arbitrary string.
+            Optional, but you should set this property on each instance because it enables you to more easily correlate requests on the broker with the client instance which made it, which can be helpful in debugging and troubleshooting scenarios.
         defaultDescription: userver
     topics:
         type: array

--- a/kafka/src/kafka/impl/configuration.cpp
+++ b/kafka/src/kafka/impl/configuration.cpp
@@ -93,6 +93,7 @@ CommonConfiguration Parse(const yaml_config::YamlConfig& config,
   common.metadata_max_age =
       config["metadata_max_age"].As<std::chrono::milliseconds>(
           common.metadata_max_age);
+  common.client_id = config["client_id"].As<std::string>(common.client_id);
 
   return common;
 }
@@ -244,6 +245,7 @@ void Configuration::SetCommon(const CommonConfiguration& common) {
             std::to_string(common.topic_metadata_refresh_interval.count()));
   SetOption("metadata.max.age.ms",
             std::to_string(common.metadata_max_age.count()));
+  SetOption("client.id", common.client_id);
 }
 
 void Configuration::SetSecurity(const SecurityConfiguration& security,

--- a/kafka/src/kafka/impl/configuration.hpp
+++ b/kafka/src/kafka/impl/configuration.hpp
@@ -23,6 +23,7 @@ struct Secret;
 struct CommonConfiguration final {
   std::chrono::milliseconds topic_metadata_refresh_interval{300000};
   std::chrono::milliseconds metadata_max_age{900000};
+  std::string client_id{"userver"};
 };
 
 struct SecurityConfiguration final {

--- a/kafka/src/kafka/producer_component.cpp
+++ b/kafka/src/kafka/producer_component.cpp
@@ -44,6 +44,10 @@ type: object
 description: Kafka producer component
 additionalProperties: false
 properties:
+    client_id:
+        type: string
+        description: An id string to pass to the server when making requests
+        defaultDescription: userver
     delivery_timeout:
         type: string
         description: time a produced message waits for successful delivery

--- a/kafka/src/kafka/producer_component.cpp
+++ b/kafka/src/kafka/producer_component.cpp
@@ -46,7 +46,10 @@ additionalProperties: false
 properties:
     client_id:
         type: string
-        description: An id string to pass to the server when making requests
+        description: |
+            Client identifier.
+            May be an arbitrary string.
+            Optional, but you should set this property on each instance because it enables you to more easily correlate requests on the broker with the client instance which made it, which can be helpful in debugging and troubleshooting scenarios.
         defaultDescription: userver
     delivery_timeout:
         type: string

--- a/kafka/tests/CMakeLists.txt
+++ b/kafka/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+file(GLOB_RECURSE UNIT_TEST_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp
+)
+
+add_executable(${PROJECT_NAME}-unittest ${UNIT_TEST_SOURCES})
+target_link_libraries(${PROJECT_NAME}-unittest PRIVATE userver::kafka userver::utest)
+target_include_directories(${PROJECT_NAME}-unittest PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+add_google_tests(${PROJECT_NAME}-unittest)

--- a/kafka/tests/CMakeLists.txt
+++ b/kafka/tests/CMakeLists.txt
@@ -8,4 +8,4 @@ target_link_libraries(${PROJECT_NAME}-unittest PRIVATE userver::kafka userver::u
 target_include_directories(${PROJECT_NAME}-unittest PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
 )
-add_google_tests(${PROJECT_NAME}-unittest)
+# add_google_tests(${PROJECT_NAME}-unittest)

--- a/kafka/tests/configuration_test.cpp
+++ b/kafka/tests/configuration_test.cpp
@@ -26,6 +26,7 @@ UTEST_F(ConfigurationTest, Producer) {
       configuration.emplace(MakeProducerConfiguration("kafka-producer")));
 
   const kafka::impl::ProducerConfiguration default_producer{};
+  EXPECT_EQ(configuration->GetOption("client.id"), default_producer.common.client_id);
   EXPECT_EQ(
       configuration->GetOption("topic.metadata.refresh.interval.ms"),
       std::to_string(
@@ -57,6 +58,7 @@ UTEST_F(ConfigurationTest, ProducerNonDefault) {
   kafka::impl::ProducerConfiguration producer_configuration{};
   producer_configuration.common.topic_metadata_refresh_interval = 10ms;
   producer_configuration.common.metadata_max_age = 30ms;
+  producer_configuration.common.client_id = "test-client";
   producer_configuration.delivery_timeout = 37ms;
   producer_configuration.queue_buffering_max = 7ms;
   producer_configuration.enable_idempotence = true;
@@ -72,6 +74,7 @@ UTEST_F(ConfigurationTest, ProducerNonDefault) {
   UEXPECT_NO_THROW(configuration.emplace(
       MakeProducerConfiguration("kafka-producer", producer_configuration)));
 
+  EXPECT_EQ(configuration->GetOption("client.id"), "test-client");
   EXPECT_EQ(configuration->GetOption("topic.metadata.refresh.interval.ms"),
             "10");
   EXPECT_EQ(configuration->GetOption("metadata.max.age.ms"), "30");
@@ -94,6 +97,7 @@ UTEST_F(ConfigurationTest, Consumer) {
       configuration.emplace(MakeConsumerConfiguration("kafka-consumer")));
 
   const kafka::impl::ConsumerConfiguration default_consumer{};
+  EXPECT_EQ(configuration->GetOption("client.id"), default_consumer.common.client_id);
   EXPECT_EQ(
       configuration->GetOption("topic.metadata.refresh.interval.ms"),
       std::to_string(
@@ -111,6 +115,7 @@ UTEST_F(ConfigurationTest, ConsumerNonDefault) {
   kafka::impl::ConsumerConfiguration consumer_configuration{};
   consumer_configuration.common.topic_metadata_refresh_interval = 10ms;
   consumer_configuration.common.metadata_max_age = 30ms;
+  consumer_configuration.common.client_id = "test-client";
   consumer_configuration.auto_offset_reset = "largest";
   consumer_configuration.rd_kafka_options["socket.keepalive.enable"] = "true";
 
@@ -120,6 +125,7 @@ UTEST_F(ConfigurationTest, ConsumerNonDefault) {
 
   EXPECT_EQ(configuration->GetOption("topic.metadata.refresh.interval.ms"),
             "10");
+  EXPECT_EQ(configuration->GetOption("client.id"), "test-client");
   EXPECT_EQ(configuration->GetOption("metadata.max.age.ms"), "30");
   EXPECT_EQ(configuration->GetOption("security.protocol"), "plaintext");
   EXPECT_EQ(configuration->GetOption("group.id"), "test-group");

--- a/kafka/tests/producer_test.cpp
+++ b/kafka/tests/producer_test.cpp
@@ -20,301 +20,301 @@ class ProducerTest : public KafkaCluster {};
 
 }  // namespace
 
-// UTEST_F(ProducerTest, OneProducerOneSendSync) {
-//   auto producer = MakeProducer("kafka-producer");
-//   UEXPECT_NO_THROW(producer.Send(GenerateTopic(), "test-key", "test-msg"));
-// }
-// 
-// UTEST_F(ProducerTest, OneProducerOneSendAsync) {
-//   auto producer = MakeProducer("kafka-producer");
-//   auto task = producer.SendAsync(GenerateTopic(), "test-key", "test-msg");
-//   UEXPECT_NO_THROW(task.Get());
-// }
-// 
-// UTEST_F(ProducerTest, BrokenConfiguration) {
-//   kafka::impl::ProducerConfiguration producer_configuration{};
-//   producer_configuration.delivery_timeout = std::chrono::milliseconds{1};
-//   producer_configuration.queue_buffering_max = std::chrono::milliseconds{7};
-// 
-//   UEXPECT_THROW(MakeProducer("kafka-producer", producer_configuration),
-//                 std::runtime_error);
-// }
-// 
-// UTEST_F(ProducerTest, LargeMessages) {
-//   constexpr std::size_t kSendCount{10};
-// 
-//   kafka::impl::ProducerConfiguration producer_configuration{};
-// 
-//   auto producer = MakeProducer("kafka-producer");
-//   const std::string topic = GenerateTopic();
-// 
-//   const std::string big_message(producer_configuration.message_max_bytes / 2,
-//                                 'm');
-//   for (std::size_t send{0}; send < kSendCount; ++send) {
-//     UEXPECT_NO_THROW(
-//         producer.Send(topic, fmt::format("test-key-{}", send), big_message));
-//   }
-// }
-// 
-// UTEST_F(ProducerTest, TooLargeMessage) {
-//   constexpr std::uint32_t kMessageMaxBytes{3000};
-// 
-//   kafka::impl::ProducerConfiguration producer_configuration{};
-//   producer_configuration.message_max_bytes = kMessageMaxBytes;
-//   producer_configuration.rd_kafka_options["debug"] = "all";
-// 
-//   auto producer = MakeProducer("kafka-producer", producer_configuration);
-//   UEXPECT_NO_THROW(
-//       producer.Send(GenerateTopic(), "small-key", "small-message"));
-// 
-//   const std::string big_key(kMessageMaxBytes, 'k');
-//   const std::string big_message(kMessageMaxBytes, 'm');
-//   UEXPECT_THROW(producer.Send(GenerateTopic(), big_key, big_message),
-//                 kafka::MessageTooLargeException);
-// }
-// 
-// UTEST_F(ProducerTest, UnknownPartition) {
-//   auto producer = MakeProducer("kafka-producer");
-//   UEXPECT_THROW(producer.Send(GenerateTopic(), "test-key", "test-msg",
-//                               /*partition=*/100500),
-//                 kafka::UnknownPartitionException);
-// }
-// 
-// UTEST_F(ProducerTest, FullQueue) {
-//   constexpr std::uint32_t kMaxQueueMessages{7};
-// 
-//   kafka::impl::ProducerConfiguration producer_configuration{};
-//   producer_configuration.delivery_timeout = std::chrono::seconds{6};
-//   producer_configuration.queue_buffering_max = std::chrono::seconds{3};
-//   producer_configuration.queue_buffering_max_messages = kMaxQueueMessages;
-// 
-//   auto producer = MakeProducer("kafka-producer", producer_configuration);
-//   const std::string topic = GenerateTopic();
-// 
-//   std::vector<engine::TaskWithResult<void>> results;
-//   results.reserve(kMaxQueueMessages);
-//   for (std::uint32_t send{0}; send < kMaxQueueMessages; ++send) {
-//     results.emplace_back(producer.SendAsync(topic,
-//                                             fmt::format("test-key-{}", send),
-//                                             fmt::format("test-msg-{}", send)));
-//   }
-//   auto make_send_request =
-//       [&producer, &topic, key = fmt::format("test-key-{}", kMaxQueueMessages),
-//        message = fmt::format("test-msg-{}", kMaxQueueMessages)] {
-//         producer.Send(topic, key, message);
-//       };
-// 
-//   UEXPECT_THROW(make_send_request(), kafka::QueueFullException);
-// 
-//   /// [Producer retryable error]
-//   bool delivered{false};
-//   const auto deadline =
-//       engine::Deadline::FromDuration(producer_configuration.delivery_timeout);
-//   while (!delivered && !deadline.IsReached()) {
-//     try {
-//       make_send_request();
-//       delivered = true;
-//     } catch (const kafka::SendException& e) {
-//       if (e.IsRetryable()) {
-//         engine::InterruptibleSleepFor(std::chrono::milliseconds{10});
-//         continue;
-//       }
-//       break;
-//     }
-//   }
-//   /// [Producer retryable error]
-// 
-//   EXPECT_TRUE(delivered);
-//   UEXPECT_NO_THROW(engine::WaitAllChecked(results));
-// }
-// 
-// UTEST_F(ProducerTest, SendCancel) {
-//   kafka::impl::ProducerConfiguration producer_configuration{};
-//   producer_configuration.delivery_timeout = std::chrono::seconds{6};
-//   producer_configuration.queue_buffering_max = std::chrono::seconds{3};
-// 
-//   auto producer = MakeProducer("kafka-producer", producer_configuration);
-// 
-//   auto send_task = producer.SendAsync(GenerateTopic(), "test-key", "test-msg");
-//   send_task.RequestCancel();
-//   UEXPECT_NO_THROW(send_task.Wait());
-// }
-// 
-// UTEST_F(ProducerTest, WaitingForMessageDelivery) {
-//   constexpr std::size_t kSendCount{100};
-// 
-//   kafka::impl::ProducerConfiguration producer_configuration{};
-//   producer_configuration.delivery_timeout = std::chrono::milliseconds{1500};
-//   producer_configuration.queue_buffering_max = std::chrono::milliseconds{1000};
-// 
-//   auto producer = std::make_unique<kafka::Producer>(
-//       utils::LazyPrvalue([this] { return MakeProducer("kafka-producer"); }));
-// 
-//   auto send_tasks = utils::GenerateFixedArray(
-//       kSendCount, [&producer, topic = GenerateTopic()](std::size_t i) {
-//         return producer->SendAsync(topic, fmt::format("test-key-{}", i),
-//                                    fmt::format("test-msg-{}", i));
-//       });
-//   /// queue_buffering_max is set to 1 seconds, therefore SendAsyncs waits for
-//   /// at least 1 second, so `producer.reset()` are invoked faster than
-//   /// SendAsyncs deliver the message.
-//   auto destroy_task = engine::AsyncNoSpan(
-//       [producer = std::move(producer)]() mutable { producer.reset(); });
-// 
-//   UEXPECT_NO_THROW(destroy_task.Get());
-//   UEXPECT_NO_THROW(engine::WaitAllChecked(send_tasks));
-// }
-// 
-// UTEST_F(ProducerTest, OneProducerManySendSync) {
-//   constexpr std::size_t kSendCount{100};
-// 
-//   auto producer = MakeProducer("kafka-producer");
-//   const auto topic = GenerateTopic();
-// 
-//   for (std::size_t send{0}; send < kSendCount; ++send) {
-//     UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send),
-//                                    fmt::format("test-msg-{}", send)))
-//         << send;
-//   }
-// }
-// 
-// UTEST_F(ProducerTest, OneProducerManySendAsync) {
-//   constexpr std::size_t kSendCount{100};
-// 
-//   auto producer = MakeProducer("kafka-producer");
-//   const auto topic = GenerateTopic();
-// 
-//   /// [Producer batch send async]
-//   std::vector<engine::TaskWithResult<void>> results;
-//   results.reserve(kSendCount);
-//   for (std::size_t send{0}; send < kSendCount; ++send) {
-//     results.emplace_back(producer.SendAsync(topic,
-//                                             fmt::format("test-key-{}", send),
-//                                             fmt::format("test-msg-{}", send)));
-//   }
-// 
-//   UEXPECT_NO_THROW(engine::WaitAllChecked(results));
-//   /// [Producer batch send async]
-// }
-// 
-// UTEST_F(ProducerTest, ManyProducersManySendSync) {
-//   constexpr std::size_t kProducerCount{4};
-//   constexpr std::size_t kSendCount{100};
-//   constexpr std::size_t kTopicCount{kSendCount / 10};
-// 
-//   kafka::impl::ProducerConfiguration producer_configuration{};
-//   producer_configuration.queue_buffering_max = std::chrono::seconds{0};
-//   const std::deque<kafka::Producer> producers = MakeProducers(
-//       kProducerCount,
-//       [](std::size_t i) { return fmt::format("kafka-producer-{}", i); },
-//       producer_configuration);
-//   const std::vector<std::string> topics = GenerateTopics(kTopicCount);
-// 
-//   for (std::size_t send{0}; send < kSendCount; ++send) {
-//     const auto& topic = topics.at(send % kTopicCount);
-//     auto& producer = producers.at(send % kProducerCount);
-//     UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send),
-//                                    fmt::format("test-msg-{}", send)))
-//         << send;
-//   }
-// }
-// 
-// UTEST_F(ProducerTest, ManyProducersManySendAsyncSingleThread) {
-//   constexpr std::size_t kProducerCount{10};
-//   constexpr std::size_t kSendCount{1000};
-// 
-//   const std::deque<kafka::Producer> producers = MakeProducers(
-//       kProducerCount,
-//       [](std::size_t i) { return fmt::format("kafka-producer-{}", i); });
-//   const std::string topic = GenerateTopic();
-// 
-//   std::vector<engine::TaskWithResult<void>> results;
-//   results.reserve(kSendCount);
-//   for (std::size_t send{0}; send < kSendCount; ++send) {
-//     auto& producer = producers.at(send % kProducerCount);
-//     results.emplace_back(producer.SendAsync(topic,
-//                                             fmt::format("test-key-{}", send),
-//                                             fmt::format("test-msg-{}", send)));
-//   }
-// 
-//   UEXPECT_NO_THROW(engine::WaitAllChecked(results));
-// }
-// 
-// UTEST_F_MT(ProducerTest, ManyProducersManySendAsync, 4 + 4) {
-//   constexpr std::size_t kProducerCount{4};
-//   constexpr std::size_t kSendCount{300};
-//   constexpr std::size_t kTopicCount{kSendCount / 10};
-// 
-//   const std::deque<kafka::Producer> producers = MakeProducers(
-//       kProducerCount,
-//       [](std::size_t i) { return fmt::format("kafka-producer-{}", i); });
-//   const std::vector<std::string> topics = GenerateTopics(kTopicCount);
-// 
-//   std::vector<engine::TaskWithResult<void>> results;
-//   results.reserve(kSendCount);
-//   for (std::size_t send{0}; send < kSendCount; ++send) {
-//     const auto& topic = topics.at(send % kTopicCount);
-//     auto& producer = producers.at(send % kProducerCount);
-//     results.emplace_back(producer.SendAsync(topic,
-//                                             fmt::format("test-key-{}", send),
-//                                             fmt::format("test-msg-{}", send)));
-//   }
-// 
-//   UEXPECT_NO_THROW(engine::WaitAllChecked(results));
-// }
-// 
-// UTEST_F_MT(ProducerTest, OneProducerManySendSyncMt, 1 + 4) {
-//   auto producer = MakeProducer("kafka-producer");
-// 
-//   constexpr std::size_t kSendCount{100};
-//   constexpr std::size_t kTopicCount{4};
-//   constexpr std::size_t kSendPerTask{kSendCount / kTopicCount};
-//   const std::vector<std::string> topics = GenerateTopics(kTopicCount);
-// 
-//   std::vector<engine::TaskWithResult<void>> results;
-//   results.reserve(GetThreadCount());
-//   for (std::size_t group{0}; group + 1 < GetThreadCount(); ++group) {
-//     results.emplace_back(utils::Async(
-//         fmt::format("producer_test_send_sync_{}", group), [&producer, &topics] {
-//           for (std::size_t send{0}; send < kSendPerTask; ++send) {
-//             producer.Send(topics.at(send % topics.size()),
-//                           fmt::format("test-key-{}", send),
-//                           fmt::format("test-msg-{}", send));
-//           }
-//         }));
-//   }
-// 
-//   UEXPECT_NO_THROW(engine::WaitAllChecked(results));
-// }
-// 
-// UTEST_F_MT(ProducerTest, OneProducerManySendAsyncMt, 1 + 4) {
-//   auto producer = MakeProducer("kafka-producer");
-// 
-//   constexpr std::size_t kSendCount{1000};
-//   constexpr std::size_t kTopicCount{4};
-//   constexpr std::size_t kSendPerTask{kSendCount / kTopicCount};
-//   const std::vector<std::string> topics = GenerateTopics(kTopicCount);
-// 
-//   std::vector<engine::TaskWithResult<void>> parallel_tasks;
-//   parallel_tasks.reserve(GetThreadCount());
-//   concurrent::Variable<std::vector<engine::TaskWithResult<void>>> results;
-//   for (std::size_t group{0}; group + 1 < GetThreadCount(); ++group) {
-//     parallel_tasks.emplace_back(utils::Async(
-//         fmt::format("producer_test_send_async_{}", group),
-//         [&producer, &results, &topics] {
-//           for (std::size_t send{0}; send < kSendPerTask; ++send) {
-//             auto task = producer.SendAsync(topics.at(send % topics.size()),
-//                                            fmt::format("test-key-{}", send),
-//                                            fmt::format("test-msg-{}", send));
-//             auto results_lock = results.Lock();
-//             results_lock->push_back(std::move(task));
-//           }
-//         }));
-//   }
-//   UEXPECT_NO_THROW(engine::WaitAllChecked(parallel_tasks));
-// 
-//   auto results_lock = results.Lock();
-//   UEXPECT_NO_THROW(engine::WaitAllChecked(*results_lock));
-// }
+UTEST_F(ProducerTest, OneProducerOneSendSync) {
+  auto producer = MakeProducer("kafka-producer");
+  UEXPECT_NO_THROW(producer.Send(GenerateTopic(), "test-key", "test-msg"));
+}
+
+UTEST_F(ProducerTest, OneProducerOneSendAsync) {
+  auto producer = MakeProducer("kafka-producer");
+  auto task = producer.SendAsync(GenerateTopic(), "test-key", "test-msg");
+  UEXPECT_NO_THROW(task.Get());
+}
+
+UTEST_F(ProducerTest, BrokenConfiguration) {
+  kafka::impl::ProducerConfiguration producer_configuration{};
+  producer_configuration.delivery_timeout = std::chrono::milliseconds{1};
+  producer_configuration.queue_buffering_max = std::chrono::milliseconds{7};
+
+  UEXPECT_THROW(MakeProducer("kafka-producer", producer_configuration),
+                std::runtime_error);
+}
+
+UTEST_F(ProducerTest, LargeMessages) {
+  constexpr std::size_t kSendCount{10};
+
+  kafka::impl::ProducerConfiguration producer_configuration{};
+
+  auto producer = MakeProducer("kafka-producer");
+  const std::string topic = GenerateTopic();
+
+  const std::string big_message(producer_configuration.message_max_bytes / 2,
+                                'm');
+  for (std::size_t send{0}; send < kSendCount; ++send) {
+    UEXPECT_NO_THROW(
+        producer.Send(topic, fmt::format("test-key-{}", send), big_message));
+  }
+}
+
+UTEST_F(ProducerTest, TooLargeMessage) {
+  constexpr std::uint32_t kMessageMaxBytes{3000};
+
+  kafka::impl::ProducerConfiguration producer_configuration{};
+  producer_configuration.message_max_bytes = kMessageMaxBytes;
+  producer_configuration.rd_kafka_options["debug"] = "all";
+
+  auto producer = MakeProducer("kafka-producer", producer_configuration);
+  UEXPECT_NO_THROW(
+      producer.Send(GenerateTopic(), "small-key", "small-message"));
+
+  const std::string big_key(kMessageMaxBytes, 'k');
+  const std::string big_message(kMessageMaxBytes, 'm');
+  UEXPECT_THROW(producer.Send(GenerateTopic(), big_key, big_message),
+                kafka::MessageTooLargeException);
+}
+
+UTEST_F(ProducerTest, UnknownPartition) {
+  auto producer = MakeProducer("kafka-producer");
+  UEXPECT_THROW(producer.Send(GenerateTopic(), "test-key", "test-msg",
+                              /*partition=*/100500),
+                kafka::UnknownPartitionException);
+}
+
+UTEST_F(ProducerTest, FullQueue) {
+  constexpr std::uint32_t kMaxQueueMessages{7};
+
+  kafka::impl::ProducerConfiguration producer_configuration{};
+  producer_configuration.delivery_timeout = std::chrono::seconds{6};
+  producer_configuration.queue_buffering_max = std::chrono::seconds{3};
+  producer_configuration.queue_buffering_max_messages = kMaxQueueMessages;
+
+  auto producer = MakeProducer("kafka-producer", producer_configuration);
+  const std::string topic = GenerateTopic();
+
+  std::vector<engine::TaskWithResult<void>> results;
+  results.reserve(kMaxQueueMessages);
+  for (std::uint32_t send{0}; send < kMaxQueueMessages; ++send) {
+    results.emplace_back(producer.SendAsync(topic,
+                                            fmt::format("test-key-{}", send),
+                                            fmt::format("test-msg-{}", send)));
+  }
+  auto make_send_request =
+      [&producer, &topic, key = fmt::format("test-key-{}", kMaxQueueMessages),
+       message = fmt::format("test-msg-{}", kMaxQueueMessages)] {
+        producer.Send(topic, key, message);
+      };
+
+  UEXPECT_THROW(make_send_request(), kafka::QueueFullException);
+
+  /// [Producer retryable error]
+  bool delivered{false};
+  const auto deadline =
+      engine::Deadline::FromDuration(producer_configuration.delivery_timeout);
+  while (!delivered && !deadline.IsReached()) {
+    try {
+      make_send_request();
+      delivered = true;
+    } catch (const kafka::SendException& e) {
+      if (e.IsRetryable()) {
+        engine::InterruptibleSleepFor(std::chrono::milliseconds{10});
+        continue;
+      }
+      break;
+    }
+  }
+  /// [Producer retryable error]
+
+  EXPECT_TRUE(delivered);
+  UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+}
+
+UTEST_F(ProducerTest, SendCancel) {
+  kafka::impl::ProducerConfiguration producer_configuration{};
+  producer_configuration.delivery_timeout = std::chrono::seconds{6};
+  producer_configuration.queue_buffering_max = std::chrono::seconds{3};
+
+  auto producer = MakeProducer("kafka-producer", producer_configuration);
+
+  auto send_task = producer.SendAsync(GenerateTopic(), "test-key", "test-msg");
+  send_task.RequestCancel();
+  UEXPECT_NO_THROW(send_task.Wait());
+}
+
+UTEST_F(ProducerTest, WaitingForMessageDelivery) {
+  constexpr std::size_t kSendCount{100};
+
+  kafka::impl::ProducerConfiguration producer_configuration{};
+  producer_configuration.delivery_timeout = std::chrono::milliseconds{1500};
+  producer_configuration.queue_buffering_max = std::chrono::milliseconds{1000};
+
+  auto producer = std::make_unique<kafka::Producer>(
+      utils::LazyPrvalue([this] { return MakeProducer("kafka-producer"); }));
+
+  auto send_tasks = utils::GenerateFixedArray(
+      kSendCount, [&producer, topic = GenerateTopic()](std::size_t i) {
+        return producer->SendAsync(topic, fmt::format("test-key-{}", i),
+                                   fmt::format("test-msg-{}", i));
+      });
+  /// queue_buffering_max is set to 1 seconds, therefore SendAsyncs waits for
+  /// at least 1 second, so `producer.reset()` are invoked faster than
+  /// SendAsyncs deliver the message.
+  auto destroy_task = engine::AsyncNoSpan(
+      [producer = std::move(producer)]() mutable { producer.reset(); });
+
+  UEXPECT_NO_THROW(destroy_task.Get());
+  UEXPECT_NO_THROW(engine::WaitAllChecked(send_tasks));
+}
+
+UTEST_F(ProducerTest, OneProducerManySendSync) {
+  constexpr std::size_t kSendCount{100};
+
+  auto producer = MakeProducer("kafka-producer");
+  const auto topic = GenerateTopic();
+
+  for (std::size_t send{0}; send < kSendCount; ++send) {
+    UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send),
+                                   fmt::format("test-msg-{}", send)))
+        << send;
+  }
+}
+
+UTEST_F(ProducerTest, OneProducerManySendAsync) {
+  constexpr std::size_t kSendCount{100};
+
+  auto producer = MakeProducer("kafka-producer");
+  const auto topic = GenerateTopic();
+
+  /// [Producer batch send async]
+  std::vector<engine::TaskWithResult<void>> results;
+  results.reserve(kSendCount);
+  for (std::size_t send{0}; send < kSendCount; ++send) {
+    results.emplace_back(producer.SendAsync(topic,
+                                            fmt::format("test-key-{}", send),
+                                            fmt::format("test-msg-{}", send)));
+  }
+
+  UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+  /// [Producer batch send async]
+}
+
+UTEST_F(ProducerTest, ManyProducersManySendSync) {
+  constexpr std::size_t kProducerCount{4};
+  constexpr std::size_t kSendCount{100};
+  constexpr std::size_t kTopicCount{kSendCount / 10};
+
+  kafka::impl::ProducerConfiguration producer_configuration{};
+  producer_configuration.queue_buffering_max = std::chrono::seconds{0};
+  const std::deque<kafka::Producer> producers = MakeProducers(
+      kProducerCount,
+      [](std::size_t i) { return fmt::format("kafka-producer-{}", i); },
+      producer_configuration);
+  const std::vector<std::string> topics = GenerateTopics(kTopicCount);
+
+  for (std::size_t send{0}; send < kSendCount; ++send) {
+    const auto& topic = topics.at(send % kTopicCount);
+    auto& producer = producers.at(send % kProducerCount);
+    UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send),
+                                   fmt::format("test-msg-{}", send)))
+        << send;
+  }
+}
+
+UTEST_F(ProducerTest, ManyProducersManySendAsyncSingleThread) {
+  constexpr std::size_t kProducerCount{10};
+  constexpr std::size_t kSendCount{1000};
+
+  const std::deque<kafka::Producer> producers = MakeProducers(
+      kProducerCount,
+      [](std::size_t i) { return fmt::format("kafka-producer-{}", i); });
+  const std::string topic = GenerateTopic();
+
+  std::vector<engine::TaskWithResult<void>> results;
+  results.reserve(kSendCount);
+  for (std::size_t send{0}; send < kSendCount; ++send) {
+    auto& producer = producers.at(send % kProducerCount);
+    results.emplace_back(producer.SendAsync(topic,
+                                            fmt::format("test-key-{}", send),
+                                            fmt::format("test-msg-{}", send)));
+  }
+
+  UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+}
+
+UTEST_F_MT(ProducerTest, ManyProducersManySendAsync, 4 + 4) {
+  constexpr std::size_t kProducerCount{4};
+  constexpr std::size_t kSendCount{300};
+  constexpr std::size_t kTopicCount{kSendCount / 10};
+
+  const std::deque<kafka::Producer> producers = MakeProducers(
+      kProducerCount,
+      [](std::size_t i) { return fmt::format("kafka-producer-{}", i); });
+  const std::vector<std::string> topics = GenerateTopics(kTopicCount);
+
+  std::vector<engine::TaskWithResult<void>> results;
+  results.reserve(kSendCount);
+  for (std::size_t send{0}; send < kSendCount; ++send) {
+    const auto& topic = topics.at(send % kTopicCount);
+    auto& producer = producers.at(send % kProducerCount);
+    results.emplace_back(producer.SendAsync(topic,
+                                            fmt::format("test-key-{}", send),
+                                            fmt::format("test-msg-{}", send)));
+  }
+
+  UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+}
+
+UTEST_F_MT(ProducerTest, OneProducerManySendSyncMt, 1 + 4) {
+  auto producer = MakeProducer("kafka-producer");
+
+  constexpr std::size_t kSendCount{100};
+  constexpr std::size_t kTopicCount{4};
+  constexpr std::size_t kSendPerTask{kSendCount / kTopicCount};
+  const std::vector<std::string> topics = GenerateTopics(kTopicCount);
+
+  std::vector<engine::TaskWithResult<void>> results;
+  results.reserve(GetThreadCount());
+  for (std::size_t group{0}; group + 1 < GetThreadCount(); ++group) {
+    results.emplace_back(utils::Async(
+        fmt::format("producer_test_send_sync_{}", group), [&producer, &topics] {
+          for (std::size_t send{0}; send < kSendPerTask; ++send) {
+            producer.Send(topics.at(send % topics.size()),
+                          fmt::format("test-key-{}", send),
+                          fmt::format("test-msg-{}", send));
+          }
+        }));
+  }
+
+  UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+}
+
+UTEST_F_MT(ProducerTest, OneProducerManySendAsyncMt, 1 + 4) {
+  auto producer = MakeProducer("kafka-producer");
+
+  constexpr std::size_t kSendCount{1000};
+  constexpr std::size_t kTopicCount{4};
+  constexpr std::size_t kSendPerTask{kSendCount / kTopicCount};
+  const std::vector<std::string> topics = GenerateTopics(kTopicCount);
+
+  std::vector<engine::TaskWithResult<void>> parallel_tasks;
+  parallel_tasks.reserve(GetThreadCount());
+  concurrent::Variable<std::vector<engine::TaskWithResult<void>>> results;
+  for (std::size_t group{0}; group + 1 < GetThreadCount(); ++group) {
+    parallel_tasks.emplace_back(utils::Async(
+        fmt::format("producer_test_send_async_{}", group),
+        [&producer, &results, &topics] {
+          for (std::size_t send{0}; send < kSendPerTask; ++send) {
+            auto task = producer.SendAsync(topics.at(send % topics.size()),
+                                           fmt::format("test-key-{}", send),
+                                           fmt::format("test-msg-{}", send));
+            auto results_lock = results.Lock();
+            results_lock->push_back(std::move(task));
+          }
+        }));
+  }
+  UEXPECT_NO_THROW(engine::WaitAllChecked(parallel_tasks));
+
+  auto results_lock = results.Lock();
+  UEXPECT_NO_THROW(engine::WaitAllChecked(*results_lock));
+}
 
 USERVER_NAMESPACE_END

--- a/kafka/tests/producer_test.cpp
+++ b/kafka/tests/producer_test.cpp
@@ -20,301 +20,301 @@ class ProducerTest : public KafkaCluster {};
 
 }  // namespace
 
-UTEST_F(ProducerTest, OneProducerOneSendSync) {
-  auto producer = MakeProducer("kafka-producer");
-  UEXPECT_NO_THROW(producer.Send(GenerateTopic(), "test-key", "test-msg"));
-}
-
-UTEST_F(ProducerTest, OneProducerOneSendAsync) {
-  auto producer = MakeProducer("kafka-producer");
-  auto task = producer.SendAsync(GenerateTopic(), "test-key", "test-msg");
-  UEXPECT_NO_THROW(task.Get());
-}
-
-UTEST_F(ProducerTest, BrokenConfiguration) {
-  kafka::impl::ProducerConfiguration producer_configuration{};
-  producer_configuration.delivery_timeout = std::chrono::milliseconds{1};
-  producer_configuration.queue_buffering_max = std::chrono::milliseconds{7};
-
-  UEXPECT_THROW(MakeProducer("kafka-producer", producer_configuration),
-                std::runtime_error);
-}
-
-UTEST_F(ProducerTest, LargeMessages) {
-  constexpr std::size_t kSendCount{10};
-
-  kafka::impl::ProducerConfiguration producer_configuration{};
-
-  auto producer = MakeProducer("kafka-producer");
-  const std::string topic = GenerateTopic();
-
-  const std::string big_message(producer_configuration.message_max_bytes / 2,
-                                'm');
-  for (std::size_t send{0}; send < kSendCount; ++send) {
-    UEXPECT_NO_THROW(
-        producer.Send(topic, fmt::format("test-key-{}", send), big_message));
-  }
-}
-
-UTEST_F(ProducerTest, TooLargeMessage) {
-  constexpr std::uint32_t kMessageMaxBytes{3000};
-
-  kafka::impl::ProducerConfiguration producer_configuration{};
-  producer_configuration.message_max_bytes = kMessageMaxBytes;
-  producer_configuration.rd_kafka_options["debug"] = "all";
-
-  auto producer = MakeProducer("kafka-producer", producer_configuration);
-  UEXPECT_NO_THROW(
-      producer.Send(GenerateTopic(), "small-key", "small-message"));
-
-  const std::string big_key(kMessageMaxBytes, 'k');
-  const std::string big_message(kMessageMaxBytes, 'm');
-  UEXPECT_THROW(producer.Send(GenerateTopic(), big_key, big_message),
-                kafka::MessageTooLargeException);
-}
-
-UTEST_F(ProducerTest, UnknownPartition) {
-  auto producer = MakeProducer("kafka-producer");
-  UEXPECT_THROW(producer.Send(GenerateTopic(), "test-key", "test-msg",
-                              /*partition=*/100500),
-                kafka::UnknownPartitionException);
-}
-
-UTEST_F(ProducerTest, FullQueue) {
-  constexpr std::uint32_t kMaxQueueMessages{7};
-
-  kafka::impl::ProducerConfiguration producer_configuration{};
-  producer_configuration.delivery_timeout = std::chrono::seconds{6};
-  producer_configuration.queue_buffering_max = std::chrono::seconds{3};
-  producer_configuration.queue_buffering_max_messages = kMaxQueueMessages;
-
-  auto producer = MakeProducer("kafka-producer", producer_configuration);
-  const std::string topic = GenerateTopic();
-
-  std::vector<engine::TaskWithResult<void>> results;
-  results.reserve(kMaxQueueMessages);
-  for (std::uint32_t send{0}; send < kMaxQueueMessages; ++send) {
-    results.emplace_back(producer.SendAsync(topic,
-                                            fmt::format("test-key-{}", send),
-                                            fmt::format("test-msg-{}", send)));
-  }
-  auto make_send_request =
-      [&producer, &topic, key = fmt::format("test-key-{}", kMaxQueueMessages),
-       message = fmt::format("test-msg-{}", kMaxQueueMessages)] {
-        producer.Send(topic, key, message);
-      };
-
-  UEXPECT_THROW(make_send_request(), kafka::QueueFullException);
-
-  /// [Producer retryable error]
-  bool delivered{false};
-  const auto deadline =
-      engine::Deadline::FromDuration(producer_configuration.delivery_timeout);
-  while (!delivered && !deadline.IsReached()) {
-    try {
-      make_send_request();
-      delivered = true;
-    } catch (const kafka::SendException& e) {
-      if (e.IsRetryable()) {
-        engine::InterruptibleSleepFor(std::chrono::milliseconds{10});
-        continue;
-      }
-      break;
-    }
-  }
-  /// [Producer retryable error]
-
-  EXPECT_TRUE(delivered);
-  UEXPECT_NO_THROW(engine::WaitAllChecked(results));
-}
-
-UTEST_F(ProducerTest, SendCancel) {
-  kafka::impl::ProducerConfiguration producer_configuration{};
-  producer_configuration.delivery_timeout = std::chrono::seconds{6};
-  producer_configuration.queue_buffering_max = std::chrono::seconds{3};
-
-  auto producer = MakeProducer("kafka-producer", producer_configuration);
-
-  auto send_task = producer.SendAsync(GenerateTopic(), "test-key", "test-msg");
-  send_task.RequestCancel();
-  UEXPECT_NO_THROW(send_task.Wait());
-}
-
-UTEST_F(ProducerTest, WaitingForMessageDelivery) {
-  constexpr std::size_t kSendCount{100};
-
-  kafka::impl::ProducerConfiguration producer_configuration{};
-  producer_configuration.delivery_timeout = std::chrono::milliseconds{1500};
-  producer_configuration.queue_buffering_max = std::chrono::milliseconds{1000};
-
-  auto producer = std::make_unique<kafka::Producer>(
-      utils::LazyPrvalue([this] { return MakeProducer("kafka-producer"); }));
-
-  auto send_tasks = utils::GenerateFixedArray(
-      kSendCount, [&producer, topic = GenerateTopic()](std::size_t i) {
-        return producer->SendAsync(topic, fmt::format("test-key-{}", i),
-                                   fmt::format("test-msg-{}", i));
-      });
-  /// queue_buffering_max is set to 1 seconds, therefore SendAsyncs waits for
-  /// at least 1 second, so `producer.reset()` are invoked faster than
-  /// SendAsyncs deliver the message.
-  auto destroy_task = engine::AsyncNoSpan(
-      [producer = std::move(producer)]() mutable { producer.reset(); });
-
-  UEXPECT_NO_THROW(destroy_task.Get());
-  UEXPECT_NO_THROW(engine::WaitAllChecked(send_tasks));
-}
-
-UTEST_F(ProducerTest, OneProducerManySendSync) {
-  constexpr std::size_t kSendCount{100};
-
-  auto producer = MakeProducer("kafka-producer");
-  const auto topic = GenerateTopic();
-
-  for (std::size_t send{0}; send < kSendCount; ++send) {
-    UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send),
-                                   fmt::format("test-msg-{}", send)))
-        << send;
-  }
-}
-
-UTEST_F(ProducerTest, OneProducerManySendAsync) {
-  constexpr std::size_t kSendCount{100};
-
-  auto producer = MakeProducer("kafka-producer");
-  const auto topic = GenerateTopic();
-
-  /// [Producer batch send async]
-  std::vector<engine::TaskWithResult<void>> results;
-  results.reserve(kSendCount);
-  for (std::size_t send{0}; send < kSendCount; ++send) {
-    results.emplace_back(producer.SendAsync(topic,
-                                            fmt::format("test-key-{}", send),
-                                            fmt::format("test-msg-{}", send)));
-  }
-
-  UEXPECT_NO_THROW(engine::WaitAllChecked(results));
-  /// [Producer batch send async]
-}
-
-UTEST_F(ProducerTest, ManyProducersManySendSync) {
-  constexpr std::size_t kProducerCount{4};
-  constexpr std::size_t kSendCount{100};
-  constexpr std::size_t kTopicCount{kSendCount / 10};
-
-  kafka::impl::ProducerConfiguration producer_configuration{};
-  producer_configuration.queue_buffering_max = std::chrono::seconds{0};
-  const std::deque<kafka::Producer> producers = MakeProducers(
-      kProducerCount,
-      [](std::size_t i) { return fmt::format("kafka-producer-{}", i); },
-      producer_configuration);
-  const std::vector<std::string> topics = GenerateTopics(kTopicCount);
-
-  for (std::size_t send{0}; send < kSendCount; ++send) {
-    const auto& topic = topics.at(send % kTopicCount);
-    auto& producer = producers.at(send % kProducerCount);
-    UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send),
-                                   fmt::format("test-msg-{}", send)))
-        << send;
-  }
-}
-
-UTEST_F(ProducerTest, ManyProducersManySendAsyncSingleThread) {
-  constexpr std::size_t kProducerCount{10};
-  constexpr std::size_t kSendCount{1000};
-
-  const std::deque<kafka::Producer> producers = MakeProducers(
-      kProducerCount,
-      [](std::size_t i) { return fmt::format("kafka-producer-{}", i); });
-  const std::string topic = GenerateTopic();
-
-  std::vector<engine::TaskWithResult<void>> results;
-  results.reserve(kSendCount);
-  for (std::size_t send{0}; send < kSendCount; ++send) {
-    auto& producer = producers.at(send % kProducerCount);
-    results.emplace_back(producer.SendAsync(topic,
-                                            fmt::format("test-key-{}", send),
-                                            fmt::format("test-msg-{}", send)));
-  }
-
-  UEXPECT_NO_THROW(engine::WaitAllChecked(results));
-}
-
-UTEST_F_MT(ProducerTest, ManyProducersManySendAsync, 4 + 4) {
-  constexpr std::size_t kProducerCount{4};
-  constexpr std::size_t kSendCount{300};
-  constexpr std::size_t kTopicCount{kSendCount / 10};
-
-  const std::deque<kafka::Producer> producers = MakeProducers(
-      kProducerCount,
-      [](std::size_t i) { return fmt::format("kafka-producer-{}", i); });
-  const std::vector<std::string> topics = GenerateTopics(kTopicCount);
-
-  std::vector<engine::TaskWithResult<void>> results;
-  results.reserve(kSendCount);
-  for (std::size_t send{0}; send < kSendCount; ++send) {
-    const auto& topic = topics.at(send % kTopicCount);
-    auto& producer = producers.at(send % kProducerCount);
-    results.emplace_back(producer.SendAsync(topic,
-                                            fmt::format("test-key-{}", send),
-                                            fmt::format("test-msg-{}", send)));
-  }
-
-  UEXPECT_NO_THROW(engine::WaitAllChecked(results));
-}
-
-UTEST_F_MT(ProducerTest, OneProducerManySendSyncMt, 1 + 4) {
-  auto producer = MakeProducer("kafka-producer");
-
-  constexpr std::size_t kSendCount{100};
-  constexpr std::size_t kTopicCount{4};
-  constexpr std::size_t kSendPerTask{kSendCount / kTopicCount};
-  const std::vector<std::string> topics = GenerateTopics(kTopicCount);
-
-  std::vector<engine::TaskWithResult<void>> results;
-  results.reserve(GetThreadCount());
-  for (std::size_t group{0}; group + 1 < GetThreadCount(); ++group) {
-    results.emplace_back(utils::Async(
-        fmt::format("producer_test_send_sync_{}", group), [&producer, &topics] {
-          for (std::size_t send{0}; send < kSendPerTask; ++send) {
-            producer.Send(topics.at(send % topics.size()),
-                          fmt::format("test-key-{}", send),
-                          fmt::format("test-msg-{}", send));
-          }
-        }));
-  }
-
-  UEXPECT_NO_THROW(engine::WaitAllChecked(results));
-}
-
-UTEST_F_MT(ProducerTest, OneProducerManySendAsyncMt, 1 + 4) {
-  auto producer = MakeProducer("kafka-producer");
-
-  constexpr std::size_t kSendCount{1000};
-  constexpr std::size_t kTopicCount{4};
-  constexpr std::size_t kSendPerTask{kSendCount / kTopicCount};
-  const std::vector<std::string> topics = GenerateTopics(kTopicCount);
-
-  std::vector<engine::TaskWithResult<void>> parallel_tasks;
-  parallel_tasks.reserve(GetThreadCount());
-  concurrent::Variable<std::vector<engine::TaskWithResult<void>>> results;
-  for (std::size_t group{0}; group + 1 < GetThreadCount(); ++group) {
-    parallel_tasks.emplace_back(utils::Async(
-        fmt::format("producer_test_send_async_{}", group),
-        [&producer, &results, &topics] {
-          for (std::size_t send{0}; send < kSendPerTask; ++send) {
-            auto task = producer.SendAsync(topics.at(send % topics.size()),
-                                           fmt::format("test-key-{}", send),
-                                           fmt::format("test-msg-{}", send));
-            auto results_lock = results.Lock();
-            results_lock->push_back(std::move(task));
-          }
-        }));
-  }
-  UEXPECT_NO_THROW(engine::WaitAllChecked(parallel_tasks));
-
-  auto results_lock = results.Lock();
-  UEXPECT_NO_THROW(engine::WaitAllChecked(*results_lock));
-}
+// UTEST_F(ProducerTest, OneProducerOneSendSync) {
+//   auto producer = MakeProducer("kafka-producer");
+//   UEXPECT_NO_THROW(producer.Send(GenerateTopic(), "test-key", "test-msg"));
+// }
+// 
+// UTEST_F(ProducerTest, OneProducerOneSendAsync) {
+//   auto producer = MakeProducer("kafka-producer");
+//   auto task = producer.SendAsync(GenerateTopic(), "test-key", "test-msg");
+//   UEXPECT_NO_THROW(task.Get());
+// }
+// 
+// UTEST_F(ProducerTest, BrokenConfiguration) {
+//   kafka::impl::ProducerConfiguration producer_configuration{};
+//   producer_configuration.delivery_timeout = std::chrono::milliseconds{1};
+//   producer_configuration.queue_buffering_max = std::chrono::milliseconds{7};
+// 
+//   UEXPECT_THROW(MakeProducer("kafka-producer", producer_configuration),
+//                 std::runtime_error);
+// }
+// 
+// UTEST_F(ProducerTest, LargeMessages) {
+//   constexpr std::size_t kSendCount{10};
+// 
+//   kafka::impl::ProducerConfiguration producer_configuration{};
+// 
+//   auto producer = MakeProducer("kafka-producer");
+//   const std::string topic = GenerateTopic();
+// 
+//   const std::string big_message(producer_configuration.message_max_bytes / 2,
+//                                 'm');
+//   for (std::size_t send{0}; send < kSendCount; ++send) {
+//     UEXPECT_NO_THROW(
+//         producer.Send(topic, fmt::format("test-key-{}", send), big_message));
+//   }
+// }
+// 
+// UTEST_F(ProducerTest, TooLargeMessage) {
+//   constexpr std::uint32_t kMessageMaxBytes{3000};
+// 
+//   kafka::impl::ProducerConfiguration producer_configuration{};
+//   producer_configuration.message_max_bytes = kMessageMaxBytes;
+//   producer_configuration.rd_kafka_options["debug"] = "all";
+// 
+//   auto producer = MakeProducer("kafka-producer", producer_configuration);
+//   UEXPECT_NO_THROW(
+//       producer.Send(GenerateTopic(), "small-key", "small-message"));
+// 
+//   const std::string big_key(kMessageMaxBytes, 'k');
+//   const std::string big_message(kMessageMaxBytes, 'm');
+//   UEXPECT_THROW(producer.Send(GenerateTopic(), big_key, big_message),
+//                 kafka::MessageTooLargeException);
+// }
+// 
+// UTEST_F(ProducerTest, UnknownPartition) {
+//   auto producer = MakeProducer("kafka-producer");
+//   UEXPECT_THROW(producer.Send(GenerateTopic(), "test-key", "test-msg",
+//                               /*partition=*/100500),
+//                 kafka::UnknownPartitionException);
+// }
+// 
+// UTEST_F(ProducerTest, FullQueue) {
+//   constexpr std::uint32_t kMaxQueueMessages{7};
+// 
+//   kafka::impl::ProducerConfiguration producer_configuration{};
+//   producer_configuration.delivery_timeout = std::chrono::seconds{6};
+//   producer_configuration.queue_buffering_max = std::chrono::seconds{3};
+//   producer_configuration.queue_buffering_max_messages = kMaxQueueMessages;
+// 
+//   auto producer = MakeProducer("kafka-producer", producer_configuration);
+//   const std::string topic = GenerateTopic();
+// 
+//   std::vector<engine::TaskWithResult<void>> results;
+//   results.reserve(kMaxQueueMessages);
+//   for (std::uint32_t send{0}; send < kMaxQueueMessages; ++send) {
+//     results.emplace_back(producer.SendAsync(topic,
+//                                             fmt::format("test-key-{}", send),
+//                                             fmt::format("test-msg-{}", send)));
+//   }
+//   auto make_send_request =
+//       [&producer, &topic, key = fmt::format("test-key-{}", kMaxQueueMessages),
+//        message = fmt::format("test-msg-{}", kMaxQueueMessages)] {
+//         producer.Send(topic, key, message);
+//       };
+// 
+//   UEXPECT_THROW(make_send_request(), kafka::QueueFullException);
+// 
+//   /// [Producer retryable error]
+//   bool delivered{false};
+//   const auto deadline =
+//       engine::Deadline::FromDuration(producer_configuration.delivery_timeout);
+//   while (!delivered && !deadline.IsReached()) {
+//     try {
+//       make_send_request();
+//       delivered = true;
+//     } catch (const kafka::SendException& e) {
+//       if (e.IsRetryable()) {
+//         engine::InterruptibleSleepFor(std::chrono::milliseconds{10});
+//         continue;
+//       }
+//       break;
+//     }
+//   }
+//   /// [Producer retryable error]
+// 
+//   EXPECT_TRUE(delivered);
+//   UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+// }
+// 
+// UTEST_F(ProducerTest, SendCancel) {
+//   kafka::impl::ProducerConfiguration producer_configuration{};
+//   producer_configuration.delivery_timeout = std::chrono::seconds{6};
+//   producer_configuration.queue_buffering_max = std::chrono::seconds{3};
+// 
+//   auto producer = MakeProducer("kafka-producer", producer_configuration);
+// 
+//   auto send_task = producer.SendAsync(GenerateTopic(), "test-key", "test-msg");
+//   send_task.RequestCancel();
+//   UEXPECT_NO_THROW(send_task.Wait());
+// }
+// 
+// UTEST_F(ProducerTest, WaitingForMessageDelivery) {
+//   constexpr std::size_t kSendCount{100};
+// 
+//   kafka::impl::ProducerConfiguration producer_configuration{};
+//   producer_configuration.delivery_timeout = std::chrono::milliseconds{1500};
+//   producer_configuration.queue_buffering_max = std::chrono::milliseconds{1000};
+// 
+//   auto producer = std::make_unique<kafka::Producer>(
+//       utils::LazyPrvalue([this] { return MakeProducer("kafka-producer"); }));
+// 
+//   auto send_tasks = utils::GenerateFixedArray(
+//       kSendCount, [&producer, topic = GenerateTopic()](std::size_t i) {
+//         return producer->SendAsync(topic, fmt::format("test-key-{}", i),
+//                                    fmt::format("test-msg-{}", i));
+//       });
+//   /// queue_buffering_max is set to 1 seconds, therefore SendAsyncs waits for
+//   /// at least 1 second, so `producer.reset()` are invoked faster than
+//   /// SendAsyncs deliver the message.
+//   auto destroy_task = engine::AsyncNoSpan(
+//       [producer = std::move(producer)]() mutable { producer.reset(); });
+// 
+//   UEXPECT_NO_THROW(destroy_task.Get());
+//   UEXPECT_NO_THROW(engine::WaitAllChecked(send_tasks));
+// }
+// 
+// UTEST_F(ProducerTest, OneProducerManySendSync) {
+//   constexpr std::size_t kSendCount{100};
+// 
+//   auto producer = MakeProducer("kafka-producer");
+//   const auto topic = GenerateTopic();
+// 
+//   for (std::size_t send{0}; send < kSendCount; ++send) {
+//     UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send),
+//                                    fmt::format("test-msg-{}", send)))
+//         << send;
+//   }
+// }
+// 
+// UTEST_F(ProducerTest, OneProducerManySendAsync) {
+//   constexpr std::size_t kSendCount{100};
+// 
+//   auto producer = MakeProducer("kafka-producer");
+//   const auto topic = GenerateTopic();
+// 
+//   /// [Producer batch send async]
+//   std::vector<engine::TaskWithResult<void>> results;
+//   results.reserve(kSendCount);
+//   for (std::size_t send{0}; send < kSendCount; ++send) {
+//     results.emplace_back(producer.SendAsync(topic,
+//                                             fmt::format("test-key-{}", send),
+//                                             fmt::format("test-msg-{}", send)));
+//   }
+// 
+//   UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+//   /// [Producer batch send async]
+// }
+// 
+// UTEST_F(ProducerTest, ManyProducersManySendSync) {
+//   constexpr std::size_t kProducerCount{4};
+//   constexpr std::size_t kSendCount{100};
+//   constexpr std::size_t kTopicCount{kSendCount / 10};
+// 
+//   kafka::impl::ProducerConfiguration producer_configuration{};
+//   producer_configuration.queue_buffering_max = std::chrono::seconds{0};
+//   const std::deque<kafka::Producer> producers = MakeProducers(
+//       kProducerCount,
+//       [](std::size_t i) { return fmt::format("kafka-producer-{}", i); },
+//       producer_configuration);
+//   const std::vector<std::string> topics = GenerateTopics(kTopicCount);
+// 
+//   for (std::size_t send{0}; send < kSendCount; ++send) {
+//     const auto& topic = topics.at(send % kTopicCount);
+//     auto& producer = producers.at(send % kProducerCount);
+//     UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send),
+//                                    fmt::format("test-msg-{}", send)))
+//         << send;
+//   }
+// }
+// 
+// UTEST_F(ProducerTest, ManyProducersManySendAsyncSingleThread) {
+//   constexpr std::size_t kProducerCount{10};
+//   constexpr std::size_t kSendCount{1000};
+// 
+//   const std::deque<kafka::Producer> producers = MakeProducers(
+//       kProducerCount,
+//       [](std::size_t i) { return fmt::format("kafka-producer-{}", i); });
+//   const std::string topic = GenerateTopic();
+// 
+//   std::vector<engine::TaskWithResult<void>> results;
+//   results.reserve(kSendCount);
+//   for (std::size_t send{0}; send < kSendCount; ++send) {
+//     auto& producer = producers.at(send % kProducerCount);
+//     results.emplace_back(producer.SendAsync(topic,
+//                                             fmt::format("test-key-{}", send),
+//                                             fmt::format("test-msg-{}", send)));
+//   }
+// 
+//   UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+// }
+// 
+// UTEST_F_MT(ProducerTest, ManyProducersManySendAsync, 4 + 4) {
+//   constexpr std::size_t kProducerCount{4};
+//   constexpr std::size_t kSendCount{300};
+//   constexpr std::size_t kTopicCount{kSendCount / 10};
+// 
+//   const std::deque<kafka::Producer> producers = MakeProducers(
+//       kProducerCount,
+//       [](std::size_t i) { return fmt::format("kafka-producer-{}", i); });
+//   const std::vector<std::string> topics = GenerateTopics(kTopicCount);
+// 
+//   std::vector<engine::TaskWithResult<void>> results;
+//   results.reserve(kSendCount);
+//   for (std::size_t send{0}; send < kSendCount; ++send) {
+//     const auto& topic = topics.at(send % kTopicCount);
+//     auto& producer = producers.at(send % kProducerCount);
+//     results.emplace_back(producer.SendAsync(topic,
+//                                             fmt::format("test-key-{}", send),
+//                                             fmt::format("test-msg-{}", send)));
+//   }
+// 
+//   UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+// }
+// 
+// UTEST_F_MT(ProducerTest, OneProducerManySendSyncMt, 1 + 4) {
+//   auto producer = MakeProducer("kafka-producer");
+// 
+//   constexpr std::size_t kSendCount{100};
+//   constexpr std::size_t kTopicCount{4};
+//   constexpr std::size_t kSendPerTask{kSendCount / kTopicCount};
+//   const std::vector<std::string> topics = GenerateTopics(kTopicCount);
+// 
+//   std::vector<engine::TaskWithResult<void>> results;
+//   results.reserve(GetThreadCount());
+//   for (std::size_t group{0}; group + 1 < GetThreadCount(); ++group) {
+//     results.emplace_back(utils::Async(
+//         fmt::format("producer_test_send_sync_{}", group), [&producer, &topics] {
+//           for (std::size_t send{0}; send < kSendPerTask; ++send) {
+//             producer.Send(topics.at(send % topics.size()),
+//                           fmt::format("test-key-{}", send),
+//                           fmt::format("test-msg-{}", send));
+//           }
+//         }));
+//   }
+// 
+//   UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+// }
+// 
+// UTEST_F_MT(ProducerTest, OneProducerManySendAsyncMt, 1 + 4) {
+//   auto producer = MakeProducer("kafka-producer");
+// 
+//   constexpr std::size_t kSendCount{1000};
+//   constexpr std::size_t kTopicCount{4};
+//   constexpr std::size_t kSendPerTask{kSendCount / kTopicCount};
+//   const std::vector<std::string> topics = GenerateTopics(kTopicCount);
+// 
+//   std::vector<engine::TaskWithResult<void>> parallel_tasks;
+//   parallel_tasks.reserve(GetThreadCount());
+//   concurrent::Variable<std::vector<engine::TaskWithResult<void>>> results;
+//   for (std::size_t group{0}; group + 1 < GetThreadCount(); ++group) {
+//     parallel_tasks.emplace_back(utils::Async(
+//         fmt::format("producer_test_send_async_{}", group),
+//         [&producer, &results, &topics] {
+//           for (std::size_t send{0}; send < kSendPerTask; ++send) {
+//             auto task = producer.SendAsync(topics.at(send % topics.size()),
+//                                            fmt::format("test-key-{}", send),
+//                                            fmt::format("test-msg-{}", send));
+//             auto results_lock = results.Lock();
+//             results_lock->push_back(std::move(task));
+//           }
+//         }));
+//   }
+//   UEXPECT_NO_THROW(engine::WaitAllChecked(parallel_tasks));
+// 
+//   auto results_lock = results.Lock();
+//   UEXPECT_NO_THROW(engine::WaitAllChecked(*results_lock));
+// }
 
 USERVER_NAMESPACE_END

--- a/kafka/tests/test_utils.cpp
+++ b/kafka/tests/test_utils.cpp
@@ -28,8 +28,9 @@ kafka::impl::Secret MakeSecrets(std::string_view bootstrap_servers) {
 }  // namespace
 
 bool operator==(const Message& lhs, const Message& rhs){
-    return std::tie(lhs.topic, lhs.key, lhs.payload, lhs.partition) ==
-           std::tie(rhs.topic, rhs.key, rhs.payload, rhs.partition)}
+  return std::tie(lhs.topic, lhs.key, lhs.payload, lhs.partition) ==
+         std::tie(rhs.topic, rhs.key, rhs.payload, rhs.partition);
+}
 
 std::ostream& operator<<(std::ostream& out, const Message& message) {
   return out << fmt::format(

--- a/kafka/tests/test_utils.cpp
+++ b/kafka/tests/test_utils.cpp
@@ -27,6 +27,11 @@ kafka::impl::Secret MakeSecrets(std::string_view bootstrap_servers) {
 
 }  // namespace
 
+bool operator==(const Message& lhs, const Message& rhs) {
+  return lhs.topic == rhs.topic && lhs.key == rhs.key &&
+         lhs.payload == rhs.payload && lhs.partition == rhs.partition;
+}
+
 std::ostream& operator<<(std::ostream& out, const Message& message) {
   return out << fmt::format(
              "Message{{topic: '{}', key: '{}', payload: '{}', partition: "

--- a/kafka/tests/test_utils.cpp
+++ b/kafka/tests/test_utils.cpp
@@ -27,10 +27,9 @@ kafka::impl::Secret MakeSecrets(std::string_view bootstrap_servers) {
 
 }  // namespace
 
-bool operator==(const Message& lhs, const Message& rhs) {
-  return lhs.topic == rhs.topic && lhs.key == rhs.key &&
-         lhs.payload == rhs.payload && lhs.partition == rhs.partition;
-}
+bool operator==(const Message& lhs, const Message& rhs){
+    return std::tie(lhs.topic, lhs.key, lhs.payload, lhs.partition) ==
+           std::tie(rhs.topic, rhs.key, rhs.payload, rhs.partition)}
 
 std::ostream& operator<<(std::ostream& out, const Message& message) {
   return out << fmt::format(

--- a/kafka/tests/test_utils.hpp
+++ b/kafka/tests/test_utils.hpp
@@ -19,9 +19,9 @@ struct Message {
   std::string key;
   std::string payload;
   std::optional<std::uint32_t> partition;
-
-  bool operator==(const Message& other) const = default;
 };
+
+bool operator==(const Message& lhs, const Message& rhs);
 
 std::ostream& operator<<(std::ostream&, const Message&);
 


### PR DESCRIPTION
Add client.id for producer and consumer into `CommonConfiguration`.

From kafka documentations:
>  Optional, but you should set this property on each instance because it enables you to more easily correlate requests on the broker with the client instance which made it, which can be helpful in debugging and troubleshooting scenarios.

Default value set to` userver`, because librdkafka use` rdkafka` as default id.

I added unittests, but didn't enable it's. They required real kafka instance

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/
