### PR TITLE
Histogram values sum implementation

### DIFF
--- a/core/include/userver/utils/statistics/histogram_view.hpp
+++ b/core/include/userver/utils/statistics/histogram_view.hpp
@@ -45,6 +45,16 @@ class HistogramView final {
   /// Returns the sum of counts from all buckets.
   std::uint64_t GetTotalCount() const noexcept;
 
+  /// Returns sum of values from the given bucket.
+  double GetSumAt(std::size_t index) const;
+
+  // Returns sum of values from the "infinity" bucket
+  /// (greater than the largest bucket boundary).
+  double GetSumAtInf() const noexcept;
+
+  /// Returns sum of values from all buckets.
+  double GetTotalSum() const noexcept;
+
  private:
   friend struct impl::histogram::Access;
 

--- a/core/include/userver/utils/statistics/impl/histogram_bucket.hpp
+++ b/core/include/userver/utils/statistics/impl/histogram_bucket.hpp
@@ -31,6 +31,7 @@ struct Bucket final {
 
   BoundOrSize upper_bound{0.0};
   std::atomic<std::uint64_t> counter{0};
+  std::atomic<double> sum{0.0};
 };
 
 void CopyBounds(Bucket* bucket_array, utils::span<const double> upper_bounds);

--- a/core/src/utils/statistics/histogram.cpp
+++ b/core/src/utils/statistics/histogram.cpp
@@ -154,6 +154,7 @@ void Histogram::Account(double value, std::uint64_t count) noexcept {
       pre_bucket_index + 1 > bucket_count_ ? 0 : pre_bucket_index + 1;
   auto& bucket = buckets_[bucket_index];
   bucket.counter.fetch_add(count, std::memory_order_relaxed);
+  impl::histogram::AddAtomic(bucket.sum, value * count);
 }
 
 void ResetMetric(Histogram& histogram) noexcept {

--- a/core/src/utils/statistics/histogram_test.cpp
+++ b/core/src/utils/statistics/histogram_test.cpp
@@ -145,6 +145,18 @@ UTEST(StatisticsHistogram, Reset) {
   EXPECT_EQ(histogram.GetView(), zero_histogram.GetView());
 }
 
+UTEST(StatisticsHistogram, Sum) {
+  utils::statistics::Histogram histogram{Bounds()};
+  AccountSome(histogram);
+
+  EXPECT_EQ(histogram.GetView().GetSumAt(0), 1.2);
+  EXPECT_EQ(histogram.GetView().GetSumAt(1), 1.8);
+  EXPECT_EQ(histogram.GetView().GetSumAt(2), 10 + 30 * 4);
+  EXPECT_EQ(histogram.GetView().GetSumAt(3), 0.0);
+  EXPECT_EQ(histogram.GetView().GetSumAtInf(), 100);
+  EXPECT_EQ(histogram.GetView().GetTotalSum(), 1.2 + 1.8 + 10 + 30 * 4 + 100);
+}
+
 UTEST(StatisticsHistogram, ZeroBuckets) {
   utils::statistics::Histogram histogram{std::vector<double>{}};
   EXPECT_EQ(histogram.GetView().GetBucketCount(), 0);
@@ -283,7 +295,8 @@ UTEST_F(StatisticsHistogramFormat, JsonFormat) {
       "value": {
         "bounds": [1.5, 5.0, 42.0, 60.0],
         "buckets": [1, 1, 5, 0],
-        "inf": 1
+        "inf": 1,
+        "sum":233.0
       },
       "labels": {},
       "type": "HIST_RATE"
@@ -306,6 +319,7 @@ test_bucket{le="42"} 7
 test_bucket{le="60"} 7
 test_bucket{le="+Inf"} 8
 test_count{} 8
+test_sum{} 233
 )";
   EXPECT_EQ(utils::statistics::ToPrometheusFormat(GetStorage()), expected);
 }
@@ -318,6 +332,7 @@ test_bucket{le="42"} 7
 test_bucket{le="60"} 7
 test_bucket{le="+Inf"} 8
 test_count{} 8
+test_sum{} 233
 )";
   EXPECT_EQ(utils::statistics::ToPrometheusFormatUntyped(GetStorage()),
             expected);
@@ -340,6 +355,7 @@ test_bucket{le="42",custom_label_1="1",custom_label_2="2"} 7
 test_bucket{le="60",custom_label_1="1",custom_label_2="2"} 7
 test_bucket{le="+Inf",custom_label_1="1",custom_label_2="2"} 8
 test_count{custom_label_1="1",custom_label_2="2"} 8
+test_sum{custom_label_1="1",custom_label_2="2"} 233
 )";
   EXPECT_EQ(utils::statistics::ToPrometheusFormat(storage), expected);
 }
@@ -364,7 +380,8 @@ UTEST_F(StatisticsHistogramFormat, SolomonFormat) {
       "hist": {
         "bounds": [1.5, 5.0, 42.0, 60.0],
         "buckets": [1, 1, 5, 0],
-        "inf": 1
+        "inf": 1,
+        "sum": 233.0
       },
       "type": "HIST_RATE"
     }

--- a/core/src/utils/statistics/histogram_view.cpp
+++ b/core/src/utils/statistics/histogram_view.cpp
@@ -47,6 +47,25 @@ std::uint64_t HistogramView::GetTotalCount() const noexcept {
   return total;
 }
 
+double HistogramView::GetSumAt(std::size_t index) const {
+  UASSERT(index < GetBucketCount());
+  return buckets_[index + 1].sum.load(std::memory_order_relaxed);
+}
+
+double HistogramView::GetSumAtInf() const noexcept {
+  UASSERT(buckets_);
+  return buckets_[0].sum.load(std::memory_order_relaxed);
+}
+
+double HistogramView::GetTotalSum() const noexcept {
+  const auto bucket_count = GetBucketCount();
+  auto total = GetSumAtInf();
+  for (std::size_t i = 0; i < bucket_count; ++i) {
+    total += GetSumAt(i);
+  }
+  return total;
+}
+
 void DumpMetric(Writer& writer, HistogramView histogram) { writer = histogram; }
 
 bool operator==(HistogramView lhs, HistogramView rhs) noexcept {

--- a/core/src/utils/statistics/impl/histogram_bucket.cpp
+++ b/core/src/utils/statistics/impl/histogram_bucket.cpp
@@ -8,13 +8,16 @@ namespace utils::statistics::impl::histogram {
 
 Bucket::Bucket(const Bucket& other) noexcept
     : upper_bound(other.upper_bound),
-      counter(other.counter.load(std::memory_order_relaxed)) {}
+      counter(other.counter.load(std::memory_order_relaxed)),
+      sum(other.sum.load(std::memory_order_relaxed)) {}
 
 Bucket& Bucket::operator=(const Bucket& other) noexcept {
   if (this == &other) return *this;
   upper_bound = other.upper_bound;
   counter.store(other.counter.load(std::memory_order_relaxed),
                 std::memory_order_relaxed);
+  sum.store(other.sum.load(std::memory_order_relaxed),
+            std::memory_order_relaxed);
   return *this;
 }
 

--- a/core/src/utils/statistics/impl/histogram_serialization.hpp
+++ b/core/src/utils/statistics/impl/histogram_serialization.hpp
@@ -14,6 +14,7 @@ Value Serialize(HistogramView value, formats::serialize::To<Value>) {
   result["bounds"] = impl::histogram::Access::Bounds(value);
   result["buckets"] = impl::histogram::Access::Values(value);
   result["inf"] = value.GetValueAtInf();
+  result["sum"] = value.GetTotalSum();
   return result.ExtractValue();
 }
 
@@ -26,6 +27,8 @@ void WriteToStream(HistogramView value, StringBuilder& sw) {
   WriteToStream(impl::histogram::Access::Values(value), sw);
   sw.Key("inf");
   WriteToStream(value.GetValueAtInf(), sw);
+  sw.Key("sum");
+  WriteToStream(value.GetTotalSum(), sw);
 }
 
 }  // namespace utils::statistics

--- a/core/src/utils/statistics/prometheus.cpp
+++ b/core/src/utils/statistics/prometheus.cpp
@@ -85,6 +85,9 @@ class FormatBuilder final : public utils::statistics::BaseFormatBuilder {
     AppendHistogramMetric("count", prometheus_name,
                           /* upper_bound */ "",
                           fmt::to_string(histogram.GetTotalCount()), labels);
+    AppendHistogramMetric("sum", prometheus_name,
+                          /* upper_bound */ "",
+                          fmt::to_string(histogram.GetTotalSum()), labels);
   }
 
   void DumpMetricNameAndType(std::string_view name, const MetricValue& value) {


### PR DESCRIPTION
Implementation of values total sum calculation in histograms.

The total sum of values is required to comply with Prometheus format standard:
https://prometheus.io/docs/concepts/metric_types/#histogram

Also, sum allows to calculate the average value, which could be useful for some metrics.

The corresponding issue:
https://github.com/userver-framework/userver/issues/707