### PR TITLE
Add missing <fmt/ranges.h> includes

### DIFF
--- a/core/include/userver/utils/statistics/fmt.hpp
+++ b/core/include/userver/utils/statistics/fmt.hpp
@@ -11,6 +11,7 @@
 #include <variant>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <userver/utils/fmt_compat.hpp>
 #include <userver/utils/overloaded.hpp>

--- a/core/src/engine/subprocess/process_starter.cpp
+++ b/core/src/engine/subprocess/process_starter.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <boost/range/adaptor/transformed.hpp>
 
 #include <engine/ev/child_process_map.hpp>

--- a/core/src/logging/component.cpp
+++ b/core/src/logging/component.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <stdexcept>
 
+#include <fmt/ranges.h>
 #include <logging/config.hpp>
 #include <logging/impl/tcp_socket_sink.hpp>
 #include <logging/tp_logger.hpp>

--- a/core/src/server/handlers/auth/digest/auth_checker_base.cpp
+++ b/core/src/server/handlers/auth/digest/auth_checker_base.cpp
@@ -9,6 +9,7 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <userver/crypto/algorithm.hpp>
 #include <userver/crypto/hash.hpp>

--- a/core/src/server/handlers/auth/digest/exception.cpp
+++ b/core/src/server/handlers/auth/digest/exception.cpp
@@ -1,6 +1,7 @@
 #include <userver/server/handlers/auth/digest/exception.hpp>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 USERVER_NAMESPACE_BEGIN
 

--- a/core/src/server/handlers/implicit_options.cpp
+++ b/core/src/server/handlers/implicit_options.cpp
@@ -1,6 +1,7 @@
 #include <userver/server/handlers/implicit_options.hpp>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <server/handlers/auth/auth_checker.hpp>
 #include <server/http/handler_info_index.hpp>

--- a/core/src/server/net/create_socket.cpp
+++ b/core/src/server/net/create_socket.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <boost/filesystem/operations.hpp>
 
 #include <userver/engine/io/socket.hpp>

--- a/core/src/testsuite/cache_control.cpp
+++ b/core/src/testsuite/cache_control.cpp
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <boost/intrusive/list.hpp>
 
 #include <userver/cache/cache_config.hpp>

--- a/core/src/utils/statistics/portability_info.cpp
+++ b/core/src/utils/statistics/portability_info.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <userver/formats/json.hpp>
 #include <userver/formats/json/serialize.hpp>


### PR DESCRIPTION
Added missing `#include <fmt/ranges.h>`. Without them the build on macOS fails with multiple `error: no member named 'join' in namespace 'fmt'`.

Issue: https://github.com/userver-framework/userver/issues/689