### PR TITLE
Add secdist parameters (user, password, secure_connection_cert) to ydb

### DIFF
--- a/ydb/src/ydb/impl/config.cpp
+++ b/ydb/src/ydb/impl/config.cpp
@@ -68,6 +68,9 @@ DriverSettings ParseDriverSettings(
     result.endpoint = MergeWithSecdist(dbsecdist.endpoint, std::move(config_endpoint), dbconfig, "endpoint");
     result.database = MergeWithSecdist(dbsecdist.database, std::move(config_database), dbconfig, "database");
     result.oauth_token = dbsecdist.oauth_token;
+    result.secure_connection_cert = dbsecdist.secure_connection_cert;
+    result.user = dbsecdist.user;
+    result.password = dbsecdist.password;
     if (dbsecdist.iam_jwt_params.has_value()) {
         result.iam_jwt_params = formats::json::ToString(dbsecdist.iam_jwt_params.value());
     }

--- a/ydb/src/ydb/impl/config.hpp
+++ b/ydb/src/ydb/impl/config.hpp
@@ -46,6 +46,9 @@ struct DriverSettings {
     bool prefer_local_dc{false};
     std::optional<std::string> oauth_token;
     std::optional<std::string> iam_jwt_params;
+    std::optional<std::string> secure_connection_cert;
+    std::optional<std::string> user;
+    std::optional<std::string> password;
     std::shared_ptr<NYdb::ICredentialsProviderFactory> credentials_provider_factory;
 };
 

--- a/ydb/src/ydb/impl/secdist.cpp
+++ b/ydb/src/ydb/impl/secdist.cpp
@@ -16,6 +16,9 @@ DatabaseSettings GetDatabaseSettings(const formats::json::Value& doc) {
     settings.endpoint = doc["endpoint"].As<std::optional<std::string>>();
     settings.database = doc["database"].As<std::optional<std::string>>();
     settings.sync_start = doc["sync_start"].As<std::optional<bool>>();
+    settings.secure_connection_cert = doc["secure_connection_cert"].As<std::optional<std::string>>();
+    settings.user = doc["user"].As<std::optional<std::string>>();
+    settings.password = doc["password"].As<std::optional<std::string>>();
     if (doc.HasMember("token")) {
         settings.oauth_token = doc["token"].As<std::string>();
     } else if (doc.HasMember("iam_jwt_params")) {

--- a/ydb/src/ydb/impl/secdist.hpp
+++ b/ydb/src/ydb/impl/secdist.hpp
@@ -13,6 +13,9 @@ struct DatabaseSettings final {
     std::optional<std::string> endpoint;
     std::optional<std::string> database;
     std::optional<std::string> oauth_token;
+    std::optional<std::string> secure_connection_cert;
+    std::optional<std::string> user;
+    std::optional<std::string> password;
     std::optional<formats::json::Value> iam_jwt_params;
     std::optional<bool> sync_start;
 };


### PR DESCRIPTION
Добавил параметры user, password, secure_connection_cert в настройки secdist для ydb.
Обеспечил их поддержку при конфигурировании драйвера ydb.


------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

