### PR TITLE
feat chaotic: additionalProperties is optional

### DIFF
--- a/chaotic/chaotic/front/types.py
+++ b/chaotic/chaotic/front/types.py
@@ -304,7 +304,7 @@ class Array(Schema):
 @dataclasses.dataclass
 class SchemaObjectRaw:
     type: str
-    additionalProperties: Any
+    additionalProperties: Any = True
     properties: Optional[dict] = None
     required: Optional[List[str]] = None
     nullable: bool = False


### PR DESCRIPTION
Здравствуйте!
additionalProperties в openapi не обязательный параметр. Сделайте пожалуйста в chaotic тоже его не обязательным.





------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

