### PR TITLE
fix chaotic: fix USERVER_CHAOTIC_FORMAT option for CMake build

### DIFF
--- a/cmake/ChaoticGen.cmake
+++ b/cmake/ChaoticGen.cmake
@@ -28,7 +28,7 @@ function(_userver_prepare_chaotic)
   find_program(CLANG_FORMAT_BIN clang-format)
   message(STATUS "Found clang-format: ${CLANG_FORMAT_BIN}")
   set_property(GLOBAL PROPERTY userver_clang_format_bin "${CLANG_FORMAT_BIN}")
-  option(USERVER_CHAOTIC_FORMAT ON "Whether to format generated code")
+  option(USERVER_CHAOTIC_FORMAT "Whether to format generated code" ON)
 
   if(NOT USERVER_CHAOTIC_SCRIPTS_PATH)
     get_filename_component(USERVER_DIR "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)


### PR DESCRIPTION
Relates: #796
Tested: localhost








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

