### PR TITLE
Parametrized chaotic exceptions

### DIFF
--- a/chaotic/include/userver/chaotic/exception.hpp
+++ b/chaotic/include/userver/chaotic/exception.hpp
@@ -10,13 +10,14 @@ USERVER_NAMESPACE_BEGIN
 
 namespace chaotic {
 
-class Error final : public formats::json::Exception {
-    using Exception::Exception;
+template <typename Value>
+class Error final : public Value::Exception {
+    using Value::Exception::Exception;
 };
 
 template <typename Value>
 [[noreturn]] inline void ThrowForValue(std::string_view str, Value value) {
-    throw Error(fmt::format("Error at path '{}': {}", value.GetPath(), str));
+    throw Error<Value>(fmt::format("Error at path '{}': {}", value.GetPath(), str));
 }
 
 }  // namespace chaotic

--- a/chaotic/include/userver/chaotic/object.hpp
+++ b/chaotic/include/userver/chaotic/object.hpp
@@ -8,6 +8,7 @@
 #include <userver/formats/common/items.hpp>
 #include <userver/formats/json/value_builder.hpp>
 #include <userver/utils/trivial_map.hpp>
+#include <userver/chaotic/exception.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -30,7 +31,7 @@ void ValidateNoAdditionalProperties(const Value& json, const utils::TrivialSet<B
     for (const auto& [name, value] : formats::common::Items(json)) {
         if (names_to_exclude.Contains(name)) continue;
 
-        throw std::runtime_error(fmt::format("Unknown property '{}'", name));
+        throw Error<Value>(fmt::format("Unknown property '{}'", name));
     }
 }
 

--- a/chaotic/integration_tests/tests/lib/array.cpp
+++ b/chaotic/integration_tests/tests/lib/array.cpp
@@ -38,7 +38,7 @@ TEST(Array, OfIntWithValidators) {
 
     const auto kJson1 = formats::json::MakeArray("foo");
     UEXPECT_THROW_MSG(
-        kJson1.As<Arr>(), chaotic::Error<userver::formats::json::Value>, "Error at path '/': Too short array, minimum length=2, given=1"
+        kJson1.As<Arr>(), chaotic::Error<formats::json::Value>, "Error at path '/': Too short array, minimum length=2, given=1"
     );
 }
 

--- a/chaotic/integration_tests/tests/lib/array.cpp
+++ b/chaotic/integration_tests/tests/lib/array.cpp
@@ -7,6 +7,7 @@
 #include <userver/chaotic/array.hpp>
 #include <userver/chaotic/primitive.hpp>
 #include <userver/chaotic/validators.hpp>
+#include <userver/formats/json.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -37,7 +38,7 @@ TEST(Array, OfIntWithValidators) {
 
     const auto kJson1 = formats::json::MakeArray("foo");
     UEXPECT_THROW_MSG(
-        kJson1.As<Arr>(), chaotic::Error, "Error at path '/': Too short array, minimum length=2, given=1"
+        kJson1.As<Arr>(), chaotic::Error<userver::formats::json::Value>, "Error at path '/': Too short array, minimum length=2, given=1"
     );
 }
 

--- a/chaotic/integration_tests/tests/lib/primitive.cpp
+++ b/chaotic/integration_tests/tests/lib/primitive.cpp
@@ -69,9 +69,9 @@ TEST(Primitive, IntMinMax) {
     int x = kJson["foo"].As<Int>();
     EXPECT_EQ(x, 1);
 
-    UEXPECT_THROW_MSG(kJson["bar"].As<Int>(), chaotic::Error<userver::formats::json::Value>,
+    UEXPECT_THROW_MSG(kJson["bar"].As<Int>(), chaotic::Error<formats::json::Value>,
         "Error at path 'bar': Invalid value, minimum=1, given=0");
-    UEXPECT_THROW_MSG(kJson["zoo"].As<Int>(), chaotic::Error<userver::formats::json::Value>,
+    UEXPECT_THROW_MSG(kJson["zoo"].As<Int>(), chaotic::Error<formats::json::Value>,
         "Error at path 'zoo': Invalid value, maximum=5, given=6");
 }
 
@@ -82,9 +82,9 @@ TEST(Primitive, UserTypeMinMax) {
     MyInt x = kJson["foo"].As<Int>();
     EXPECT_EQ(x.value, 1);
 
-    UEXPECT_THROW_MSG(kJson["bar"].As<Int>(), chaotic::Error<userver::formats::json::Value>,
+    UEXPECT_THROW_MSG(kJson["bar"].As<Int>(), chaotic::Error<formats::json::Value>,
         "Error at path 'bar': Invalid value, minimum=1, given=0");
-    UEXPECT_THROW_MSG(kJson["zoo"].As<Int>(), chaotic::Error<userver::formats::json::Value>,
+    UEXPECT_THROW_MSG(kJson["zoo"].As<Int>(), chaotic::Error<formats::json::Value>,
         "Error at path 'zoo': Invalid value, maximum=5, given=6");
 }
 
@@ -97,11 +97,11 @@ TEST(Primitive, StringMinMaxLength) {
     EXPECT_EQ(x, "12");
 
     UEXPECT_THROW_MSG(
-        kLocalJson["1"].As<Str>(), chaotic::Error<userver::formats::json::Value>,
+        kLocalJson["1"].As<Str>(), chaotic::Error<formats::json::Value>,
             "Error at path '1': Too short string, minimum length=2, given=1"
     );
     UEXPECT_THROW_MSG(
-        kLocalJson["6"].As<Str>(), chaotic::Error<userver::formats::json::Value>,
+        kLocalJson["6"].As<Str>(), chaotic::Error<formats::json::Value>,
             "Error at path '6': Too long string, maximum length=5, given=6"
     );
 }
@@ -116,7 +116,7 @@ TEST(Primitive, StringPattern) {
     std::string x = kLocalJson["1"].As<Str>();
     EXPECT_EQ(x, "foo");
 
-    UEXPECT_THROW_MSG(kLocalJson["2"].As<Str>(), chaotic::Error<userver::formats::json::Value>, "doesn't match regex");
+    UEXPECT_THROW_MSG(kLocalJson["2"].As<Str>(), chaotic::Error<formats::json::Value>, "doesn't match regex");
 }
 
 USERVER_NAMESPACE_END

--- a/chaotic/integration_tests/tests/lib/primitive.cpp
+++ b/chaotic/integration_tests/tests/lib/primitive.cpp
@@ -69,8 +69,10 @@ TEST(Primitive, IntMinMax) {
     int x = kJson["foo"].As<Int>();
     EXPECT_EQ(x, 1);
 
-    UEXPECT_THROW_MSG(kJson["bar"].As<Int>(), chaotic::Error, "Error at path 'bar': Invalid value, minimum=1, given=0");
-    UEXPECT_THROW_MSG(kJson["zoo"].As<Int>(), chaotic::Error, "Error at path 'zoo': Invalid value, maximum=5, given=6");
+    UEXPECT_THROW_MSG(kJson["bar"].As<Int>(), chaotic::Error<userver::formats::json::Value>,
+        "Error at path 'bar': Invalid value, minimum=1, given=0");
+    UEXPECT_THROW_MSG(kJson["zoo"].As<Int>(), chaotic::Error<userver::formats::json::Value>,
+        "Error at path 'zoo': Invalid value, maximum=5, given=6");
 }
 
 TEST(Primitive, UserTypeMinMax) {
@@ -80,8 +82,10 @@ TEST(Primitive, UserTypeMinMax) {
     MyInt x = kJson["foo"].As<Int>();
     EXPECT_EQ(x.value, 1);
 
-    UEXPECT_THROW_MSG(kJson["bar"].As<Int>(), chaotic::Error, "Error at path 'bar': Invalid value, minimum=1, given=0");
-    UEXPECT_THROW_MSG(kJson["zoo"].As<Int>(), chaotic::Error, "Error at path 'zoo': Invalid value, maximum=5, given=6");
+    UEXPECT_THROW_MSG(kJson["bar"].As<Int>(), chaotic::Error<userver::formats::json::Value>,
+        "Error at path 'bar': Invalid value, minimum=1, given=0");
+    UEXPECT_THROW_MSG(kJson["zoo"].As<Int>(), chaotic::Error<userver::formats::json::Value>,
+        "Error at path 'zoo': Invalid value, maximum=5, given=6");
 }
 
 TEST(Primitive, StringMinMaxLength) {
@@ -93,10 +97,12 @@ TEST(Primitive, StringMinMaxLength) {
     EXPECT_EQ(x, "12");
 
     UEXPECT_THROW_MSG(
-        kLocalJson["1"].As<Str>(), chaotic::Error, "Error at path '1': Too short string, minimum length=2, given=1"
+        kLocalJson["1"].As<Str>(), chaotic::Error<userver::formats::json::Value>,
+            "Error at path '1': Too short string, minimum length=2, given=1"
     );
     UEXPECT_THROW_MSG(
-        kLocalJson["6"].As<Str>(), chaotic::Error, "Error at path '6': Too long string, maximum length=5, given=6"
+        kLocalJson["6"].As<Str>(), chaotic::Error<userver::formats::json::Value>,
+            "Error at path '6': Too long string, maximum length=5, given=6"
     );
 }
 
@@ -110,7 +116,7 @@ TEST(Primitive, StringPattern) {
     std::string x = kLocalJson["1"].As<Str>();
     EXPECT_EQ(x, "foo");
 
-    UEXPECT_THROW_MSG(kLocalJson["2"].As<Str>(), chaotic::Error, "doesn't match regex");
+    UEXPECT_THROW_MSG(kLocalJson["2"].As<Str>(), chaotic::Error<userver::formats::json::Value>, "doesn't match regex");
 }
 
 USERVER_NAMESPACE_END

--- a/chaotic/integration_tests/tests/render/minmax.cpp
+++ b/chaotic/integration_tests/tests/render/minmax.cpp
@@ -10,7 +10,8 @@ USERVER_NAMESPACE_BEGIN
 TEST(MinMax, ExclusiveInt) {
     auto json = formats::json::MakeObject("foo", 1);
     UEXPECT_THROW_MSG(
-        json.As<ns::IntegerObject>(), chaotic::Error, "Error at path 'foo': Invalid value, exclusive minimum=1, given=1"
+        json.As<ns::IntegerObject>(), chaotic::Error<userver::formats::json::Value>,
+            "Error at path 'foo': Invalid value, exclusive minimum=1, given=1"
     );
 
     json = formats::json::MakeObject("foo", 2);
@@ -19,7 +20,7 @@ TEST(MinMax, ExclusiveInt) {
     json = formats::json::MakeObject("foo", 20);
     UEXPECT_THROW_MSG(
         json.As<ns::IntegerObject>(),
-        chaotic::Error,
+        chaotic::Error<userver::formats::json::Value>,
         "Error at path 'foo': Invalid value, exclusive maximum=20, given=20"
     );
 
@@ -30,24 +31,28 @@ TEST(MinMax, ExclusiveInt) {
 TEST(MinMax, String) {
     auto json = formats::json::MakeObject("bar", "");
     UEXPECT_THROW_MSG(
-        json.As<ns::IntegerObject>(), chaotic::Error, "Error at path 'bar': Too short string, minimum length=2, given=0"
+        json.As<ns::IntegerObject>(), chaotic::Error<userver::formats::json::Value>,
+            "Error at path 'bar': Too short string, minimum length=2, given=0"
     );
 
     json = formats::json::MakeObject("bar", "longlonglong");
     UEXPECT_THROW_MSG(
-        json.As<ns::IntegerObject>(), chaotic::Error, "Error at path 'bar': Too long string, maximum length=5, given=12"
+        json.As<ns::IntegerObject>(), chaotic::Error<userver::formats::json::Value>,
+            "Error at path 'bar': Too long string, maximum length=5, given=12"
     );
 }
 
 TEST(MinMax, Array) {
     auto json = formats::json::MakeObject("zoo", formats::json::MakeArray(1));
     UEXPECT_THROW_MSG(
-        json.As<ns::IntegerObject>(), chaotic::Error, "Error at path 'zoo': Too short array, minimum length=2, given=1"
+        json.As<ns::IntegerObject>(), chaotic::Error<userver::formats::json::Value>,
+            "Error at path 'zoo': Too short array, minimum length=2, given=1"
     );
 
     json = formats::json::MakeObject("zoo", formats::json::MakeArray(1, 2, 3, 4, 5, 6, 7, 8));
     UEXPECT_THROW_MSG(
-        json.As<ns::IntegerObject>(), chaotic::Error, "Error at path 'zoo': Too long array, maximum length=5, given=8"
+        json.As<ns::IntegerObject>(), chaotic::Error<userver::formats::json::Value>,
+            "Error at path 'zoo': Too long array, maximum length=5, given=8"
     );
 }
 

--- a/chaotic/integration_tests/tests/render/minmax.cpp
+++ b/chaotic/integration_tests/tests/render/minmax.cpp
@@ -10,7 +10,7 @@ USERVER_NAMESPACE_BEGIN
 TEST(MinMax, ExclusiveInt) {
     auto json = formats::json::MakeObject("foo", 1);
     UEXPECT_THROW_MSG(
-        json.As<ns::IntegerObject>(), chaotic::Error<userver::formats::json::Value>,
+        json.As<ns::IntegerObject>(), chaotic::Error<formats::json::Value>,
             "Error at path 'foo': Invalid value, exclusive minimum=1, given=1"
     );
 
@@ -20,7 +20,7 @@ TEST(MinMax, ExclusiveInt) {
     json = formats::json::MakeObject("foo", 20);
     UEXPECT_THROW_MSG(
         json.As<ns::IntegerObject>(),
-        chaotic::Error<userver::formats::json::Value>,
+        chaotic::Error<formats::json::Value>,
         "Error at path 'foo': Invalid value, exclusive maximum=20, given=20"
     );
 
@@ -31,13 +31,13 @@ TEST(MinMax, ExclusiveInt) {
 TEST(MinMax, String) {
     auto json = formats::json::MakeObject("bar", "");
     UEXPECT_THROW_MSG(
-        json.As<ns::IntegerObject>(), chaotic::Error<userver::formats::json::Value>,
+        json.As<ns::IntegerObject>(), chaotic::Error<formats::json::Value>,
             "Error at path 'bar': Too short string, minimum length=2, given=0"
     );
 
     json = formats::json::MakeObject("bar", "longlonglong");
     UEXPECT_THROW_MSG(
-        json.As<ns::IntegerObject>(), chaotic::Error<userver::formats::json::Value>,
+        json.As<ns::IntegerObject>(), chaotic::Error<formats::json::Value>,
             "Error at path 'bar': Too long string, maximum length=5, given=12"
     );
 }
@@ -45,13 +45,13 @@ TEST(MinMax, String) {
 TEST(MinMax, Array) {
     auto json = formats::json::MakeObject("zoo", formats::json::MakeArray(1));
     UEXPECT_THROW_MSG(
-        json.As<ns::IntegerObject>(), chaotic::Error<userver::formats::json::Value>,
+        json.As<ns::IntegerObject>(), chaotic::Error<formats::json::Value>,
             "Error at path 'zoo': Too short array, minimum length=2, given=1"
     );
 
     json = formats::json::MakeObject("zoo", formats::json::MakeArray(1, 2, 3, 4, 5, 6, 7, 8));
     UEXPECT_THROW_MSG(
-        json.As<ns::IntegerObject>(), chaotic::Error<userver::formats::json::Value>,
+        json.As<ns::IntegerObject>(), chaotic::Error<formats::json::Value>,
             "Error at path 'zoo': Too long array, maximum length=5, given=8"
     );
 }

--- a/chaotic/integration_tests/tests/render/simple.cpp
+++ b/chaotic/integration_tests/tests/render/simple.cpp
@@ -45,7 +45,7 @@ TEST(Simple, DefaultFieldValue) {
 TEST(Simple, IntegerMinimum) {
     auto json = formats::json::MakeObject("int3", 1, "int", -10);
     UEXPECT_THROW_MSG(
-        json.As<ns::SimpleObject>(), chaotic::Error<userver::formats::json::Value>,
+        json.As<ns::SimpleObject>(), chaotic::Error<formats::json::Value>,
             "Error at path 'int': Invalid value, minimum=-1, given=-10"
     );
 }
@@ -53,7 +53,7 @@ TEST(Simple, IntegerMinimum) {
 TEST(Simple, IntegerMaximum) {
     auto json = formats::json::MakeObject("int3", 1, "int", 11);
     UEXPECT_THROW_MSG(
-        json.As<ns::SimpleObject>(), chaotic::Error<userver::formats::json::Value>,
+        json.As<ns::SimpleObject>(), chaotic::Error<formats::json::Value>,
             "Error at path 'int': Invalid value, maximum=10, given=11"
     );
 }
@@ -80,7 +80,7 @@ TEST(Simple, IntegerFormat) {
 TEST(Simple, ObjectWithRefType) {
     auto json = formats::json::MakeObject("integer", 0);
     UEXPECT_THROW_MSG(
-        json.As<ns::ObjectWithRef>(), chaotic::Error<userver::formats::json::Value>,
+        json.As<ns::ObjectWithRef>(), chaotic::Error<formats::json::Value>,
             "Error at path 'integer': Invalid value, minimum=1, given=0"
     );
 }
@@ -145,7 +145,7 @@ TEST(Simple, ObjectWithAdditionalPropertiesFalseStrict) {
     auto json = formats::json::MakeObject("foo", 1, "bar", 2);
     UEXPECT_THROW_MSG(
         json.As<ns::ObjectWithAdditionalPropertiesFalseStrict>(),
-        chaotic::Error<userver::formats::json::Value>,
+        chaotic::Error<formats::json::Value>,
         "Unknown property 'bar'"
     );
 }
@@ -161,7 +161,7 @@ TEST(Simple, IntegerEnum) {
     auto json2 = formats::json::MakeObject("one", 5);
     UEXPECT_THROW_MSG(
         json2["one"].As<ns::IntegerEnum>(),
-        chaotic::Error<userver::formats::json::Value>,
+        chaotic::Error<formats::json::Value>,
         "Error at path 'one': Invalid enum value (5) for type ns::IntegerEnum"
     );
 
@@ -186,7 +186,7 @@ TEST(Simple, StringEnum) {
     auto json2 = formats::json::MakeObject("one", "zoo");
     UEXPECT_THROW_MSG(
         json2["one"].As<ns::StringEnum>(),
-        chaotic::Error<userver::formats::json::Value>,
+        chaotic::Error<formats::json::Value>,
         "Error at path 'one': Invalid enum value (zoo) for type ns::StringEnum"
     );
 

--- a/chaotic/integration_tests/tests/render/simple.cpp
+++ b/chaotic/integration_tests/tests/render/simple.cpp
@@ -45,14 +45,16 @@ TEST(Simple, DefaultFieldValue) {
 TEST(Simple, IntegerMinimum) {
     auto json = formats::json::MakeObject("int3", 1, "int", -10);
     UEXPECT_THROW_MSG(
-        json.As<ns::SimpleObject>(), chaotic::Error, "Error at path 'int': Invalid value, minimum=-1, given=-10"
+        json.As<ns::SimpleObject>(), chaotic::Error<userver::formats::json::Value>,
+            "Error at path 'int': Invalid value, minimum=-1, given=-10"
     );
 }
 
 TEST(Simple, IntegerMaximum) {
     auto json = formats::json::MakeObject("int3", 1, "int", 11);
     UEXPECT_THROW_MSG(
-        json.As<ns::SimpleObject>(), chaotic::Error, "Error at path 'int': Invalid value, maximum=10, given=11"
+        json.As<ns::SimpleObject>(), chaotic::Error<userver::formats::json::Value>,
+            "Error at path 'int': Invalid value, maximum=10, given=11"
     );
 }
 
@@ -78,7 +80,8 @@ TEST(Simple, IntegerFormat) {
 TEST(Simple, ObjectWithRefType) {
     auto json = formats::json::MakeObject("integer", 0);
     UEXPECT_THROW_MSG(
-        json.As<ns::ObjectWithRef>(), chaotic::Error, "Error at path 'integer': Invalid value, minimum=1, given=0"
+        json.As<ns::ObjectWithRef>(), chaotic::Error<userver::formats::json::Value>,
+            "Error at path 'integer': Invalid value, minimum=1, given=0"
     );
 }
 
@@ -141,7 +144,9 @@ TEST(Simple, ObjectExtraMemberFalse) {
 TEST(Simple, ObjectWithAdditionalPropertiesFalseStrict) {
     auto json = formats::json::MakeObject("foo", 1, "bar", 2);
     UEXPECT_THROW_MSG(
-        json.As<ns::ObjectWithAdditionalPropertiesFalseStrict>(), std::runtime_error, "Unknown property 'bar'"
+        json.As<ns::ObjectWithAdditionalPropertiesFalseStrict>(),
+        chaotic::Error<userver::formats::json::Value>,
+        "Unknown property 'bar'"
     );
 }
 
@@ -156,7 +161,7 @@ TEST(Simple, IntegerEnum) {
     auto json2 = formats::json::MakeObject("one", 5);
     UEXPECT_THROW_MSG(
         json2["one"].As<ns::IntegerEnum>(),
-        chaotic::Error,
+        chaotic::Error<userver::formats::json::Value>,
         "Error at path 'one': Invalid enum value (5) for type ns::IntegerEnum"
     );
 
@@ -181,7 +186,7 @@ TEST(Simple, StringEnum) {
     auto json2 = formats::json::MakeObject("one", "zoo");
     UEXPECT_THROW_MSG(
         json2["one"].As<ns::StringEnum>(),
-        chaotic::Error,
+        chaotic::Error<userver::formats::json::Value>,
         "Error at path 'one': Invalid enum value (zoo) for type ns::StringEnum"
     );
 


### PR DESCRIPTION
Parametrized chaotic exceptions with typename value. Chaotic validators now throw exceptions derived from formats::Value::Exception