### PR TITLE
feat universal: add insert method to SmallString

### DIFF
--- a/universal/include/userver/utils/small_string.hpp
+++ b/universal/include/userver/utils/small_string.hpp
@@ -142,6 +142,10 @@ public:
     /// @brief Append contents of a string_view to the string.
     void append(std::string_view str);
 
+    /// @brief Append contents of a string_view to the string.
+    template <class InputIt>
+    void insert(const_iterator pos, InputIt begin, InputIt end);
+
     /// @brief Remove the last character from the string.
     void pop_back();
 
@@ -274,6 +278,12 @@ template <std::size_t N>
 void SmallString<N>::append(std::string_view str) {
     std::size_t old_size = data_.size();
     data_.insert(data_.begin() + old_size, str.begin(), str.end());
+}
+
+template <std::size_t N>
+template <class InputIt>
+void SmallString<N>::insert(SmallString::const_iterator pos, InputIt begin, InputIt end) {
+    data_.insert(pos, begin, end);
 }
 
 template <std::size_t N>

--- a/universal/src/utils/small_string_test.cpp
+++ b/universal/src/utils/small_string_test.cpp
@@ -69,6 +69,14 @@ TEST(SmallString, Append) {
     EXPECT_EQ(str, "abcdabcd");
 }
 
+TEST(SmallString, Insert) {
+    constexpr std::string_view data{"ab"};
+
+    utils::SmallString<3> str("c");
+    str.insert(str.begin(), data.begin(), data.end());
+    EXPECT_EQ(str, "abc");
+}
+
 TEST(SmallString, SizeCapacity) {
     utils::SmallString<10> str("abcd");
     str.resize(3, '1');
@@ -151,6 +159,12 @@ TEST(SmallString, Format) {
     utils::SmallString<3> str1("abcd");
     utils::SmallString<5> str2("1234");
     EXPECT_EQ("abcd1234", fmt::format("{}{}", str1, str2));
+}
+
+TEST(SmallString, FormatTo) {
+    utils::SmallString<6> str("abc");
+    fmt::format_to(std::back_inserter(str), "d={}", 1);
+    EXPECT_EQ("abcd=1", str);
 }
 
 TEST(SmallString, Iterator) {


### PR DESCRIPTION
fixes:
```shell
-c /Users/runner/work/userver/userver/universal/src/logging/impl/formatters/tskv.cpp
In file included from /Users/runner/work/userver/userver/universal/src/logging/impl/formatters/tskv.cpp:5:
In file included from /opt/homebrew/include/fmt/chrono.h:23:
In file included from /opt/homebrew/include/fmt/format.h:41:
/opt/homebrew/include/fmt/base.h:2027:5: error: no member named 'insert' in 'userver::utils::SmallString<4096>'
  c.insert(c.end(), begin, end);
  ~ ^
/opt/homebrew/include/fmt/format.h:535:10: note: in instantiation of function template specialization 'fmt::detail::copy<char, const char *, std::back_insert_iterator<userver::utils::SmallString<4096>>, 0>' requested here
  return copy<OutChar>(begin, end, out);
```




------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

