### PR TITLE
Cmake build type matching for installed userver

### DIFF
--- a/cmake/install/Config.cmake.in
+++ b/cmake/install/Config.cmake.in
@@ -26,7 +26,7 @@ if (NOT userver_FIND_COMPONENTS)
   return()
 endif()
 
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
+if(CMAKE_BUILD_TYPE MATCHES "^.*Rel.*$")
   include("${CMAKE_CURRENT_LIST_DIR}/release/userver-targets.cmake")
 else()
   include("${CMAKE_CURRENT_LIST_DIR}/debug/userver-targets_d.cmake")


### PR DESCRIPTION
Fixed issue when installed userver configures in debug mode for `CMAKE_BUILD_TYPE` like RelWithDebInfo, MinSizeRel.





------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

