### PR TITLE
feat: Make implicit include paths explicit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,15 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
 project(userver)
 
+# Generate compile_commands.json by default
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
+if(CMAKE_EXPORT_COMPILE_COMMANDS)
+  # Make sure the file is generated with all implicit paths spelled out explicitly
+  # This makes clangd usable on nix-based setups
+  set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
+    ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+endif()
+
 set(USERVER_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 option(


### PR DESCRIPTION
Here is example how compile commands will look like:
```
{
  "directory": "/home/pprettysimpple/prjs/userver/build_debug",
  "command": "/nix/store/4ijy8jbsiqmj37avrk83gn2m903486mr-gcc-wrapper-14-20241116/bin/g++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_STACKTRACE_BASIC_DYN_LINK -DBOOST_STACKTRACE_BASIC_NO_LIB -DBOOST_STACKTRACE_LINK -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DCRYPTOPP_ENABLE_NAMESPACE_WEAK=1 -DNDEBUG -DOPENSSL_SUPPRESS_DEPRECATED=\"\" -DPIC=1 -DUSERVER=1 -DUSERVER_NAMESPACE=userver -DUSERVER_NAMESPACE_BEGIN=\"namespace userver { inline namespace v2_8_rc { \" -DUSERVER_NAMESPACE_END=\"} }\" -D_FORTIFY_SOURCE=2 -I/home/pprettysimpple/prjs/userver/universal/include -I/home/pprettysimpple/prjs/userver/third_party/date/include -I/home/pprettysimpple/prjs/userver/third_party/function_backports/include -I/home/pprettysimpple/prjs/userver/universal/src -I/home/pprettysimpple/prjs/userver/build_debug/universal -I/home/pprettysimpple/prjs/userver/build_debug/universal/gdb_autogen -isystem /home/pprettysimpple/prjs/userver/third_party/rapidjson/include -isystem /nix/store/2im8z9a4i8gv3d54fxx9361g8mb6giwm-gtest-1.15.2-dev/include -isystem /nix/store/s58sr3zi9m114xwngpz47nabhfynbn87-gbenchmark-1.9.1/include -isystem /nix/store/ijpxqas99h25v4vdznj2g92gyv976n0j-boost-1.87.0-dev/include -isystem /nix/store/0l539chjmcq5kdd43j6dgdjky4sjl7hl-python3-3.12.8/include -isystem /nix/store/zgbn7c77c40zv9vaakvhynkjq8qnrn1y-openssl-3.3.2-dev/include -isystem /nix/store/82cipbkvgdrzl2jq1gsg8ym0kmm1jfa9-yaml-cpp-0.8.0/include -isystem /nix/store/dlwar8yval6cqyln15p6i3flg268v22a-zstd-1.5.6-dev/include -isystem /nix/store/5gl6ia24ki89i5s4rqzcl43273vyrjh5-icu4c-74.2-dev/include -isystem /nix/store/wvz2wwp4pkm550i9a33yqwmzj4mkqbk4-zlib-1.3.1-dev/include -isystem /nix/store/a6nmcyx9xmxacs5n1jijbm4bxm2w9z3j-nghttp2-1.64.0-dev/include -isystem /nix/store/2k0cgcj46iaharh2plwczbkzg32d2595-libev-4.33/include -isystem /nix/store/j9xwizppkzp6nhxjpfhdwrrzcq3l8x5f-fmt-10.2.1-dev/include -isystem /nix/store/v13aiczplk6hn18sqhrkhj5sxag0lmgk-crypto++-8.9.0-dev/include -isystem /nix/store/4ngacxgivfvpd48ifmg7nswfx9vj76m2-cctz-2.4/include -isystem /nix/store/l0zpcih0dkclhml0j70dhh4zxbx9fi7z-re2-2024-07-02-dev/include -isystem /nix/store/cqc78pjz20a0akjscxqsy51lwrrw27gw-abseil-cpp-20240722.1/include -isystem /nix/store/1b6bvb19cxrmqkidra4jxxnwdv0zsd37-jemalloc-5.3.0/include -isystem /nix/store/zqcym67v5fab6k3n03cb4kp8j7892814-rapidjson-unstable-2024-04-09/include -isystem /nix/store/78lx9nlmzkcavs8z1nskd1dkx0b9xaz7-c-ares-1.27.0-dev/include -isystem /nix/store/799qv2id5wamkydm33qlvzq1khx1dfxq-lz4-1.10.0-dev/include -isystem /nix/store/6m1q932f97y5l1h0v4r3icrx3rs20is6-cyrus-sasl-2.1.28-dev/include -isystem /nix/store/77hf42pzrxhl4q152zirzx7babv6b23i-curl-8.11.1-dev/include -isystem /nix/store/vj4yg07caqph51fihavhin0pak6wj412-brotli-1.1.0-dev/include -isystem /nix/store/plnajdv4w5602hwk6zlgwgjy8p6ypy4b-krb5-1.21.3-dev/include -isystem /nix/store/p2wr7ijqdma50q1dw8fm255vgrprrw10-libidn2-2.3.7-dev/include -isystem /nix/store/h5ymqil8iysbrw3nwrrsh0xp0jjbifb7-libpsl-0.21.5-dev/include -isystem /nix/store/zai4qagp4z5vyrdw1scf7kyh6607g1lr-libssh2-1.11.1-dev/include -isystem /nix/store/87vkg52j5w0pakfnqyylriibf24yd452-rdkafka-2.8.0/include -isystem /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116 -isystem /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/x86_64-unknown-linux-gnu -isystem /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include/c++/14-20241116/backward -isystem /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/lib/gcc/x86_64-unknown-linux-gnu/14.2.1/include -isystem /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/include -isystem /nix/store/zs2gq6fkglrd28g1nxlb8waqq37cdc2z-gcc-14-20241116/lib/gcc/x86_64-unknown-linux-gnu/14.2.1/include-fixed -isystem /nix/store/6aci60gk5wj4bjj1rygzbkc6ximmsm17-glibc-2.40-66-dev/include -std=c++17 -fvisibility-inlines-hidden -pipe -g -fPIC -fdata-sections -ffunction-sections -gz=zstd -mcx16 -Wall -Wextra -Wpedantic -ftemplate-backtrace-limit=0 -Wdisabled-optimization -Winvalid-pch -Wimplicit-fallthrough -Wlogical-op -Wformat=2 -Wno-error=deprecated-declarations -Wno-useless-cast -Wno-gnu-zero-variadic-macro-arguments -fmacro-prefix-map=/home/pprettysimpple/prjs/userver/build_debug/= -fmacro-prefix-map=/home/pprettysimpple/prjs/= -o universal/CMakeFiles/userver-universal.dir/src/compiler/demangle.cpp.o -c /home/pprettysimpple/prjs/userver/universal/src/compiler/demangle.cpp",
  "file": "/home/pprettysimpple/prjs/userver/universal/src/compiler/demangle.cpp",
  "output": "universal/CMakeFiles/userver-universal.dir/src/compiler/demangle.cpp.o"
}
```
Instead of old:
```
{
  "directory": "/home/pprettysimpple/prjs/userver/build_debug",
  "command": "/nix/store/4ijy8jbsiqmj37avrk83gn2m903486mr-gcc-wrapper-14-20241116/bin/g++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_STACKTRACE_BASIC_DYN_LINK -DBOOST_STACKTRACE_BASIC_NO_LIB -DBOOST_STACKTRACE_LINK -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DCRYPTOPP_ENABLE_NAMESPACE_WEAK=1 -DNDEBUG -DOPENSSL_SUPPRESS_DEPRECATED=\"\" -DPIC=1 -DUSERVER=1 -DUSERVER_NAMESPACE=userver -DUSERVER_NAMESPACE_BEGIN=\"namespace userver { inline namespace v2_8_rc { \" -DUSERVER_NAMESPACE_END=\"} }\" -D_FORTIFY_SOURCE=2 -I/home/pprettysimpple/prjs/userver/universal/include -I/home/pprettysimpple/prjs/userver/third_party/date/include -I/home/pprettysimpple/prjs/userver/third_party/function_backports/include -I/home/pprettysimpple/prjs/userver/universal/src -I/home/pprettysimpple/prjs/userver/build_debug/universal -I/home/pprettysimpple/prjs/userver/build_debug/universal/gdb_autogen -isystem /home/pprettysimpple/prjs/userver/third_party/rapidjson/include -std=c++17 -fvisibility-inlines-hidden -pipe -g -fPIC -fdata-sections -ffunction-sections -gz=zstd -mcx16 -Wall -Wextra -Wpedantic -ftemplate-backtrace-limit=0 -Wdisabled-optimization -Winvalid-pch -Wimplicit-fallthrough -Wlogical-op -Wformat=2 -Wno-error=deprecated-declarations -Wno-useless-cast -Wno-gnu-zero-variadic-macro-arguments -fmacro-prefix-map=/home/pprettysimpple/prjs/userver/build_debug/= -fmacro-prefix-map=/home/pprettysimpple/prjs/= -o universal/CMakeFiles/userver-universal.dir/src/compiler/demangle.cpp.o -c /home/pprettysimpple/prjs/userver/universal/src/compiler/demangle.cpp",
  "file": "/home/pprettysimpple/prjs/userver/universal/src/compiler/demangle.cpp",
  "output": "universal/CMakeFiles/userver-universal.dir/src/compiler/demangle.cpp.o"
}
```

As you see, old way does not spell out paths for includes, that were found in system, and that creates problems for clangd to work properly.
This change is useful for development on nixos.