### PR TITLE
feat build: add USERVER_DISABLE_DEBUG_INFO_COMPRESSION flag

### DIFF
--- a/cmake/SetupDebugInfoCompression.cmake
+++ b/cmake/SetupDebugInfoCompression.cmake
@@ -34,5 +34,16 @@ function(setup_compiler_debug_info_compression)
     endif()
 endfunction()
 
-setup_linker_debug_info_compression()
-setup_compiler_debug_info_compression()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(USERVER_DISABLE_DEBUG_INFO_COMPRESSION_DEFAULT ON)
+else()
+    set(USERVER_DISABLE_DEBUG_INFO_COMPRESSION_DEFAULT OFF)
+endif()
+
+option(USERVER_DISABLE_DEBUG_INFO_COMPRESSION "Disable linker and compiler debug info compression" ${USERVER_DISABLE_DEBUG_INFO_COMPRESSION_DEFAULT})
+
+if(NOT USERVER_DISABLE_DEBUG_INFO_COMPRESSION)
+    setup_linker_debug_info_compression()
+    setup_compiler_debug_info_compression()
+endif()


### PR DESCRIPTION
Possibility to force disable debug compression with a flag  
(disabling by default in debug mode is open to discussion)




------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

