### PR TITLE
feat scripts: jinja2 in sql

### DIFF
--- a/scripts/sql/generator.py
+++ b/scripts/sql/generator.py
@@ -88,11 +88,10 @@ def read_items(args) -> List[SqlQuery]:
         if basename.startswith('_'):
             continue
 
-        with open(filename, 'r') as file:
-            loader = jinja2.FileSystemLoader(os.path.dirname(filename))
-            env = jinja2.Environment(loader=loader)
-            tpl = env.get_template(basename)
-            content = tpl.render()
+        loader = jinja2.FileSystemLoader(os.path.dirname(filename))
+        env = jinja2.Environment(loader=loader)
+        tpl = env.get_template(basename)
+        content = tpl.render()
 
         name = pathlib.Path(filename).stem  # TODO: CamelCase
         items.append(

--- a/scripts/sql/generator.py
+++ b/scripts/sql/generator.py
@@ -85,10 +85,10 @@ def read_items(args) -> List[SqlQuery]:
     items: List[SqlQuery] = []
     for filename in args.files:
         basename = os.path.basename(filename)
-        if basename.startswith("_"):
+        if basename.startswith('_'):
             continue
 
-        with open(filename, "r") as file:
+        with open(filename, 'r') as file:
             loader = jinja2.FileSystemLoader(os.path.dirname(filename))
             env = jinja2.Environment(loader=loader)
             tpl = env.get_template(basename)
@@ -100,7 +100,7 @@ def read_items(args) -> List[SqlQuery]:
                 source=filename,
                 contents=content,
                 name=name,
-                variable=("k" + camel_case(name)),
+                variable=('k' + camel_case(name)),
             ),
         )
     return items

--- a/scripts/sql/generator.py
+++ b/scripts/sql/generator.py
@@ -84,15 +84,23 @@ def camel_case(string: str) -> str:
 def read_items(args) -> List[SqlQuery]:
     items: List[SqlQuery] = []
     for filename in args.files:
-        with open(filename, 'r') as file:
-            content = file.read()
+        basename = os.path.basename(filename)
+        if basename.startswith("_"):
+            continue
+
+        with open(filename, "r") as file:
+            loader = jinja2.FileSystemLoader(os.path.dirname(filename))
+            env = jinja2.Environment(loader=loader)
+            tpl = env.get_template(basename)
+            content = tpl.render()
+
         name = pathlib.Path(filename).stem  # TODO: CamelCase
         items.append(
             SqlQuery(
                 source=filename,
                 contents=content,
                 name=name,
-                variable=('k' + camel_case(name)),
+                variable=("k" + camel_case(name)),
             ),
         )
     return items


### PR DESCRIPTION
SQL queries often have duplicate elements, such as fields in SELECT. I would like to put such elements in a separate file to reduce duplication.

This Pull Request adds the ability to use Jinja2 substitution in SQL queries. The following is an example of usage.

<details>

<summary>_fields.sql</summary>

```sql
id,
first_name,
last_name
```

</details>

<details>

<summary>select_user_by_id.sql</summary>

```sql
SELECT
{% include '_fields.sql' %}
FROM users
WHERE id = $1
```

</details>

<details>

<summary>select_users.sql</summary>

```sql
SELECT
{% include '_fields.sql' %}
FROM users
ORDER BY id
```

</details>


------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

