### PR TITLE
Extend TaskCancellationToken interface

### DIFF
--- a/core/include/userver/engine/task/cancel.hpp
+++ b/core/include/userver/engine/task/cancel.hpp
@@ -119,6 +119,15 @@ public:
     /// This method should not be called on invalid TaskCancellationToken
     void RequestCancel();
 
+    /// @see engine::Task::CancellationReason
+    /// This method should not be called on invalid TaskCancellationToken
+    TaskCancellationReason CancellationReason() const noexcept;
+
+    /// @see @ref task_cancellation_intro
+    /// True if there is pending cancellation request for the associated task
+    /// This method should not be called on invalid TaskCancellationToken
+    bool IsCancelRequested() const noexcept;
+
     /// True if this token is associated with a task
     bool IsValid() const noexcept;
 

--- a/core/src/engine/task/cancel.cpp
+++ b/core/src/engine/task/cancel.cpp
@@ -120,6 +120,16 @@ void TaskCancellationToken::RequestCancel() {
     context_->RequestCancel(TaskCancellationReason::kUserRequest);
 }
 
+TaskCancellationReason TaskCancellationToken::CancellationReason() const noexcept {
+    UASSERT(context_);
+    return context_->CancellationReason();
+}
+
+bool TaskCancellationToken::IsCancelRequested() const noexcept {
+    UASSERT(context_);
+    return context_->IsCancelRequested();
+}
+
 bool TaskCancellationToken::IsValid() const noexcept { return !!context_; }
 
 }  // namespace engine


### PR DESCRIPTION
New methods in `TaskCancellationToken` class: `CancellationReason()` and `IsCancelRequested()`.
