### PR TITLE
fix clickhouse: do not use fmt::detail

### DIFF
--- a/clickhouse/include/userver/storages/clickhouse/io/floating_point_types.hpp
+++ b/clickhouse/include/userver/storages/clickhouse/io/floating_point_types.hpp
@@ -3,9 +3,6 @@
 /// @file userver/storages/clickhouse/io/floating_point_types.hpp
 /// @brief @copybrief storages::clickhouse::io::FloatingWithPrecision
 
-#if FMT_VERSION >= 110000
-#include <fmt/base.h>  // Y_IGNORE
-#endif
 #include <fmt/format.h>
 
 USERVER_NAMESPACE_BEGIN
@@ -48,36 +45,11 @@ public:
     }
 
     std::string ToString() {
-        std::string result;
-        fmt::detail::write(std::back_inserter(result), value_, spec_);
-        return result;
+        return fmt::format("{:.{}f}", value_, Precision);
     }
 
 private:
     FloatingPointT value_;
-
-#if FMT_VERSION >= 110100
-    constexpr static fmt::format_specs spec_ = []() {
-        fmt::format_specs spec;
-        spec.precision = Precision;
-        spec.set_type(fmt::presentation_type::fixed);
-        return spec;
-    }();
-#elif FMT_VERSION >= 110000
-    constexpr static fmt::format_specs spec_ = []() {
-        fmt::format_specs spec;
-        spec.precision = Precision;
-        spec.type = fmt::presentation_type::fixed;
-        return spec;
-    }();
-#else
-    constexpr static fmt::basic_format_specs<char> spec_ = []() {
-        fmt::basic_format_specs<char> spec;
-        spec.precision = Precision;
-        spec.type = fmt::presentation_type::fixed_lower;
-        return spec;
-    }();
-#endif
 
     template <typename U, std::uint32_t AnotherPrecision, typename>
     friend class FloatingWithPrecision;


### PR DESCRIPTION
Usage of `fmt::detail` leads to unexpected tests failures





------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

