### PR TITLE
fix chaotic: validate array type before parsing chaotic::Array

### DIFF
--- a/chaotic/include/userver/chaotic/array.hpp
+++ b/chaotic/include/userver/chaotic/array.hpp
@@ -20,6 +20,9 @@ struct Array final {
 
 template <typename Value, typename ItemType, typename UserType, typename... Validators>
 UserType Parse(const Value& value, formats::parse::To<Array<ItemType, UserType, Validators...>>) {
+    value.CheckNotMissing();
+    value.CheckArrayOrNull();
+
     UserType arr;
     if constexpr (meta::kIsReservable<UserType>) {
         arr.reserve(value.GetSize());
@@ -39,6 +42,9 @@ UserType Parse(const Value& value, formats::parse::To<Array<ItemType, UserType, 
 template <typename Value, typename ItemType, typename... Validators>
 std::vector<formats::common::ParseType<Value, ItemType>>
 Parse(const Value& value, formats::parse::To<Array<ItemType, std::vector<formats::common::ParseType<Value, ItemType>>, Validators...>>) {
+    value.CheckNotMissing();
+    value.CheckArrayOrNull();
+
     std::vector<formats::common::ParseType<Value, ItemType>> arr;
     arr.reserve(value.GetSize());
     for (const auto& item : value) {

--- a/chaotic/integration_tests/tests/lib/array.cpp
+++ b/chaotic/integration_tests/tests/lib/array.cpp
@@ -72,6 +72,17 @@ TEST(Array, OfEmptyArraySerializer) {
     EXPECT_EQ(formats::json::ValueBuilder{Arr{kJson.As<Arr>()}}.ExtractValue(), kJson);
 }
 
+TEST(Array, FromObjectShouldThrow) {
+    const auto kJson = formats::json::MakeObject("lat", 56.008889, "lon", 92.871944);
+    using Arr = chaotic::Array<double, std::vector<double>>;
+
+    UEXPECT_THROW_MSG(
+        kJson.As<Arr>(),
+        formats::json::TypeMismatchException,
+        "Error at path '/': Wrong type. Expected: arrayValue, actual: objectValue"
+    );
+}
+
 }  // namespace
 
 USERVER_NAMESPACE_END


### PR DESCRIPTION
Add CheckNotMissing() and CheckArrayOrNull() to fix object-to-array parsing
Fixes #939

------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

