### PR TITLE
Allow dynamic selection of response streaming

### DIFF
--- a/core/include/userver/server/handlers/http_handler_base.hpp
+++ b/core/include/userver/server/handlers/http_handler_base.hpp
@@ -151,6 +151,11 @@ protected:
     /// "response-body-streamed" value from static config.
     virtual bool IsStreamed() const { return is_body_streamed_; }
 
+    /// Override it if you need a custom streamed logic based on request and context.
+    /// @note The default implementation returns the cached value of
+    /// "response-body-streamed" value from static config.
+    virtual bool IsStreamed(const http::HttpRequest&, server::request::RequestContext&) const { return IsStreamed(); }
+
     /// Override it to show per HTTP-method statistics besides statistics for all
     /// methods
     virtual bool IsMethodStatisticIncluded() const { return false; }

--- a/core/src/server/handlers/http_handler_base.cpp
+++ b/core/src/server/handlers/http_handler_base.cpp
@@ -250,7 +250,7 @@ void HttpHandlerBase::HandleHttpRequest(http::HttpRequest& http_request, request
     context.GetInternalContext().ResetConfigSnapshot();
 
     const auto scope_time = tracing::ScopeTime::CreateOptionalScopeTime("http_handle_request");
-    if (response.IsBodyStreamed()) {
+    if (IsStreamed(http_request, context)) {
         HandleRequestStream(http_request, context);
     } else {
         // !IsBodyStreamed()


### PR DESCRIPTION
Motivation:

Sometimes it's required to make decisions regarding streaming responses based on request body, e.g. `{ "stream": true }` in json request. Adding a virtual function that can make the decision based on request and context might be helpful for that.



------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

