### PR TITLE
feat conan: added flag for support redis tls .

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -82,6 +82,7 @@ class UserverConan(ConanFile):
         'grpc/*:ruby_plugin': False,
         'grpc/*:csharp_plugin': False,
         'grpc/*:objective_c_plugin': False,
+        'hiredis/*:with_ssl': True,
         'librdkafka/*:ssl': True,
         'librdkafka/*:curl': True,
         'librdkafka/*:sasl': True,

--- a/conanfile.py
+++ b/conanfile.py
@@ -34,6 +34,7 @@ class UserverConan(ConanFile):
         'with_postgresql': [True, False],
         'with_postgresql_extra': [True, False],
         'with_redis': [True, False],
+        'with_redis_tls': [True, False],
         'with_grpc': [True, False],
         'with_clickhouse': [True, False],
         'with_rabbitmq': [True, False],
@@ -59,6 +60,7 @@ class UserverConan(ConanFile):
         'with_postgresql': True,
         'with_postgresql_extra': False,
         'with_redis': True,
+        'with_redis_tls': True,
         'with_grpc': True,
         'with_clickhouse': True,
         'with_rabbitmq': True,
@@ -217,6 +219,7 @@ class UserverConan(ConanFile):
         tool_ch.variables['USERVER_FEATURE_POSTGRESQL'] = self.options.with_postgresql
         tool_ch.variables['USERVER_FEATURE_PATCH_LIBPQ'] = self.options.with_postgresql_extra
         tool_ch.variables['USERVER_FEATURE_REDIS'] = self.options.with_redis
+        tool_ch.variables['USERVER_FEATURE_REDIS_TLS'] = self.options.with_redis_tls
         tool_ch.variables['USERVER_FEATURE_GRPC'] = self.options.with_grpc
         tool_ch.variables['USERVER_FEATURE_CLICKHOUSE'] = self.options.with_clickhouse
         tool_ch.variables['USERVER_FEATURE_RABBITMQ'] = self.options.with_rabbitmq

--- a/redis/CMakeLists.txt
+++ b/redis/CMakeLists.txt
@@ -30,7 +30,7 @@ if(USERVER_FEATURE_REDIS_TLS)
 endif()
 
 if (USERVER_FEATURE_REDIS_TLS)
-  target_link_libraries(${PROJECT_NAME} PUBLIC hiredis_ssl)
+  target_link_libraries(${PROJECT_NAME} PUBLIC hiredis::hiredis_ssl)
 endif()
 target_include_directories(${PROJECT_NAME} PRIVATE
     $<TARGET_PROPERTY:userver-core,INCLUDE_DIRECTORIES>

--- a/redis/CMakeLists.txt
+++ b/redis/CMakeLists.txt
@@ -30,7 +30,7 @@ if(USERVER_FEATURE_REDIS_TLS)
 endif()
 
 if (USERVER_FEATURE_REDIS_TLS)
-  target_link_libraries(${PROJECT_NAME} PUBLIC hiredis::hiredis_ssl)
+  target_link_libraries(${PROJECT_NAME} PUBLIC hiredis_ssl)
 endif()
 target_include_directories(${PROJECT_NAME} PRIVATE
     $<TARGET_PROPERTY:userver-core,INCLUDE_DIRECTORIES>


### PR DESCRIPTION
* Added `with_redis_tls` option for build to enable redis TLS support in `conanfile.py` .




------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

