### PR TITLE
feat kafka: fix for 'std::uint32_t' -> 'std::uint64_t' for kafka offset.

### DIFF
--- a/kafka/include/userver/kafka/offset_range.hpp
+++ b/kafka/include/userver/kafka/offset_range.hpp
@@ -9,12 +9,14 @@ namespace kafka {
 /// @brief Represents the range of offsets for certain topic.
 struct OffsetRange final {
     /// @brief The low watermark offset. It indicates the earliest available offset in Kafka.
-    /// @note low offset is guaranteed to be committed
-    std::int64_t low{};
+    /// @note low offset is guaranteed to be committed. Max value is std::int64_t::max() according to Kafka protocol
+    /// document.
+    std::uint64_t low{};
 
     /// @brief The high watermark offset. It indicates the next offset that will be written in Kafka.
-    /// @note high offset is not required to be committed yet
-    std::int64_t high{};
+    /// @note high offset is not required to be committed yet. Max value is std::int64_t::max() according to Kafka
+    /// protocol document.
+    std::uint64_t high{};
 };
 
 }  // namespace kafka

--- a/kafka/include/userver/kafka/offset_range.hpp
+++ b/kafka/include/userver/kafka/offset_range.hpp
@@ -10,11 +10,11 @@ namespace kafka {
 struct OffsetRange final {
     /// @brief The low watermark offset. It indicates the earliest available offset in Kafka.
     /// @note low offset is guaranteed to be committed
-    std::uint32_t low{};
+    std::int64_t low{};
 
     /// @brief The high watermark offset. It indicates the next offset that will be written in Kafka.
     /// @note high offset is not required to be committed yet
-    std::uint32_t high{};
+    std::int64_t high{};
 };
 
 }  // namespace kafka

--- a/kafka/src/kafka/impl/consumer_impl.cpp
+++ b/kafka/src/kafka/impl/consumer_impl.cpp
@@ -351,11 +351,12 @@ OffsetRange ConsumerImpl::GetOffsetRange(
     if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {
         throw OffsetRangeException{fmt::format("Failed to get offsets: {}", rd_kafka_err2str(err)), topic, partition};
     }
-    if (low_offset == RD_KAFKA_OFFSET_INVALID || high_offset == RD_KAFKA_OFFSET_INVALID) {
-        throw OffsetRangeException{fmt::format("Failed to get offsets: invalid offset."), topic, partition};
+    if (low_offset == RD_KAFKA_OFFSET_INVALID || high_offset == RD_KAFKA_OFFSET_INVALID || low_offset < 0 ||
+        high_offset < 0) {
+        throw OffsetRangeException{"Failed to get offsets: invalid offset.", topic, partition};
     }
 
-    return {low_offset, high_offset};
+    return {static_cast<std::uint64_t>(low_offset), static_cast<std::uint64_t>(high_offset)};
 }
 
 std::vector<std::uint32_t>

--- a/kafka/src/kafka/impl/consumer_impl.cpp
+++ b/kafka/src/kafka/impl/consumer_impl.cpp
@@ -152,7 +152,8 @@ void PrintTopicPartitionsList(
     }
 
     const utils::span<const rd_kafka_topic_partition_t> topic_partitions{
-        list->elems, list->elems + static_cast<std::size_t>(list->cnt)};
+        list->elems, list->elems + static_cast<std::size_t>(list->cnt)
+    };
     for (const auto& topic_partition : topic_partitions) {
         if (skip_invalid_offsets && topic_partition.offset == RD_KAFKA_OFFSET_INVALID) {
             /// @note `librdkafka` does not sets offsets for partitions that were
@@ -355,7 +356,7 @@ OffsetRange ConsumerImpl::GetOffsetRange(
         throw OffsetRangeException{fmt::format("Failed to get offsets: invalid offset."), topic, partition};
     }
 
-    return {static_cast<std::uint32_t>(low_offset), static_cast<std::uint32_t>(high_offset)};
+    return {low_offset, high_offset};
 }
 
 std::vector<std::uint32_t>
@@ -380,7 +381,8 @@ ConsumerImpl::GetPartitionIds(const std::string& topic, std::optional<std::chron
     }()};
 
     const utils::span<const rd_kafka_metadata_topic> topics{
-        metadata->topics, static_cast<std::size_t>(metadata->topic_cnt)};
+        metadata->topics, static_cast<std::size_t>(metadata->topic_cnt)
+    };
     const auto* topic_it =
         std::find_if(topics.begin(), topics.end(), [&topic](const rd_kafka_metadata_topic& topic_raw) {
             return topic == topic_raw.topic;
@@ -390,7 +392,8 @@ ConsumerImpl::GetPartitionIds(const std::string& topic, std::optional<std::chron
     }
 
     const utils::span<const rd_kafka_metadata_partition> partitions{
-        topic_it->partitions, static_cast<std::size_t>(topic_it->partition_cnt)};
+        topic_it->partitions, static_cast<std::size_t>(topic_it->partition_cnt)
+    };
     std::vector<std::uint32_t> partition_ids;
     partition_ids.reserve(partitions.size());
 

--- a/kafka/src/kafka/impl/consumer_impl.cpp
+++ b/kafka/src/kafka/impl/consumer_impl.cpp
@@ -152,8 +152,7 @@ void PrintTopicPartitionsList(
     }
 
     const utils::span<const rd_kafka_topic_partition_t> topic_partitions{
-        list->elems, list->elems + static_cast<std::size_t>(list->cnt)
-    };
+        list->elems, list->elems + static_cast<std::size_t>(list->cnt)};
     for (const auto& topic_partition : topic_partitions) {
         if (skip_invalid_offsets && topic_partition.offset == RD_KAFKA_OFFSET_INVALID) {
             /// @note `librdkafka` does not sets offsets for partitions that were
@@ -381,8 +380,7 @@ ConsumerImpl::GetPartitionIds(const std::string& topic, std::optional<std::chron
     }()};
 
     const utils::span<const rd_kafka_metadata_topic> topics{
-        metadata->topics, static_cast<std::size_t>(metadata->topic_cnt)
-    };
+        metadata->topics, static_cast<std::size_t>(metadata->topic_cnt)};
     const auto* topic_it =
         std::find_if(topics.begin(), topics.end(), [&topic](const rd_kafka_metadata_topic& topic_raw) {
             return topic == topic_raw.topic;
@@ -392,8 +390,7 @@ ConsumerImpl::GetPartitionIds(const std::string& topic, std::optional<std::chron
     }
 
     const utils::span<const rd_kafka_metadata_partition> partitions{
-        topic_it->partitions, static_cast<std::size_t>(topic_it->partition_cnt)
-    };
+        topic_it->partitions, static_cast<std::size_t>(topic_it->partition_cnt)};
     std::vector<std::uint32_t> partition_ids;
     partition_ids.reserve(partitions.size());
 


### PR DESCRIPTION
* Fix for using std::uint64_t instead of std::uint32_t for OffsetRange structure for better compatibility with Java's Long type and librdkafka offset type also.
* https://kafka.apache.org/protocol#protocol_messages Kafka protocol says it is also int64_t , the same type as used in librdkafka
* casting int64_t to uint32_t can be dangerous for large topics .





------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

