### PR TITLE
ClickHouse: add parametr store

### DIFF
--- a/clickhouse/include/userver/storages/clickhouse/cluster.hpp
+++ b/clickhouse/include/userver/storages/clickhouse/cluster.hpp
@@ -61,6 +61,10 @@ public:
     template <typename... Args>
     ExecutionResult Execute(OptionalCommandControl, const Query& query, const Args&... args) const;
 
+    ExecutionResult Execute(const Query& query, const ParameterStore& params) const;
+
+    ExecutionResult Execute(OptionalCommandControl, const Query& query, const ParameterStore& params) const;
+
     /// @brief Insert data at some host of the cluster;
     /// `T` is expected to be a struct of vectors of same length.
     /// @param table_name table to insert into

--- a/clickhouse/include/userver/storages/clickhouse/io/impl/escape.hpp
+++ b/clickhouse/include/userver/storages/clickhouse/io/impl/escape.hpp
@@ -5,6 +5,8 @@
 #include <string_view>
 #include <vector>
 
+#include <boost/uuid/uuid.hpp>
+
 #include <userver/utils/strong_typedef.hpp>
 
 #include <userver/storages/clickhouse/io/floating_point_types.hpp>
@@ -34,6 +36,8 @@ std::string Escape(float number);
 std::string Escape(const char* source);
 std::string Escape(const std::string& source);
 std::string Escape(std::string_view source);
+
+std::string Escape(const boost::uuids::uuid& uuid);
 
 std::string Escape(std::chrono::system_clock::time_point source);
 std::string Escape(DateTime64Milli source);

--- a/clickhouse/include/userver/storages/clickhouse/parameter_store.hpp
+++ b/clickhouse/include/userver/storages/clickhouse/parameter_store.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <fmt/args.h>
+#include <fmt/format.h>
+
+#include <userver/storages/clickhouse/io/impl/escape.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace storages::clickhouse {
+
+/// @ingroup userver_containers
+///
+/// @brief Class for dynamic ClickHouse parameter list construction.
+///
+class ParameterStore {
+public:
+    ParameterStore() = default;
+    ParameterStore(const ParameterStore&) = delete;
+    ParameterStore(ParameterStore&&) = default;
+    ParameterStore& operator=(const ParameterStore&) = delete;
+    ParameterStore& operator=(ParameterStore&&) = default;
+
+    /// @brief Adds a parameter to the end of the parameter list.
+    /// @note Currently only built-in/system types are supported.
+    template <typename T>
+    ParameterStore& PushBack(const T& param) {
+        parameters_.push_back(io::impl::Escape(param));
+        return *this;
+    }
+
+    /// Returns whether the parameter list is empty.
+    bool IsEmpty() const;
+
+    /// Returns current size of the list.
+    size_t Size() const;
+
+    /// @brief Get serialized parameters for substitution in a query.
+    const fmt::dynamic_format_arg_store<fmt::format_context>& GetParameters() const;
+
+private:
+    fmt::dynamic_format_arg_store<fmt::format_context> parameters_{};
+};
+
+}  // namespace storages::clickhouse
+
+USERVER_NAMESPACE_END

--- a/clickhouse/include/userver/storages/clickhouse/query.hpp
+++ b/clickhouse/include/userver/storages/clickhouse/query.hpp
@@ -47,20 +47,10 @@ public:
     friend class impl::Pool;
 
 private:
-    inline std::size_t CountBraces(std::string_view s) const;
-
     template <typename... Args>
     Query WithArgs(const Args&... args) const {
-        auto expected = CountBraces(text_);
-        auto actual = sizeof...(args);
-        if (expected != actual) {
-            throw std::runtime_error(fmt::format(
-                "Parameter count mismatch: query ({}) expects {} placeholders, but got {} parameters.\n",
-                text_,
-                expected,
-                actual
-            ));
-        }
+        // we should throw on params count mismatch
+        // TODO : https://st.yandex-team.ru/TAXICOMMON-5066
         return Query{fmt::format(fmt::runtime(text_), io::impl::Escape(args)...), name_};
     }
 

--- a/clickhouse/include/userver/storages/clickhouse/query.hpp
+++ b/clickhouse/include/userver/storages/clickhouse/query.hpp
@@ -11,6 +11,7 @@
 #include <userver/utils/strong_typedef.hpp>
 
 #include <userver/storages/clickhouse/io/impl/escape.hpp>
+#include <userver/storages/clickhouse/parameter_store.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -46,12 +47,24 @@ public:
     friend class impl::Pool;
 
 private:
+    inline std::size_t CountBraces(std::string_view s) const;
+
     template <typename... Args>
     Query WithArgs(const Args&... args) const {
-        // we should throw on params count mismatch
-        // TODO : https://st.yandex-team.ru/TAXICOMMON-5066
+        auto expected = CountBraces(text_);
+        auto actual = sizeof...(args);
+        if (expected != actual) {
+            throw std::runtime_error(fmt::format(
+                "Parameter count mismatch: query ({}) expects {} placeholders, but got {} parameters.\n",
+                text_,
+                expected,
+                actual
+            ));
+        }
         return Query{fmt::format(fmt::runtime(text_), io::impl::Escape(args)...), name_};
     }
+
+    Query WithArgs(const ParameterStore& params) const;
 
     void FillSpanTags(tracing::Span&) const;
 

--- a/clickhouse/src/storages/clickhouse/cluster.cpp
+++ b/clickhouse/src/storages/clickhouse/cluster.cpp
@@ -50,6 +50,17 @@ Cluster::Cluster(
 
 Cluster::~Cluster() = default;
 
+ExecutionResult Cluster::Execute(const Query& query, const ParameterStore& params) const {
+    auto formatted_query = query.WithArgs(params);
+    return DoExecute(OptionalCommandControl{}, formatted_query);
+}
+
+ExecutionResult Cluster::Execute(OptionalCommandControl optional_cc, const Query& query, const ParameterStore& params)
+    const {
+    auto formatted_query = query.WithArgs(params);
+    return DoExecute(optional_cc, formatted_query);
+}
+
 ExecutionResult Cluster::DoExecute(OptionalCommandControl optional_cc, const Query& query) const {
     return GetPool().Execute(optional_cc, query);
 }

--- a/clickhouse/src/storages/clickhouse/io/impl/escape.cpp
+++ b/clickhouse/src/storages/clickhouse/io/impl/escape.cpp
@@ -1,6 +1,9 @@
+
 #include <userver/storages/clickhouse/io/impl/escape.hpp>
 
 #include <userver/storages/clickhouse/io/type_traits.hpp>
+
+#include <boost/uuid/uuid_io.hpp>
 
 #include <fmt/format.h>
 

--- a/clickhouse/src/storages/clickhouse/io/impl/escape.cpp
+++ b/clickhouse/src/storages/clickhouse/io/impl/escape.cpp
@@ -73,6 +73,10 @@ std::string Escape(std::string_view source) {
     return result;
 }
 
+std::string Escape(const boost::uuids::uuid& uuid) {
+    return fmt::format("toUUID('{}')", boost::uuids::to_string(uuid));
+}
+
 std::string Escape(std::chrono::system_clock::time_point source) {
     return fmt::format(
         "toDateTime({})", std::chrono::duration_cast<std::chrono::seconds>(source.time_since_epoch()).count()

--- a/clickhouse/src/storages/clickhouse/parameter_store.cpp
+++ b/clickhouse/src/storages/clickhouse/parameter_store.cpp
@@ -1,0 +1,15 @@
+#include <userver/storages/clickhouse/parameter_store.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace storages::clickhouse {
+
+bool ParameterStore::IsEmpty() const { return parameters_.size(); }
+
+size_t ParameterStore::Size() const { return parameters_.size(); }
+
+const fmt::dynamic_format_arg_store<fmt::format_context>& ParameterStore::GetParameters() const { return parameters_; }
+
+}  // namespace storages::clickhouse
+
+USERVER_NAMESPACE_END

--- a/clickhouse/src/storages/clickhouse/query.cpp
+++ b/clickhouse/src/storages/clickhouse/query.cpp
@@ -15,6 +15,30 @@ const std::string& Query::QueryText() const& { return text_; }
 
 const std::optional<Query::Name>& Query::QueryName() const& { return name_; }
 
+inline std::size_t Query::CountBraces(std::string_view s) const {
+    std::size_t count = 0;
+    std::size_t pos = 0;
+    while ((pos = s.find("{}", pos)) != std::string_view::npos) {
+        ++count;
+        pos += 2;
+    }
+    return count;
+}
+
+Query Query::WithArgs(const ParameterStore& params) const {
+    auto expected = CountBraces(text_);
+    auto actual = params.GetParameters().size();
+    if (expected != actual) {
+        throw std::runtime_error(fmt::format(
+            "Parameter count mismatch: query ({}) expects {} placeholders, but got {} parameters.\n",
+            text_,
+            expected,
+            actual
+        ));
+    }
+    return Query{fmt::vformat(text_, params.GetParameters()), name_};
+}
+
 void Query::FillSpanTags(tracing::Span& span) const {
     if (name_.has_value()) {
         span.AddTag(tracing::kDatabaseStatementName, name_->GetUnderlying());

--- a/clickhouse/src/storages/clickhouse/query.cpp
+++ b/clickhouse/src/storages/clickhouse/query.cpp
@@ -15,27 +15,9 @@ const std::string& Query::QueryText() const& { return text_; }
 
 const std::optional<Query::Name>& Query::QueryName() const& { return name_; }
 
-inline std::size_t Query::CountBraces(std::string_view s) const {
-    std::size_t count = 0;
-    std::size_t pos = 0;
-    while ((pos = s.find("{}", pos)) != std::string_view::npos) {
-        ++count;
-        pos += 2;
-    }
-    return count;
-}
-
 Query Query::WithArgs(const ParameterStore& params) const {
-    auto expected = CountBraces(text_);
-    auto actual = params.GetParameters().size();
-    if (expected != actual) {
-        throw std::runtime_error(fmt::format(
-            "Parameter count mismatch: query ({}) expects {} placeholders, but got {} parameters.\n",
-            text_,
-            expected,
-            actual
-        ));
-    }
+    // we should throw on params count mismatch
+    // TODO : https://st.yandex-team.ru/TAXICOMMON-5066
     return Query{fmt::vformat(text_, params.GetParameters()), name_};
 }
 

--- a/clickhouse/src/storages/tests/parameter_store_chtest.cpp
+++ b/clickhouse/src/storages/tests/parameter_store_chtest.cpp
@@ -1,0 +1,180 @@
+#include <userver/storages/clickhouse/parameter_store.hpp>
+#include <userver/storages/clickhouse/query.hpp>
+#include <userver/utest/utest.hpp>
+
+#include "utils_test.hpp"
+
+USERVER_NAMESPACE_BEGIN
+
+UTEST(ClickhouseParameterStore, ParamsEqualPlaceholders) {
+    ClusterWrapper cluster;
+    cluster->Execute(userver::storages::clickhouse::Query{
+        "CREATE TABLE IF NOT EXISTS users (id UInt64, name String) ENGINE = Memory"
+    });
+    userver::storages::clickhouse::Query q{"SELECT {} FROM {} WHERE id = {}"};
+    userver::storages::clickhouse::ParameterStore params;
+    params.PushBack("name");
+    params.PushBack("users");
+    params.PushBack(42);
+    EXPECT_NO_THROW(cluster->Execute(q, params));
+}
+
+UTEST(ClickhouseParameterStore, LessParamsThanPlaceholders) {
+    ClusterWrapper cluster;
+    cluster->Execute(userver::storages::clickhouse::Query{
+        "CREATE TABLE IF NOT EXISTS users (id UInt64, name String) ENGINE = Memory"
+    });
+    userver::storages::clickhouse::Query q{"SELECT {} FROM {} WHERE id = {}"};
+    userver::storages::clickhouse::ParameterStore params1;
+    params1.PushBack("name");
+    params1.PushBack("users");
+    EXPECT_THROW(cluster->Execute(q, params1), std::runtime_error);
+
+    userver::storages::clickhouse::ParameterStore params2;
+    params2.PushBack("name");
+    EXPECT_THROW(cluster->Execute(q, params2), std::runtime_error);
+
+    userver::storages::clickhouse::ParameterStore params3;
+    EXPECT_THROW(cluster->Execute(q, params3), std::runtime_error);
+}
+
+UTEST(ClickhouseParameterStore, MoreParamsThanPlaceholders) {
+    ClusterWrapper cluster;
+    cluster->Execute(userver::storages::clickhouse::Query{
+        "CREATE TABLE IF NOT EXISTS users (id UInt64, name String) ENGINE = Memory"
+    });
+    userver::storages::clickhouse::Query q{"SELECT {} FROM {} WHERE id = {}"};
+    userver::storages::clickhouse::ParameterStore params;
+    params.PushBack("name");
+    params.PushBack("users");
+    params.PushBack(42);
+    params.PushBack("extra");
+    EXPECT_NO_THROW(cluster->Execute(q, params));
+}
+
+UTEST(ClickhouseParameterStore, NoPlaceholdersNoParams) {
+    ClusterWrapper cluster;
+    userver::storages::clickhouse::Query q{"SELECT 1"};
+    userver::storages::clickhouse::ParameterStore params;
+    EXPECT_NO_THROW(cluster->Execute(q, params));
+}
+
+UTEST(ClickhouseParameterStore, NoPlaceholdersWithParams) {
+    ClusterWrapper cluster;
+    userver::storages::clickhouse::Query q{"SELECT 1"};
+    userver::storages::clickhouse::ParameterStore params;
+    params.PushBack(1);
+    EXPECT_NO_THROW(cluster->Execute(q, params));
+}
+
+UTEST(ClickhouseParameterStore, OnlyBraces) {
+    ClusterWrapper cluster;
+    userver::storages::clickhouse::Query q{"SELECT {}"};
+    userver::storages::clickhouse::ParameterStore params1;
+    params1.PushBack(1);
+    EXPECT_NO_THROW(cluster->Execute(q, params1));
+
+    userver::storages::clickhouse::ParameterStore params2;
+    EXPECT_THROW(cluster->Execute(q, params2), std::runtime_error);
+
+    userver::storages::clickhouse::ParameterStore params3;
+    params3.PushBack(1);
+    params3.PushBack(2);
+    EXPECT_NO_THROW(cluster->Execute(q, params3));
+}
+
+UTEST(ClickhouseParameterStore, MultipleBracesCases) {
+    ClusterWrapper cluster;
+    userver::storages::clickhouse::Query q{"SELECT {}, {}, {}"};
+    userver::storages::clickhouse::ParameterStore params1;
+    params1.PushBack(1);
+    params1.PushBack(2);
+    params1.PushBack(3);
+    EXPECT_NO_THROW(cluster->Execute(q, params1));
+
+    userver::storages::clickhouse::ParameterStore params2;
+    params2.PushBack(1);
+    params2.PushBack(2);
+    EXPECT_THROW(cluster->Execute(q, params2), std::runtime_error);
+
+    userver::storages::clickhouse::ParameterStore params3;
+    params3.PushBack(1);
+    params3.PushBack(2);
+    params3.PushBack(3);
+    params3.PushBack(4);
+    EXPECT_NO_THROW(cluster->Execute(q, params3));
+}
+
+UTEST(ClickhouseParameterStore, IndexedPlaceholdersExactParams) {
+    ClusterWrapper cluster;
+    cluster->Execute(userver::storages::clickhouse::Query{
+        "CREATE TABLE IF NOT EXISTS users (id UInt64, name String) ENGINE = Memory"
+    });
+    userver::storages::clickhouse::Query q{"SELECT {1} FROM {0} WHERE id = {2}"};
+    userver::storages::clickhouse::ParameterStore params;
+    params.PushBack("users");
+    params.PushBack("name");
+    params.PushBack(42);
+    EXPECT_NO_THROW(cluster->Execute(q, params));
+}
+
+UTEST(ClickhouseParameterStore, IndexedPlaceholdersLessParams) {
+    ClusterWrapper cluster;
+    userver::storages::clickhouse::Query q{"SELECT {0}, {1}, {2} FROM users"};
+    userver::storages::clickhouse::ParameterStore params;
+    params.PushBack("id");
+    params.PushBack("name");
+    EXPECT_THROW(cluster->Execute(q, params), std::runtime_error);
+}
+
+UTEST(ClickhouseParameterStore, IndexedPlaceholdersMoreParams) {
+    ClusterWrapper cluster;
+    userver::storages::clickhouse::Query q{"SELECT {2}, {1}, {0} FROM users"};
+    userver::storages::clickhouse::ParameterStore params;
+    params.PushBack("name");
+    params.PushBack("id");
+    params.PushBack("age");
+    params.PushBack("extra");
+    EXPECT_NO_THROW(cluster->Execute(q, params));
+}
+
+UTEST(ClickhouseParameterStore, IndexedPlaceholdersRepeatedIndexes) {
+    ClusterWrapper cluster;
+    userver::storages::clickhouse::Query q{"SELECT {0}, {0}, {1} FROM users"};
+    userver::storages::clickhouse::ParameterStore params;
+    params.PushBack("id");
+    params.PushBack("name");
+    EXPECT_NO_THROW(cluster->Execute(q, params));
+}
+
+UTEST(ClickhouseParameterStore, IndexedPlaceholdersNonSequential) {
+    ClusterWrapper cluster;
+    userver::storages::clickhouse::Query q{"SELECT {2}, {0}, {5} FROM users"};
+    userver::storages::clickhouse::ParameterStore params;
+    params.PushBack("first");
+    params.PushBack("second");
+    params.PushBack("third");
+    params.PushBack("fourth");
+    params.PushBack("fifth");
+    params.PushBack("sixth");
+    EXPECT_NO_THROW(cluster->Execute(q, params));
+}
+
+UTEST(ClickhouseParameterStore, IndexedPlaceholdersTooFewParamsForMaxIndex) {
+    ClusterWrapper cluster;
+    userver::storages::clickhouse::Query q{"SELECT {2}, {0}, {5} FROM users"};
+    userver::storages::clickhouse::ParameterStore params;
+    params.PushBack("first");
+    params.PushBack("second");
+    params.PushBack("third");
+    EXPECT_THROW(cluster->Execute(q, params), std::runtime_error);
+}
+
+UTEST(ClickhouseParameterStore, IndexedPlaceholdersZeroParams) {
+    ClusterWrapper cluster;
+    userver::storages::clickhouse::Query q{"SELECT {0} FROM users"};
+    userver::storages::clickhouse::ParameterStore params;
+    EXPECT_THROW(cluster->Execute(q, params), std::runtime_error);
+}
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
Изменения
Добавлен новый объект userver::storages::clickhouse::ParameterStore store;
Реализована возможность накапливать параметры для ClickHouse-запросов через store.PushBack(data);
Добавлен Escape для типа boost::uuids::uuid

