### PR TITLE
Add support for Google Benchmark ASLR-disabling feature

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -251,18 +251,9 @@ if(USERVER_BUILD_TESTS)
 endif()
 
 if(USERVER_FEATURE_UTEST)
-    check_cxx_source_compiles("
-    #include <benchmark/benchmark.h>
-    int main() {
-        void* p = (void*)&benchmark::MaybeReenterWithoutASLR;
-        return 0;
-    }
-" MAYBE_REENTER_WITHOUT_ASLR_EXISTS)
-
     add_library(userver-ubench ${LIBUBENCH_SOURCES})
     target_include_directories(userver-ubench PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},INCLUDE_DIRECTORIES>)
     target_compile_definitions(userver-ubench PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
-    target_compile_definitions(userver-ubench PRIVATE MAYBE_REENTER_WITHOUT_ASLR_EXISTS)
     target_link_libraries(
         userver-ubench
         PUBLIC ${PROJECT_NAME} userver-universal-internal-ubench

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -251,9 +251,18 @@ if(USERVER_BUILD_TESTS)
 endif()
 
 if(USERVER_FEATURE_UTEST)
+    check_cxx_source_compiles("
+    #include <benchmark/benchmark.h>
+    int main() {
+        void* p = (void*)&benchmark::MaybeReenterWithoutASLR;
+        return 0;
+    }
+" MAYBE_REENTER_WITHOUT_ASLR_EXISTS)
+
     add_library(userver-ubench ${LIBUBENCH_SOURCES})
     target_include_directories(userver-ubench PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},INCLUDE_DIRECTORIES>)
     target_compile_definitions(userver-ubench PUBLIC $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
+    target_compile_definitions(userver-ubench PRIVATE MAYBE_REENTER_WITHOUT_ASLR_EXISTS)
     target_link_libraries(
         userver-ubench
         PUBLIC ${PROJECT_NAME} userver-universal-internal-ubench

--- a/core/benchmarks/main.cpp
+++ b/core/benchmarks/main.cpp
@@ -15,4 +15,5 @@ int main(int argc, char** argv) {
     ::benchmark::Initialize(&argc, argv);
     if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
     ::benchmark::RunSpecifiedBenchmarks();
+    ::benchmark::Shutdown();
 }

--- a/core/benchmarks/main.cpp
+++ b/core/benchmarks/main.cpp
@@ -4,6 +4,10 @@
 #include <userver/utils/impl/static_registration.hpp>
 
 int main(int argc, char** argv) {
+#ifdef MAYBE_REENTER_WITHOUT_ASLR_EXISTS
+    benchmark::MaybeReenterWithoutASLR(argc, argv);
+#endif
+
     USERVER_NAMESPACE::utils::impl::FinishStaticRegistration();
 
     const USERVER_NAMESPACE::logging::DefaultLoggerLevelScope level_scope{USERVER_NAMESPACE::logging::Level::kError};

--- a/universal/CMakeLists.txt
+++ b/universal/CMakeLists.txt
@@ -313,6 +313,16 @@ if(USERVER_FEATURE_UTEST)
         include(SetupGBench)
         set(_benchmark_target benchmark::benchmark)
     endif()
+
+    try_compile(
+        HAVE_MAYBE_REENTER_WITHOUT_ASLR ${CMAKE_CURRENT_BINARY_DIR}/benchmarks/main_check_aslr_disable
+        SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/benchmarks/main_check_aslr_disable.cpp
+        LINK_LIBRARIES benchmark::benchmark
+    )
+    if(HAVE_MAYBE_REENTER_WITHOUT_ASLR)
+        target_compile_definitions(${PROJECT_NAME}-internal-ubench INTERFACE MAYBE_REENTER_WITHOUT_ASLR_EXISTS)
+    endif()
+
     target_link_libraries(${PROJECT_NAME}-internal-ubench INTERFACE ${_benchmark_target} ${PROJECT_NAME})
 endif()
 

--- a/universal/benchmarks/main_check_aslr_disable.cpp
+++ b/universal/benchmarks/main_check_aslr_disable.cpp
@@ -1,0 +1,5 @@
+#include <benchmark/benchmark.h>
+int main() {
+    void* p = (void*)&benchmark::MaybeReenterWithoutASLR;
+    return 0;
+}


### PR DESCRIPTION
Closes #960 

I didn't find any compile-time way to check version of google-benchmark in c++
I had to made some cmake stuff...





------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

