### PR TITLE
cmake: dependency generalization between service and it's testsuite runner

### DIFF
--- a/cmake/UserverTestsuite.cmake
+++ b/cmake/UserverTestsuite.cmake
@@ -225,8 +225,10 @@ function(userver_testsuite_add)
         VERBATIM ${CODEGEN}
     )
     _userver_codegen_register_files("${TESTSUITE_RUNNER}")
-    # HACK: it seems too verbose to create a separate target for the file.
-    target_sources("${ARG_SERVICE_TARGET}" PRIVATE "${TESTSUITE_RUNNER}")
+
+    set(CREATE_TESTSUITE_RUNNER_TARGET "create-runtests-${service_target_with_suffix}")
+    add_custom_target("${CREATE_TESTSUITE_RUNNER_TARGET}" SOURCES "${TESTSUITE_RUNNER}")
+    add_dependencies("${ARG_SERVICE_TARGET}" "${CREATE_TESTSUITE_RUNNER_TARGET}")
 
     set(PRETTY_LOGS_MODE "")
     if(ARG_PRETTY_LOGS)


### PR DESCRIPTION
`target_sources("${ARG_SERVICE_TARGET}" PRIVATE "${TESTSUITE_RUNNER}")` expression does not work properly when `add_executable(service)` and `userver_testsuite_add(SERVICE_TARGET service)` declared in different files.

For example, CMake generation would fail in this case:
```
# CMakeLists.txt
add_subdirectory(src)
add_subdirectory(test)

# src/CMakeLists.txt
add_subdirectory(my_server)

# src/my_server/CMakeLists.txt
add_executable(my_server my_server.cc)

# test/CMakeLists.txt
add_subdirectory(my_server)

# test/my_server/CMakeLists.txt
userver_testsuite_add(SERVICE_TARGET my_server ...)
```

The suggested change will fix it.