### PR TITLE
Support SSL security protocol in Kafka configuration

### DIFF
--- a/kafka/include/userver/kafka/impl/broker_secrets.hpp
+++ b/kafka/include/userver/kafka/impl/broker_secrets.hpp
@@ -15,6 +15,9 @@ struct Secret final {
     std::string brokers;
     SecretType username;
     SecretType password;
+    SecretType ssl_certificate_location;
+    SecretType ssl_key_location;
+    SecretType ssl_key_password;
 };
 
 class BrokerSecrets final {

--- a/kafka/include/userver/kafka/impl/configuration.hpp
+++ b/kafka/include/userver/kafka/impl/configuration.hpp
@@ -33,8 +33,11 @@ struct SecurityConfiguration final {
         std::string security_mechanism;
         std::string ssl_ca_location;
     };
+    struct Ssl final {
+        std::string ssl_ca_location;
+    };
 
-    using SecurityProtocol = std::variant<Plaintext, SaslPlaintext, SaslSsl>;
+    using SecurityProtocol = std::variant<Plaintext, SaslPlaintext, SaslSsl, Ssl>;
     SecurityProtocol security_protocol{};
 };
 

--- a/kafka/src/kafka/consumer_component.cpp
+++ b/kafka/src/kafka/consumer_component.cpp
@@ -146,6 +146,7 @@ properties:
           - PLAINTEXT
           - SASL_SSL
           - SASL_PLAINTEXT
+          - SSL
     sasl_mechanisms:
         type: string
         description: |
@@ -159,7 +160,7 @@ properties:
         type: string
         description: |
             file or directory path to CA certificate(s) for verifying the broker's key.
-            Must be set if `security_protocol` equals `SASL_SSL`.
+            Must be set if `security_protocol` equals `SASL_SSL` or `SSL`.
             If set to `probe`, CA certificates are probed from the default certificates paths
         defaultDescription: none
     topic_metadata_refresh_interval:

--- a/kafka/src/kafka/impl/broker_secrets.cpp
+++ b/kafka/src/kafka/impl/broker_secrets.cpp
@@ -11,7 +11,10 @@ Secret Parse(const formats::json::Value& doc, formats::parse::To<Secret>) {
     Secret secret{
         doc["brokers"].As<std::string>(),
         doc["username"].As<Secret::SecretType>(),
-        doc["password"].As<Secret::SecretType>()};
+        doc["password"].As<Secret::SecretType>(),
+        doc["ssl_certificate_location"].As<Secret::SecretType>(Secret::SecretType{""}),
+        doc["ssl_key_location"].As<Secret::SecretType>(Secret::SecretType{""}),
+        doc["ssl_key_password"].As<Secret::SecretType>(Secret::SecretType{""})};
 
     return secret;
 }

--- a/kafka/src/kafka/impl/configuration.cpp
+++ b/kafka/src/kafka/impl/configuration.cpp
@@ -107,10 +107,12 @@ SecurityConfiguration Parse(const yaml_config::YamlConfig& config, formats::pars
     static constexpr std::string_view kPlainTextProtocol{"PLAINTEXT"};
     static constexpr std::string_view kSaslPlainTextProtocol{"SASL_PLAINTEXT"};
     static constexpr std::string_view kSaslSSLProtocol{"SASL_SSL"};
+    static constexpr std::string_view kSSLProtocol{"SSL"};
     static constexpr std::array kSupportedSecurityProtocols{
         kPlainTextProtocol,
         kSaslSSLProtocol,
         kSaslPlainTextProtocol,
+        kSSLProtocol,
     };
     static constexpr std::array kSupportedSaslSecurityMechanisms{"PLAIN", "SCRAM-SHA-512"};
 
@@ -122,6 +124,13 @@ SecurityConfiguration Parse(const yaml_config::YamlConfig& config, formats::pars
     }
     if (protocol == kPlainTextProtocol) {
         security.security_protocol.emplace<SecurityConfiguration::Plaintext>();
+        return security;
+    }
+
+    if (protocol == kSSLProtocol) {
+        security.security_protocol.emplace<SecurityConfiguration::Ssl>(SecurityConfiguration::Ssl{
+            /*ssl_ca_location=*/config["ssl_ca_location"].As<std::string>(),
+        });
         return security;
     }
 
@@ -260,6 +269,17 @@ void Configuration::SetSecurity(const SecurityConfiguration& security, const Sec
             SetOption("sasl.username", secrets.username);
             SetOption("sasl.password", secrets.password);
             SetOption("ssl.ca.location", sasl_ssl.ssl_ca_location);
+        },
+        [this, &secrets](const SecurityConfiguration::Ssl& ssl) {
+            LOG_INFO("Using SSL security protocol");
+
+            SetOption("security.protocol", "SSL");
+            SetOption("ssl.ca.location", ssl.ssl_ca_location);
+            SetOption("ssl.certificate.location", secrets.ssl_certificate_location);
+            SetOption("ssl.key.location", secrets.ssl_key_location);
+            if (!secrets.ssl_key_password.GetUnderlying().empty()) {
+                SetOption("ssl.key.password", secrets.ssl_key_password);
+            }
         }
     );
 }

--- a/kafka/src/kafka/producer_component.cpp
+++ b/kafka/src/kafka/producer_component.cpp
@@ -108,6 +108,7 @@ properties:
           - PLAINTEXT
           - SASL_SSL
           - SASL_PLAINTEXT
+          - SSL
     sasl_mechanisms:
         type: string
         description: |
@@ -121,9 +122,10 @@ properties:
         type: string
         description: |
             file or directory path to CA certificate(s) for verifying the broker's key.
-            Must be set if `security_protocol` equals `SASL_SSL`.
+            Must be set if `security_protocol` equals `SASL_SSL` or `SSL`.
             If set to `probe`, CA certificates are probed from the default certificates paths
         defaultDescription: none
+
     rd_kafka_custom_options:
         type: object
         description: |

--- a/kafka/tests/configuration_test.cpp
+++ b/kafka/tests/configuration_test.cpp
@@ -234,4 +234,49 @@ UTEST_F(ConfigurationTest, ConsumerResolveGroupId) {
     EXPECT_EQ(configuration->GetOption("group.id"), "test-group-pod-example-com");
 }
 
+UTEST_F(ConfigurationTest, ProducerSSL) {
+    kafka::impl::ProducerConfiguration producer_configuration{};
+    producer_configuration.security.security_protocol = kafka::impl::SecurityConfiguration::Ssl{
+        /*ssl_ca_location=*/"/etc/ssl/ca.crt",
+    };
+
+    kafka::impl::Secret secrets;
+    secrets.ssl_certificate_location = kafka::impl::Secret::SecretType{"/etc/ssl/client.crt"};
+    secrets.ssl_key_location = kafka::impl::Secret::SecretType{"/etc/ssl/client.key"};
+    secrets.ssl_key_password = kafka::impl::Secret::SecretType{"password123"};
+
+    std::optional<kafka::impl::Configuration> configuration;
+    UEXPECT_NO_THROW(
+        configuration.emplace(MakeProducerConfiguration("kafka-producer", producer_configuration, secrets))
+    );
+
+    EXPECT_EQ(configuration->GetOption("security.protocol"), "ssl");
+    EXPECT_EQ(configuration->GetOption("ssl.ca.location"), "/etc/ssl/ca.crt");
+    EXPECT_EQ(configuration->GetOption("ssl.certificate.location"), "/etc/ssl/client.crt");
+    EXPECT_EQ(configuration->GetOption("ssl.key.location"), "/etc/ssl/client.key");
+    EXPECT_EQ(configuration->GetOption("ssl.key.password"), "password123");
+}
+
+UTEST_F(ConfigurationTest, ConsumerSSL) {
+    kafka::impl::ConsumerConfiguration consumer_configuration{};
+    consumer_configuration.security.security_protocol = kafka::impl::SecurityConfiguration::Ssl{
+        /*ssl_ca_location=*/"/etc/ssl/ca.crt",
+    };
+
+    kafka::impl::Secret secrets;
+    secrets.ssl_certificate_location = kafka::impl::Secret::SecretType{"/etc/ssl/client.crt"};
+    secrets.ssl_key_location = kafka::impl::Secret::SecretType{"/etc/ssl/client.key"};
+    secrets.ssl_key_password = kafka::impl::Secret::SecretType{""};  // No password
+
+    std::optional<kafka::impl::Configuration> configuration;
+    UEXPECT_NO_THROW(
+        configuration.emplace(MakeConsumerConfiguration("kafka-consumer", consumer_configuration, secrets))
+    );
+
+    EXPECT_EQ(configuration->GetOption("security.protocol"), "ssl");
+    EXPECT_EQ(configuration->GetOption("ssl.ca.location"), "/etc/ssl/ca.crt");
+    EXPECT_EQ(configuration->GetOption("ssl.certificate.location"), "/etc/ssl/client.crt");
+    EXPECT_EQ(configuration->GetOption("ssl.key.location"), "/etc/ssl/client.key");
+}
+
 USERVER_NAMESPACE_END


### PR DESCRIPTION
Added `SSL` option to `security_protocol` parameter, that enables SSL authentication mechanism in Kafka

