### PR TITLE
feat universal: is_constructible check for MakeSharedRef, MakeUniqueRef

### DIFF
--- a/universal/include/userver/utils/not_null.hpp
+++ b/universal/include/userver/utils/not_null.hpp
@@ -106,13 +106,13 @@ template <typename U>
 using UniqueRef = NotNull<std::unique_ptr<U>>;
 
 /// @brief An equivalent of `std::make_shared` for SharedRef.
-template <typename U, typename... Args>
+template <typename U, typename... Args, typename = std::enable_if_t<std::is_constructible_v<U, Args...>>>
 SharedRef<U> MakeSharedRef(Args&&... args) {
     return SharedRef<U>{std::make_shared<U>(std::forward<Args>(args)...)};
 }
 
 /// @brief An equivalent of `std::make_unique` for UniqueRef.
-template <typename U, typename... Args>
+template <typename U, typename... Args, typename = std::enable_if_t<std::is_constructible_v<U, Args...>>>
 UniqueRef<U> MakeUniqueRef(Args&&... args) {
     return UniqueRef<U>{std::make_unique<U>(std::forward<Args>(args)...)};
 }


### PR DESCRIPTION
Problem: 
```cpp
struct X { 
    X(Arg1, Arg2, Arg3);
};
::utils:MakeSharedRef<X>(Arg1, Arg2); /// There should be 
```
This code doesn't compile, but I want to get errors/warnings from clangd in the last line fragment above.
I didn't find a solution in the clangd flags for similar std::make_shared/std::make_unique, so I add a std::is_constructible check.

