### PR TITLE
Schedule defered _userver_codegen_make_main_target only once

### DIFF
--- a/cmake/UserverCodegenTarget.cmake
+++ b/cmake/UserverCodegenTarget.cmake
@@ -68,6 +68,30 @@ function(_userver_codegen_make_directory_target)
     set_property(GLOBAL APPEND PROPERTY userver_codegen_targets "userver-codegen-impl-${index}")
 endfunction()
 
+function(_userver_schedule_make_main_target_once)
+    cmake_language(
+        DEFER
+        DIRECTORY
+        "${CMAKE_SOURCE_DIR}"
+        GET_CALL
+        userver_codegen_make_main_target
+        scheduled
+    )
+    message(STATUS "already scheduled: ${scheduled}")
+    if(NOT scheduled)
+        # On first codegen invocation, schedule userver-codegen target creation.
+        cmake_language(
+            DEFER
+            DIRECTORY
+            "${CMAKE_SOURCE_DIR}"
+            ID
+            userver_codegen_make_main_target
+            CALL
+            _userver_codegen_make_main_target
+        )
+    endif()
+endfunction()
+
 function(_userver_codegen_register_files FILES_LIST)
     if(CMAKE_VERSION VERSION_LESS "3.19" OR NOT FILES_LIST)
         return()
@@ -83,23 +107,7 @@ function(_userver_codegen_register_files FILES_LIST)
         # On first codegen files in the current directory, schedule indexed codegen target creation.
         cmake_language(DEFER DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" CALL _userver_codegen_make_directory_target)
 
-        get_property(
-            has_userver_codegen_targets GLOBAL
-            PROPERTY userver_codegen_targets
-            SET
-        )
-        if(NOT has_userver_codegen_targets)
-            # On first codegen invocation, schedule userver-codegen target creation.
-            cmake_language(
-                DEFER
-                DIRECTORY
-                "${CMAKE_SOURCE_DIR}"
-                ID
-                userver_codegen_make_main_target
-                CALL
-                _userver_codegen_make_main_target
-            )
-        endif()
+        _userver_schedule_make_main_target_once()
     endif()
 
     set_property(

--- a/cmake/UserverCodegenTarget.cmake
+++ b/cmake/UserverCodegenTarget.cmake
@@ -77,7 +77,6 @@ function(_userver_schedule_make_main_target_once)
         userver_codegen_make_main_target
         scheduled
     )
-    message(STATUS "already scheduled: ${scheduled}")
     if(NOT scheduled)
         # On first codegen invocation, schedule userver-codegen target creation.
         cmake_language(


### PR DESCRIPTION
Subsequent calls of cmake function _userver_codegen_register_files fails with error "userver-codegen target already defined".
Reproduces in case of adding grpc proto libs using `userver_add_grpc_library` in a subsequent call chain.

simplified example:

```
find_package(
    userver
    COMPONENTS grpc
    REQUIRED
)

userver_add_grpc_library(${PROJECT_NAME}-proto PROTOS samples/greeter.proto)

add_subdirectory(another_grpc_lib)
# there CMakeLists.txt inside another_grpc_lib with content like
# userver_add_grpc_library(another-lib-proto PROTOS samples/service.proto)
#
```





------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

