### PR TITLE
fix chaotic: format golden_test/output before comparing

### DIFF
--- a/chaotic/golden_tests/CMakeLists.txt
+++ b/chaotic/golden_tests/CMakeLists.txt
@@ -19,9 +19,14 @@ userver_target_generate_chaotic(
     RELATIVE_TO "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
-add_test(NAME chaotic-golden COMMAND # Diff returns 0 if files are the same, 1 if they differ
-                                     diff -uNrpB "${CMAKE_CURRENT_SOURCE_DIR}/output" "${CMAKE_CURRENT_BINARY_DIR}/src"
+add_test(
+    NAME chaotic-golden
+    COMMAND "${USERVER_CHAOTIC_PYTEST_PYTHON_BINARY}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/compare.py"
+    --golden-dir "${CMAKE_CURRENT_SOURCE_DIR}/output"
+    --generated-dir "${CMAKE_CURRENT_BINARY_DIR}/src"
 )
+
 add_custom_target(
     update-golden-tests
     DEPENDS ${PROJECT_NAME}-chgen

--- a/chaotic/golden_tests/scripts/compare.py
+++ b/chaotic/golden_tests/scripts/compare.py
@@ -1,0 +1,59 @@
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def check_binary_available(binary_name):
+    try: # Pass version arg to expect any "wait for input" situations
+        subprocess.run([binary_name, '--version'], capture_output=True, check=True)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Compare formatted source files.')
+    parser.add_argument('--golden-dir', required=True, help='Golden directory (e.g., ${CMAKE_CURRENT_SOURCE_DIR}/output)')
+    parser.add_argument('--generated-dir', required=True, help='Generated directory (e.g., ${CMAKE_CURRENT_BINARY_DIR}/src)')
+    args = parser.parse_args()
+
+    if not check_binary_available('clang-format'):
+        print("Error: clang-format is not available in PATH", file=sys.stderr)
+        sys.exit(1)
+
+    if not check_binary_available('diff'):
+        print("Error: diff is not available in PATH", file=sys.stderr)
+        sys.exit(1)
+
+    # Create temporary directory in /tmp/
+    with tempfile.TemporaryDirectory() as tmpdir:
+        golden_copy = os.path.join(tmpdir, 'golden')
+        generated_copy = os.path.join(tmpdir, 'generated')
+        shutil.copytree(args.golden_dir, golden_copy)
+        shutil.copytree(args.generated_dir, generated_copy)
+
+        extensions = ('.hpp', '.cpp', '.ipp')
+        for root, _, files in os.walk(tmpdir):
+            for file in files:
+                if file.lower().endswith(extensions):
+                    file_path = os.path.join(root, file)
+                    subprocess.run(['clang-format', '-i', file_path], check=True)
+
+        result = subprocess.run([
+            'diff', '-uNrpB',
+            golden_copy,
+            generated_copy
+        ], capture_output=True, text=True)
+
+        if result.returncode != 0:
+            print(result.stdout)
+            print(result.stderr, file=sys.stderr)
+
+        sys.exit(result.returncode)  # Diff returns 0 if files are the same, 1 if they differ
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Now we run clang-format on both sides of diff
Its prevents problems due to clang-format version changes

Fixes #1024








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

