### PR TITLE
feat urabbitmq: support for ReplyTo, CorrelationId, Expiration fields

### DIFF
--- a/rabbitmq/functional_tests/basic_chaos/rabbitmq_service.cpp
+++ b/rabbitmq/functional_tests/basic_chaos/rabbitmq_service.cpp
@@ -47,8 +47,7 @@ public:
         }
     }
 
-    void PublishReliable(const std::string& message) const {
-        const urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient};
+    void PublishReliable(const urabbitmq::Publishing& publishing) const {
         rabbit_client_->PublishReliable(
             exchange_,
             routing_key_,
@@ -57,8 +56,7 @@ public:
         );
     }
 
-    void PublishUnreliable(const std::string& message) const {
-        const urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient};
+    void PublishUnreliable(const urabbitmq::Publishing& publishing) const {
         rabbit_client_->Publish(
             exchange_,
             routing_key_,
@@ -95,13 +93,17 @@ public:
         return urabbitmq::ConsumerComponentBase::GetStaticConfigSchema();
     }
 
-    std::vector<std::string> GetMessages() const {
+    std::vector<userver::urabbitmq::ConsumedMessage> GetMessages() const {
         auto messages = [this] {
             auto storage = messages_.Lock();
             return *storage;
         }();
 
-        std::sort(messages.begin(), messages.end());
+        std::sort(messages.begin(), messages.end(), 
+            []( const auto& lhs, const auto& rhs )
+            {
+                return lhs.message < rhs.message;
+            });
         return messages;
     }
 
@@ -116,17 +118,17 @@ private:
         Consumer(
             const components::ComponentConfig& config,
             const components::ComponentContext& context,
-            concurrent::Variable<std::vector<std::string>>& messages
+            concurrent::Variable<std::vector<userver::urabbitmq::ConsumedMessage>>& messages
         )
             : urabbitmq::
                   ConsumerBase{context.FindComponent<components::RabbitMQ>(config["rabbit_name"].As<std::string>()).GetClient(), ParseSettings(config)},
               messages_{messages} {}
 
     protected:
-        void Process(std::string message) override {
+        void Process(urabbitmq::ConsumedMessage msg) override {
             {
                 auto storage = messages_.Lock();
-                storage->push_back(std::move(message));
+                storage->push_back(std::move(msg));
             }
             TESTPOINT("message_consumed", {});
         }
@@ -136,10 +138,10 @@ private:
             return {urabbitmq::Queue{config["queue"].As<std::string>()}, config["prefetch_count"].As<std::uint16_t>()};
         }
 
-        concurrent::Variable<std::vector<std::string>>& messages_;
+        concurrent::Variable<std::vector<userver::urabbitmq::ConsumedMessage>>& messages_;
     };
 
-    concurrent::Variable<std::vector<std::string>> messages_;
+    concurrent::Variable<std::vector<userver::urabbitmq::ConsumedMessage>> messages_;
     Consumer consumer_;
 };
 
@@ -175,13 +177,33 @@ private:
         if (message.empty()) {
             throw server::handlers::ClientError{server::handlers::ExternalBody{"No 'message' query argument"}};
         }
+        urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient};
+        const auto& correlation_id = request.GetArg("correlation_id");
+        if (!correlation_id.empty()) {
+            publishing.correlation_id = correlation_id;
+        }
+
+        const auto& reply_to = request.GetArg("reply_to");
+        if (!reply_to.empty()) {
+            publishing.reply_to = reply_to;
+        }
+
+        const auto& expiration = request.GetArg("expiration");
+        if (!expiration.empty()) {
+            
+            publishing.expiration = std::chrono::milliseconds{std::stol(expiration)};
+        }
 
         const auto& reliable = request.GetArg("reliable");
         if (!reliable.empty()) {
-            producer_.PublishReliable(message);
+            producer_.PublishReliable(publishing);
         } else {
-            producer_.PublishUnreliable(message);
+            producer_.PublishUnreliable(publishing);
         }
+
+        
+        
+        
 
         return {};
     }
@@ -201,9 +223,19 @@ private:
     }
 
     std::string HandleGet() const {
-        const auto messages_list = consumer_.GetMessages();
-
-        return formats::json::ToString(formats::json::ValueBuilder{messages_list}.ExtractValue());
+        formats::json::ValueBuilder messages_builder;
+        for (const auto& item : consumer_.GetMessages()) {
+            formats::json::ValueBuilder item_builder;
+            item_builder["message"] = item.message;
+            if (item.correlation_id.has_value()) {
+                item_builder["correlation_id"] = item.correlation_id;
+            }
+            if (item.reply_to.has_value()) {
+                item_builder["reply_to"] = item.reply_to;
+            }
+            messages_builder.PushBack(std::move(item_builder));
+        }
+        return formats::json::ToString(messages_builder.ExtractValue());
     }
 
     std::string HandleDelete() const {

--- a/rabbitmq/functional_tests/basic_chaos/rabbitmq_service.cpp
+++ b/rabbitmq/functional_tests/basic_chaos/rabbitmq_service.cpp
@@ -177,7 +177,7 @@ private:
         if (message.empty()) {
             throw server::handlers::ClientError{server::handlers::ExternalBody{"No 'message' query argument"}};
         }
-        urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient};
+        urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient, {}, {}, {}};
         const auto& correlation_id = request.GetArg("correlation_id");
         if (!correlation_id.empty()) {
             publishing.correlation_id = correlation_id;

--- a/rabbitmq/functional_tests/basic_chaos/rabbitmq_service.cpp
+++ b/rabbitmq/functional_tests/basic_chaos/rabbitmq_service.cpp
@@ -93,7 +93,7 @@ public:
         return urabbitmq::ConsumerComponentBase::GetStaticConfigSchema();
     }
 
-    std::vector<userver::urabbitmq::ConsumedMessage> GetMessages() const {
+    std::vector<urabbitmq::ConsumedMessage> GetMessages() const {
         auto messages = [this] {
             auto storage = messages_.Lock();
             return *storage;
@@ -118,7 +118,7 @@ private:
         Consumer(
             const components::ComponentConfig& config,
             const components::ComponentContext& context,
-            concurrent::Variable<std::vector<userver::urabbitmq::ConsumedMessage>>& messages
+            concurrent::Variable<std::vector<urabbitmq::ConsumedMessage>>& messages
         )
             : urabbitmq::
                   ConsumerBase{context.FindComponent<components::RabbitMQ>(config["rabbit_name"].As<std::string>()).GetClient(), ParseSettings(config)},
@@ -138,10 +138,10 @@ private:
             return {urabbitmq::Queue{config["queue"].As<std::string>()}, config["prefetch_count"].As<std::uint16_t>()};
         }
 
-        concurrent::Variable<std::vector<userver::urabbitmq::ConsumedMessage>>& messages_;
+        concurrent::Variable<std::vector<urabbitmq::ConsumedMessage>>& messages_;
     };
 
-    concurrent::Variable<std::vector<userver::urabbitmq::ConsumedMessage>> messages_;
+    concurrent::Variable<std::vector<urabbitmq::ConsumedMessage>> messages_;
     Consumer consumer_;
 };
 

--- a/rabbitmq/functional_tests/basic_chaos/rabbitmq_service.cpp
+++ b/rabbitmq/functional_tests/basic_chaos/rabbitmq_service.cpp
@@ -48,21 +48,21 @@ public:
     }
 
     void PublishReliable(const std::string& message) const {
+        const urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient};
         rabbit_client_->PublishReliable(
             exchange_,
             routing_key_,
-            message,
-            urabbitmq::MessageType::kTransient,
+            publishing,
             engine::Deadline::FromDuration(kDefaultOperationTimeout)
         );
     }
 
     void PublishUnreliable(const std::string& message) const {
+        const urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient};
         rabbit_client_->Publish(
             exchange_,
             routing_key_,
-            message,
-            urabbitmq::MessageType::kTransient,
+            publishing,
             engine::Deadline::FromDuration(kDefaultOperationTimeout)
         );
     }

--- a/rabbitmq/functional_tests/basic_chaos/tests/test_rabbitmq.py
+++ b/rabbitmq/functional_tests/basic_chaos/tests/test_rabbitmq.py
@@ -2,7 +2,10 @@ import asyncio
 
 import pytest
 
-MESSAGES = ['a', 'b', 'c']
+MESSAGES = [{'message' : 'a'}, 
+            {'message' : 'b', 'reply_to' : 'reply_from_b'}, 
+            {'message' : 'c', 'correlation_id' : 'id_from_c'},
+            {'message' : 'd', 'correlation_id' : 'id_from_d', 'reply_to' : 'reply_from_d'}]
 
 
 async def _start_consumer(service_client):
@@ -16,9 +19,12 @@ async def _stop_consumer(service_client):
 
 
 async def _publish_message(service_client, message):
-    response = await service_client.post(
-        f'/v1/messages?message={message}&reliable=1',
-    )
+    request_str = f'/v1/messages?message={message["message"]}&reliable=1'
+    if "reply_to" in message:
+        request_str = request_str + f'&reply_to={message["reply_to"]}'
+    if "correlation_id" in message:
+        request_str = request_str + f'&correlation_id={message["correlation_id"]}'
+    response = await service_client.post(request_str,)
     assert response.status_code == 200
 
 

--- a/rabbitmq/functional_tests/metrics/rabbitmq_service.cpp
+++ b/rabbitmq/functional_tests/metrics/rabbitmq_service.cpp
@@ -46,11 +46,11 @@ public:
     }
 
     void Publish(const std::string& message) {
+        const urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient};
         client_->PublishReliable(
             exchange_,
             routing_key_,
-            message,
-            urabbitmq::MessageType::kTransient,
+            publishing,
             engine::Deadline::FromDuration(std::chrono::seconds{2})
         );
     }

--- a/rabbitmq/include/userver/urabbitmq/broker_interface.hpp
+++ b/rabbitmq/include/userver/urabbitmq/broker_interface.hpp
@@ -99,6 +99,23 @@ public:
     virtual void Publish(
         const Exchange& exchange,
         const std::string& routing_key,
+        const std::string& message,
+        MessageType type,
+        engine::Deadline deadline
+    ) = 0;
+
+    /// @brief overload of Publish
+    virtual void Publish(
+        const Exchange& exchange,
+        const std::string& routing_key,
+        const std::string& message,
+        engine::Deadline deadline
+    ) = 0;
+
+    /// @brief overload of Publish
+    virtual void Publish(
+        const Exchange& exchange,
+        const std::string& routing_key,
         const Publishing& publishing,
         engine::Deadline deadline
     ) = 0;
@@ -143,6 +160,23 @@ public:
     /// @param message the message to send
     /// @param type see @ref MessageType
     /// @param deadline execution deadline
+    virtual void PublishReliable(
+        const Exchange& exchange,
+        const std::string& routing_key,
+        const std::string& message,
+        MessageType type,
+        engine::Deadline deadline
+    ) = 0;
+
+    /// @brief overload of PublishReliable
+    virtual void PublishReliable(
+        const Exchange& exchange,
+        const std::string& routing_key,
+        const std::string& message,
+        engine::Deadline deadline
+    ) = 0;
+
+    /// @brief overload of PublishReliable
     virtual void PublishReliable(
         const Exchange& exchange,
         const std::string& routing_key,

--- a/rabbitmq/include/userver/urabbitmq/broker_interface.hpp
+++ b/rabbitmq/include/userver/urabbitmq/broker_interface.hpp
@@ -99,16 +99,7 @@ public:
     virtual void Publish(
         const Exchange& exchange,
         const std::string& routing_key,
-        const std::string& message,
-        MessageType type,
-        engine::Deadline deadline
-    ) = 0;
-
-    /// @brief overload of Publish
-    virtual void Publish(
-        const Exchange& exchange,
-        const std::string& routing_key,
-        const std::string& message,
+        const Publishing& publishing,
         engine::Deadline deadline
     ) = 0;
 
@@ -155,16 +146,7 @@ public:
     virtual void PublishReliable(
         const Exchange& exchange,
         const std::string& routing_key,
-        const std::string& message,
-        MessageType type,
-        engine::Deadline deadline
-    ) = 0;
-
-    /// @brief overload of PublishReliable
-    virtual void PublishReliable(
-        const Exchange& exchange,
-        const std::string& routing_key,
-        const std::string& message,
+        const Publishing& publishing,
         engine::Deadline deadline
     ) = 0;
 

--- a/rabbitmq/include/userver/urabbitmq/channel.hpp
+++ b/rabbitmq/include/userver/urabbitmq/channel.hpp
@@ -35,19 +35,9 @@ public:
     void Publish(
         const Exchange& exchange,
         const std::string& routing_key,
-        const std::string& message,
-        MessageType type,
+        const Publishing& publishing,
         engine::Deadline deadline
     ) override;
-
-    void Publish(
-        const Exchange& exchange,
-        const std::string& routing_key,
-        const std::string& message,
-        engine::Deadline deadline
-    ) override {
-        Publish(exchange, routing_key, message, MessageType::kTransient, deadline);
-    };
 
     std::string Get(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) override;
 
@@ -76,19 +66,9 @@ public:
     void PublishReliable(
         const Exchange& exchange,
         const std::string& routing_key,
-        const std::string& message,
-        MessageType type,
+        const Publishing& publishing,
         engine::Deadline deadline
     ) override;
-
-    void PublishReliable(
-        const Exchange& exchange,
-        const std::string& routing_key,
-        const std::string& message,
-        engine::Deadline deadline
-    ) override {
-        PublishReliable(exchange, routing_key, message, MessageType::kTransient, deadline);
-    }
 
 private:
     utils::FastPimpl<ConnectionPtr, 32, 8> impl_;

--- a/rabbitmq/include/userver/urabbitmq/channel.hpp
+++ b/rabbitmq/include/userver/urabbitmq/channel.hpp
@@ -35,6 +35,25 @@ public:
     void Publish(
         const Exchange& exchange,
         const std::string& routing_key,
+        const std::string& message,
+        MessageType type,
+        engine::Deadline deadline
+    ) override {
+        Publish(exchange, routing_key, Publishing{message, type, {}, {}, {}}, deadline);
+    }
+
+    void Publish(
+        const Exchange& exchange,
+        const std::string& routing_key,
+        const std::string& message,
+        engine::Deadline deadline
+    ) override {
+        Publish(exchange, routing_key, message, MessageType::kTransient, deadline);
+    };
+
+    void Publish(
+        const Exchange& exchange,
+        const std::string& routing_key,
         const Publishing& publishing,
         engine::Deadline deadline
     ) override;
@@ -64,6 +83,25 @@ public:
     ReliableChannel(ReliableChannel&& other) noexcept;
 
     void PublishReliable(
+        const Exchange& exchange,
+        const std::string& routing_key,
+        const std::string& message,
+        MessageType type,
+        engine::Deadline deadline
+    ) override {
+        PublishReliable(exchange, routing_key, Publishing{message, type, {}, {}, {}}, deadline);
+    }
+
+    void PublishReliable(
+        const Exchange& exchange,
+        const std::string& routing_key,
+        const std::string& message,
+        engine::Deadline deadline
+    ) override {
+        PublishReliable(exchange, routing_key, message, MessageType::kTransient, deadline);
+    }
+
+    virtual void PublishReliable(
         const Exchange& exchange,
         const std::string& routing_key,
         const Publishing& publishing,

--- a/rabbitmq/include/userver/urabbitmq/client.hpp
+++ b/rabbitmq/include/userver/urabbitmq/client.hpp
@@ -75,6 +75,25 @@ public:
     void Publish(
         const Exchange& exchange,
         const std::string& routing_key,
+        const std::string& message,
+        MessageType type,
+        engine::Deadline deadline
+    ) override {
+        Publish(exchange, routing_key, Publishing{message, type, {}, {}, {}}, deadline);
+    };
+
+    void Publish(
+        const Exchange& exchange,
+        const std::string& routing_key,
+        const std::string& message,
+        engine::Deadline deadline
+    ) override {
+        Publish(exchange, routing_key, message, MessageType::kTransient, deadline);
+    };
+
+    void Publish(
+        const Exchange& exchange,
+        const std::string& routing_key,
         const Publishing& publishing,
         engine::Deadline deadline
     ) override;
@@ -85,6 +104,25 @@ public:
     ///
     /// @param deadline deadline for connection acquisition from the pool
     Channel GetChannel(engine::Deadline deadline);
+
+    void PublishReliable(
+        const Exchange& exchange,
+        const std::string& routing_key,
+        const std::string& message,
+        MessageType type,
+        engine::Deadline deadline
+    ) override {
+        PublishReliable(exchange, routing_key, Publishing{message, type, {}, {}, {}}, deadline);
+    }
+
+    void PublishReliable(
+        const Exchange& exchange,
+        const std::string& routing_key,
+        const std::string& message,
+        engine::Deadline deadline
+    ) override {
+        PublishReliable(exchange, routing_key, message, MessageType::kTransient, deadline);
+    }
 
     void PublishReliable(
         const Exchange& exchange,

--- a/rabbitmq/include/userver/urabbitmq/client.hpp
+++ b/rabbitmq/include/userver/urabbitmq/client.hpp
@@ -75,19 +75,9 @@ public:
     void Publish(
         const Exchange& exchange,
         const std::string& routing_key,
-        const std::string& message,
-        MessageType type,
+        const Publishing& publishing,
         engine::Deadline deadline
     ) override;
-
-    void Publish(
-        const Exchange& exchange,
-        const std::string& routing_key,
-        const std::string& message,
-        engine::Deadline deadline
-    ) override {
-        Publish(exchange, routing_key, message, MessageType::kTransient, deadline);
-    };
 
     std::string Get(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) override;
 
@@ -99,19 +89,9 @@ public:
     void PublishReliable(
         const Exchange& exchange,
         const std::string& routing_key,
-        const std::string& message,
-        MessageType type,
+        const Publishing& publishing,
         engine::Deadline deadline
     ) override;
-
-    void PublishReliable(
-        const Exchange& exchange,
-        const std::string& routing_key,
-        const std::string& message,
-        engine::Deadline deadline
-    ) override {
-        PublishReliable(exchange, routing_key, message, MessageType::kTransient, deadline);
-    }
 
     /// @brief Get a reliable publisher interface for the broker
     /// (publisher-confirms)

--- a/rabbitmq/include/userver/urabbitmq/typedefs.hpp
+++ b/rabbitmq/include/userver/urabbitmq/typedefs.hpp
@@ -83,9 +83,9 @@ struct ConsumedMessage {
 struct Publishing {
     std::string message;
     MessageType type;
-    std::optional<std::string> reply_to;
-    std::optional<std::string> correlation_id;
-    std::optional<std::chrono::milliseconds> expiration;
+    std::optional<std::string> reply_to{};
+    std::optional<std::string> correlation_id{};
+    std::optional<std::chrono::milliseconds> expiration{};
 };
 
 }  // namespace urabbitmq

--- a/rabbitmq/include/userver/urabbitmq/typedefs.hpp
+++ b/rabbitmq/include/userver/urabbitmq/typedefs.hpp
@@ -71,6 +71,18 @@ struct ConsumedMessage {
     };
     std::string message;
     Metadata metadata;
+    std::optional<std::string> reply_to;
+    std::optional<std::string> correlation_id;
+};
+
+/// @brief Structure holding an AMQP message body along with some of its
+/// metadata fields. This struct is used to pass messages from the end user,
+/// hiding the actual AMQP message object implementation.
+struct Publishing {
+    std::string message;
+    MessageType type;
+    std::optional<std::string> reply_to;
+    std::optional<std::string> correlation_id;
 };
 
 }  // namespace urabbitmq

--- a/rabbitmq/include/userver/urabbitmq/typedefs.hpp
+++ b/rabbitmq/include/userver/urabbitmq/typedefs.hpp
@@ -3,6 +3,8 @@
 /// @file userver/urabbitmq/typedefs.hpp
 /// @brief Convenient typedefs for RabbitMQ entities.
 
+#include <chrono>
+
 #include <userver/utils/strong_typedef.hpp>
 
 USERVER_NAMESPACE_BEGIN
@@ -83,6 +85,7 @@ struct Publishing {
     MessageType type;
     std::optional<std::string> reply_to;
     std::optional<std::string> correlation_id;
+    std::optional<std::chrono::milliseconds> expiration;
 };
 
 }  // namespace urabbitmq

--- a/rabbitmq/src/tests/publish_consume_rmqtest.cpp
+++ b/rabbitmq/src/tests/publish_consume_rmqtest.cpp
@@ -101,9 +101,9 @@ UTEST(Consumer, ConsumeWorks) {
     client.SetupRmqEntities();
     const urabbitmq::ConsumerSettings settings{client.GetQueue(), 10};
 
-    const std::string message = "Hi from userver!";
+    const urabbitmq::Publishing publishing {"Hi from userver!", urabbitmq::MessageType::kTransient};
     client->PublishReliable(
-        client.GetExchange(), client.GetRoutingKey(), message, urabbitmq::MessageType::kTransient, client.GetDeadline()
+        client.GetExchange(), client.GetRoutingKey(), publishing, client.GetDeadline()
     );
 
     Consumer consumer{client.Get(), settings};
@@ -113,7 +113,7 @@ UTEST(Consumer, ConsumeWorks) {
     auto consumed = consumer.Wait();
 
     ASSERT_EQ(consumed.size(), 1);
-    EXPECT_EQ(consumed[0], message);
+    EXPECT_EQ(consumed[0], publishing.message);
 }
 
 UTEST(Consumer, BasicGetWorks) {
@@ -121,16 +121,16 @@ UTEST(Consumer, BasicGetWorks) {
     client.SetupRmqEntities();
     const urabbitmq::ConsumerSettings settings{client.GetQueue(), 10};
 
-    const std::string message = "Hi from userver!";
+    const urabbitmq::Publishing publishing {"Hi from userver!", urabbitmq::MessageType::kTransient};
     client->PublishReliable(
-        client.GetExchange(), client.GetRoutingKey(), message, urabbitmq::MessageType::kTransient, client.GetDeadline()
+        client.GetExchange(), client.GetRoutingKey(), publishing, client.GetDeadline()
     );
 
     const std::string consumed_message =
         client->Get(client.GetQueue(), urabbitmq::Queue::Flags::kNoAck, client.GetDeadline());
 
     EXPECT_EQ(!consumed_message.empty(), true);
-    EXPECT_EQ(consumed_message, message);
+    EXPECT_EQ(consumed_message, publishing.message);
 }
 
 UTEST(Consumer, ExhaustesQueue) {
@@ -141,11 +141,11 @@ UTEST(Consumer, ExhaustesQueue) {
     const size_t messages_count = 1000;
     for (size_t i = 0; i < messages_count; ++i) {
         auto channel = client->GetReliableChannel(client.GetDeadline());
+        const urabbitmq::Publishing publishing {std::to_string(i), urabbitmq::MessageType::kTransient};
         channel.PublishReliable(
             client.GetExchange(),
             client.GetRoutingKey(),
-            std::to_string(i),
-            urabbitmq::MessageType::kTransient,
+            publishing,
             client.GetDeadline()
         );
     }
@@ -165,11 +165,11 @@ UTEST(Consumer, ThrowsReturnsToQueue) {
     const size_t messages_count = 200;
     for (size_t i = 0; i < messages_count; ++i) {
         auto channel = client->GetReliableChannel(client.GetDeadline());
+        const urabbitmq::Publishing publishing {std::to_string(i), urabbitmq::MessageType::kTransient};
         channel.PublishReliable(
             client.GetExchange(),
             client.GetRoutingKey(),
-            std::to_string(i),
-            urabbitmq::MessageType::kTransient,
+            publishing,
             client.GetDeadline()
         );
     }
@@ -197,11 +197,11 @@ UTEST(Consumer, MultipleConcurrentWork) {
     const size_t messages_count = 1000;
     for (size_t i = 0; i < messages_count; ++i) {
         auto channel = client->GetReliableChannel(client.GetDeadline());
+        const urabbitmq::Publishing publishing {std::to_string(i), urabbitmq::MessageType::kTransient};
         channel.PublishReliable(
             client.GetExchange(),
             client.GetRoutingKey(),
-            std::to_string(i),
-            urabbitmq::MessageType::kTransient,
+            publishing,
             client.GetDeadline()
         );
     }
@@ -229,11 +229,11 @@ UTEST(Consumer, ForDifferentQueuesWork) {
 
     const size_t messages_count = 200;
     for (size_t i = 0; i < messages_count; ++i) {
+        const urabbitmq::Publishing publishing {std::to_string(i), urabbitmq::MessageType::kTransient};
         client->PublishReliable(
             client.GetExchange(),
             client.GetRoutingKey(),
-            std::to_string(i),
-            urabbitmq::MessageType::kTransient,
+            publishing,
             client.GetDeadline()
         );
     }

--- a/rabbitmq/src/urabbitmq/channel.cpp
+++ b/rabbitmq/src/urabbitmq/channel.cpp
@@ -16,11 +16,10 @@ Channel::Channel(Channel&& other) noexcept = default;
 void Channel::Publish(
     const Exchange& exchange,
     const std::string& routing_key,
-    const std::string& message,
-    MessageType type,
+    const Publishing& publishing,
     engine::Deadline deadline
 ) {
-    ConnectionHelper::Publish(*impl_, exchange, routing_key, message, type, deadline);
+    ConnectionHelper::Publish(*impl_, exchange, routing_key, publishing, deadline);
 }
 
 std::string Channel::Get(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) {
@@ -38,11 +37,10 @@ ReliableChannel::ReliableChannel(ReliableChannel&& other) noexcept = default;
 void ReliableChannel::PublishReliable(
     const Exchange& exchange,
     const std::string& routing_key,
-    const std::string& message,
-    MessageType type,
+    const Publishing& publishing,
     engine::Deadline deadline
 ) {
-    ConnectionHelper::PublishReliable(*impl_, exchange, routing_key, message, type, deadline).Wait(deadline);
+    ConnectionHelper::PublishReliable(*impl_, exchange, routing_key, publishing, deadline).Wait(deadline);
 }
 
 }  // namespace urabbitmq

--- a/rabbitmq/src/urabbitmq/client.cpp
+++ b/rabbitmq/src/urabbitmq/client.cpp
@@ -68,22 +68,20 @@ std::string Client::Get(const Queue& queue, utils::Flags<Queue::Flags> flags, en
 void Client::Publish(
     const Exchange& exchange,
     const std::string& routing_key,
-    const std::string& message,
-    MessageType type,
+    const Publishing& publishing,
     engine::Deadline deadline
 ) {
-    ConnectionHelper::Publish(impl_->GetConnection(deadline), exchange, routing_key, message, type, deadline);
+    ConnectionHelper::Publish(impl_->GetConnection(deadline), exchange, routing_key, publishing, deadline);
 }
 
 void Client::PublishReliable(
     const Exchange& exchange,
     const std::string& routing_key,
-    const std::string& message,
-    MessageType type,
+    const Publishing& publishing,
     engine::Deadline deadline
 ) {
     auto awaiter = ConnectionHelper::PublishReliable(
-        impl_->GetConnection(deadline), exchange, routing_key, message, type, deadline
+        impl_->GetConnection(deadline), exchange, routing_key, publishing, deadline
     );
     awaiter.Wait(deadline);
 }

--- a/rabbitmq/src/urabbitmq/connection_helper.cpp
+++ b/rabbitmq/src/urabbitmq/connection_helper.cpp
@@ -64,24 +64,22 @@ void ConnectionHelper::Publish(
     const ConnectionPtr& connection,
     const Exchange& exchange,
     const std::string& routing_key,
-    const std::string& message,
-    MessageType type,
+    const Publishing& publishing,
     engine::Deadline deadline
 ) {
     tracing::Span span{"publish"};
-    connection->GetChannel().Publish(exchange, routing_key, message, type, deadline);
+    connection->GetChannel().Publish(exchange, routing_key, publishing, deadline);
 }
 
 impl::ResponseAwaiter ConnectionHelper::PublishReliable(
     const ConnectionPtr& connection,
     const Exchange& exchange,
     const std::string& routing_key,
-    const std::string& message,
-    MessageType type,
+    const Publishing& publishing,
     engine::Deadline deadline
 ) {
     return WithSpan("reliable_publish", [&] {
-        return connection->GetReliableChannel().Publish(exchange, routing_key, message, type, deadline);
+        return connection->GetReliableChannel().Publish(exchange, routing_key, publishing, deadline);
     });
 }
 

--- a/rabbitmq/src/urabbitmq/connection_helper.hpp
+++ b/rabbitmq/src/urabbitmq/connection_helper.hpp
@@ -61,8 +61,7 @@ public:
         const ConnectionPtr& connection,
         const Exchange& exchange,
         const std::string& routing_key,
-        const std::string& message,
-        MessageType type,
+        const Publishing& publishing,
         engine::Deadline deadline
     );
 
@@ -70,8 +69,7 @@ public:
         const ConnectionPtr& connection,
         const Exchange& exchange,
         const std::string& routing_key,
-        const std::string& message,
-        MessageType type,
+        const Publishing& publishing,
         engine::Deadline deadline
     );
 

--- a/rabbitmq/src/urabbitmq/consumer_base_impl.cpp
+++ b/rabbitmq/src/urabbitmq/consumer_base_impl.cpp
@@ -97,6 +97,13 @@ void ConsumerBaseImpl::OnMessage(const AMQP::Message& message, uint64_t delivery
     consumed.message = std::string(message.body(), message.bodySize());
     consumed.metadata.exchange = message.exchange();
     consumed.metadata.routingKey = message.routingkey();
+    if (message.hasReplyTo()) {
+        consumed.reply_to = message.replyTo();
+    }
+    if (message.hasCorrelationID()) {
+        consumed.correlation_id = message.correlationID();
+    }
+    
 
     bts_.Detach(engine::AsyncNoSpan(
         dispatcher_,

--- a/rabbitmq/src/urabbitmq/impl/amqp_channel.cpp
+++ b/rabbitmq/src/urabbitmq/impl/amqp_channel.cpp
@@ -254,6 +254,9 @@ ResponseAwaiter AmqpReliableChannel::Publish(
     if (publishing.correlation_id.has_value()) {
         envelope.setCorrelationID(publishing.correlation_id.value().c_str());
     }
+    if (publishing.expiration.has_value()) {
+        envelope.setExpiration(std::to_string(publishing.expiration.value().count()));
+    }
     envelope.setHeaders(CreateHeaders());
 
     auto awaiter = conn_.GetAwaiter(deadline);

--- a/rabbitmq/src/urabbitmq/impl/amqp_channel.cpp
+++ b/rabbitmq/src/urabbitmq/impl/amqp_channel.cpp
@@ -175,7 +175,7 @@ void AmqpChannel::Publish(
         envelope.setReplyTo(publishing.reply_to.value().c_str());
     }
     if (publishing.correlation_id.has_value()) {
-        envelope.setReplyTo(publishing.correlation_id.value().c_str());
+        envelope.setCorrelationID(publishing.correlation_id.value().c_str());
     }
 
     {

--- a/rabbitmq/src/urabbitmq/impl/amqp_channel.cpp
+++ b/rabbitmq/src/urabbitmq/impl/amqp_channel.cpp
@@ -165,13 +165,18 @@ ResponseAwaiter AmqpChannel::Get(
 void AmqpChannel::Publish(
     const Exchange& exchange,
     const std::string& routing_key,
-    const std::string& message,
-    MessageType type,
+    const Publishing& publishing,
     engine::Deadline deadline
 ) {
-    AMQP::Envelope envelope{message.data(), message.size()};
-    envelope.setPersistent(type == MessageType::kPersistent);
+    AMQP::Envelope envelope{publishing.message.data(), publishing.message.size()};
+    envelope.setPersistent(publishing.type == MessageType::kPersistent);
     envelope.setHeaders(CreateHeaders());
+    if (publishing.reply_to.has_value()) {
+        envelope.setReplyTo(publishing.reply_to.value().c_str());
+    }
+    if (publishing.correlation_id.has_value()) {
+        envelope.setReplyTo(publishing.correlation_id.value().c_str());
+    }
 
     {
         auto channel = conn_.GetChannel(deadline);
@@ -238,12 +243,17 @@ AmqpReliableChannel::~AmqpReliableChannel() = default;
 ResponseAwaiter AmqpReliableChannel::Publish(
     const Exchange& exchange,
     const std::string& routing_key,
-    const std::string& message,
-    MessageType type,
+    const Publishing& publishing,
     engine::Deadline deadline
 ) {
-    AMQP::Envelope envelope{message.data(), message.size()};
-    envelope.setPersistent(type == MessageType::kPersistent);
+    AMQP::Envelope envelope{publishing.message.data(), publishing.message.size()};
+    envelope.setPersistent(publishing.type == MessageType::kPersistent);
+    if (publishing.reply_to.has_value()) {
+        envelope.setReplyTo(publishing.reply_to.value().c_str());
+    }
+    if (publishing.correlation_id.has_value()) {
+        envelope.setCorrelationID(publishing.correlation_id.value().c_str());
+    }
     envelope.setHeaders(CreateHeaders());
 
     auto awaiter = conn_.GetAwaiter(deadline);

--- a/rabbitmq/src/urabbitmq/impl/amqp_channel.hpp
+++ b/rabbitmq/src/urabbitmq/impl/amqp_channel.hpp
@@ -55,8 +55,7 @@ public:
     void Publish(
         const Exchange& exchange,
         const std::string& routing_key,
-        const std::string& message,
-        MessageType type,
+        const Publishing& publishing,
         engine::Deadline deadline
     );
 
@@ -95,8 +94,7 @@ public:
     ResponseAwaiter Publish(
         const Exchange& exchange,
         const std::string& routing_key,
-        const std::string& message,
-        MessageType type,
+        const Publishing& publishing,
         engine::Deadline deadline
     );
 

--- a/samples/rabbitmq_service/main.cpp
+++ b/samples/rabbitmq_service/main.cpp
@@ -46,7 +46,7 @@ public:
     }
 
     void Publish(const std::string& message) {
-        const urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient};
+        const urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient, {}, {}, {}};
         client_->PublishReliable(
             exchange_,
             routing_key_,

--- a/samples/rabbitmq_service/main.cpp
+++ b/samples/rabbitmq_service/main.cpp
@@ -46,11 +46,11 @@ public:
     }
 
     void Publish(const std::string& message) {
+        const urabbitmq::Publishing publishing{message, urabbitmq::MessageType::kTransient};
         client_->PublishReliable(
             exchange_,
             routing_key_,
-            message,
-            urabbitmq::MessageType::kTransient,
+            publishing,
             engine::Deadline::FromDuration(std::chrono::seconds{2})
         );
     }


### PR DESCRIPTION
ReplyTo, CorrelationId are helpful fields to easily implement RPC in rabbitmq terms. (expration field was added just in case).
API was changed in a little bit go style (**with breaking changes**.) I have removed extra (in my opinion) methods and encapsulated additional fields like ReplyTo, CorrelationId, Expiration, Message etc into separate Publishing structue. In future any additional metadata can be easily added into it (without any major compatibility issues I hope).
I have added minor coverage into functional tests also. But any additional testing of real rabbitmq projects will be appreciated. ReplyTo, CorrelationId cases were covered. Testing expiration field inside functional tests will be more challenging I guess.

UPD: Api was redesigned in order to exclude potential breaks and keep compatibility