### PR TITLE
Add bool type support to LogExtra::Value

### DIFF
--- a/core/src/logging/log_json_test.cpp
+++ b/core/src/logging/log_json_test.cpp
@@ -40,6 +40,28 @@ TEST_F(LoggingJsonTest, NoThreadIdInProduction) {
     EXPECT_FALSE(json.HasMember("thread_id")) << ToString(json);
 }
 
+TEST_F(LoggingJsonTest, LogExtraBool) {
+    // Force thread_id and task_id to appear.
+    SetDefaultLoggerLevel(logging::Level::kDebug);
+
+    LOG_CRITICAL() << "test" << logging::LogExtra{{"bool_true", true}, {"bool_false", false}};
+
+    auto str = GetStreamString();
+    auto json = formats::json::FromString(str);
+
+    EXPECT_EQ(str.back(), '\n');
+
+    EXPECT_EQ(json["level"].As<std::string>(), "CRITICAL");
+    EXPECT_NO_THROW(json["module"].As<std::string>());
+    EXPECT_NO_THROW(json["timestamp"].As<std::string>());
+    EXPECT_EQ(json["task_id"].As<std::string>(), "0");
+    EXPECT_EQ(json["text"].As<std::string>(), "test");
+    EXPECT_NO_THROW(json["thread_id"].As<std::string>());
+
+    EXPECT_TRUE(json["bool_true"].As<bool>());
+    EXPECT_FALSE(json["bool_false"].As<bool>());
+}
+
 TEST_F(LoggingJsonTest, LogExtraJsonString) {
     // Force thread_id and task_id to appear.
     SetDefaultLoggerLevel(logging::Level::kDebug);

--- a/core/src/logging/log_message_test.cpp
+++ b/core/src/logging/log_message_test.cpp
@@ -335,6 +335,18 @@ TEST_F(LoggingTest, PartialPrefixModulePath) {
     CheckModulePath(GetStreamString(), kPath);
 }
 
+TEST_F(LoggingTest, LogExtraBool) {
+    LOG_CRITICAL() << "test" << logging::LogExtra{{"bool_true", true}};
+    logging::LogFlush();
+    EXPECT_THAT(GetStreamString(), testing::HasSubstr("bool_true=1"));
+
+    ClearLog();
+
+    LOG_CRITICAL() << "test" << logging::LogExtra{{"bool_false", false}};
+    logging::LogFlush();
+    EXPECT_THAT(GetStreamString(), testing::HasSubstr("bool_false=0"));
+}
+
 TEST_F(LoggingTest, LogExtraTAXICOMMON1362) {
     const char* str = reinterpret_cast<const char*>(tskv_test::data_bin);
     const std::string input(str, str + sizeof(tskv_test::data_bin));

--- a/universal/include/userver/logging/log_extra.hpp
+++ b/universal/include/userver/logging/log_extra.hpp
@@ -40,6 +40,7 @@ public:
     using Value = std::variant<
         std::string,
         int,
+        bool,
         long,
         long long,
         unsigned int,


### PR DESCRIPTION
- Add bool to std::variant in LogExtra::Value to match OpenTelemetry AnyValue protocol
- Add tests for using bool type in LogExtra::Value
- Correct serializing into ['0', '1'] values in TSKV and ['true', 'false'] in JSON

Fixes #847

------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

