### PR TITLE
Add ARG_PIP_ARGS to the pip call

### DIFF
--- a/cmake/UserverVenv.cmake
+++ b/cmake/UserverVenv.cmake
@@ -148,7 +148,7 @@ function(userver_venv_setup)
         list(TRANSFORM ARG_REQUIREMENTS PREPEND "--requirement=" OUTPUT_VARIABLE pip_requirements)
 
         # psycopg2 implicitly requires 'wheel' to be already installed
-        execute_process(COMMAND "${venv_bin_dir}/python3" -m pip install -U wheel RESULT_VARIABLE status)
+        execute_process(COMMAND "${venv_bin_dir}/python3" -m pip install -U wheel ${ARG_PIP_ARGS} RESULT_VARIABLE status)
         if(status)
             message(FATAL_ERROR "Failed to install venv requirements")
         endif()


### PR DESCRIPTION
Fix issue with pip call ignored args specified in USERVER_PIP_OPTIONS.

