### PR TITLE
Обновить api-common-protos до ветки main

### DIFF
--- a/cmake/SetupGoogleProtoApis.cmake
+++ b/cmake/SetupGoogleProtoApis.cmake
@@ -19,12 +19,10 @@ if(NOT EXISTS ${api-common-protos_SOURCE_DIR})
     cpmaddpackage(
         NAME
         api-common-protos
-        VERSION
-        1.50.0
         GITHUB_REPOSITORY
         googleapis/api-common-protos
         GIT_TAG
-        1.50.0
+        main
         DOWNLOAD_ONLY
         YES
     )

--- a/scripts/docker/base-ubuntu-22.04.dockerfile
+++ b/scripts/docker/base-ubuntu-22.04.dockerfile
@@ -24,7 +24,7 @@ RUN ( \
   && ./pip-install.sh \
   && mkdir /app \
   && cd /app \
-  && git clone --depth 1 -b 1.50.0 https://github.com/googleapis/api-common-protos.git \
+  && git clone --depth 1 https://github.com/googleapis/api-common-protos.git \
   && rm -rf /app/api-common-protos/.git \
   && rm -rf /userver_tmp \
   && cd /app \


### PR DESCRIPTION
В проекте использовалась устаревшая версия googleapis/api-common-protos (1.50.0), из-за чего недоступны новые типы ошибок и структуры (google.rpc.ErrorInfo и другие).
Теперь вместо фиксированной версии подключается актуальная ветка main, что позволяет использовать последние изменения и поддерживать современные gRPC-фичи.