### PR TITLE
Fix problem with /endpoint?args parameters without =

### DIFF
--- a/universal/src/http/parser/http_request_parse_args.cpp
+++ b/universal/src/http/parser/http_request_parse_args.cpp
@@ -72,7 +72,15 @@ void ParseAndConsumeArgs(std::string_view args, ArgsConsumer handler) {
                         USERVER_NAMESPACE::http::parser::UrlDecode(value)
                     );
                 }
+            } else {
+                key_end = ptr;
+                const std::string_view key(key_begin, key_end - key_begin);
+                handler(
+                    USERVER_NAMESPACE::http::parser::UrlDecode(key),
+                    USERVER_NAMESPACE::http::parser::UrlDecode("")
+                );
             }
+
             parse_key = true;
             key_begin = ptr + 1;
             continue;

--- a/universal/src/http/parser/http_request_parse_args_test.cpp
+++ b/universal/src/http/parser/http_request_parse_args_test.cpp
@@ -1,0 +1,28 @@
+#include <string>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+#include <userver/http/parser/http_request_parse_args.hpp>
+#include <utils/impl/internal_tag.hpp>
+
+#include <userver/utils/encoding/hex.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+using namespace http::parser;
+
+
+TEST(ParseArgs, Basic) {
+    constexpr std::string_view params = "a=123&b=456&c1=someText&x";
+    std::unordered_map<std::string, std::vector<std::string>, utils::StrCaseHash> result;
+    ParseArgs(params, result);
+
+    EXPECT_EQ(result.at("a").size(), 1);
+    EXPECT_EQ(result.at("a")[0], "123");
+    EXPECT_EQ(result.at("b")[0], "456");
+    EXPECT_EQ(result.at("c1")[0], "someText");
+    EXPECT_EQ(result.at("x")[0], "");
+}
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
Fixing problem with parsing http request arguments without "=". This is valid case that the most clients used in their request. In my case it was a boto3 s3 client([createMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html) with argument ?uploads).



------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

