### PR TITLE
fix s3 mock: compatibility of response body for aws sdk clients

### DIFF
--- a/testsuite/pytest_plugins/pytest_userver/s3api.py
+++ b/testsuite/pytest_plugins/pytest_userver/s3api.py
@@ -168,7 +168,8 @@ class S3HandleMock:
                 user_defined_meta[meta_key] = meta_value
 
         meta = bucket_storage.put_object(key, data, user_defined_meta)
-        return self._mockserver.make_response('OK', 200, headers=meta)
+        # Some clients like aws sdk cpp can parse not empty body
+        return self._mockserver.make_response('', 200, headers=meta)
 
     def copy_object(self, request):
         key = self._extract_key(request)
@@ -184,7 +185,8 @@ class S3HandleMock:
         src_data = src_obj.data
         src_meta = src_obj.meta
         meta = dst_bucket_storage.put_object(key, src_data, src_meta)
-        return self._mockserver.make_response('OK', 200, headers=meta)
+        # Some clients like aws sdk cpp can parse not empty body
+        return self._mockserver.make_response('', 200, headers=meta)
 
     def get_objects(self, request):
         prefix = request.query['prefix']
@@ -218,7 +220,8 @@ class S3HandleMock:
 
         bucket_storage.delete_object(key)
         # S3 always return 204, even if file doesn't exist
-        return self._mockserver.make_response('OK', 204)
+        # Some clients like aws sdk cpp can parse not empty body
+        return self._mockserver.make_response('', 204)
 
     def get_object_head(self, request):
         key = self._extract_key(request)
@@ -228,8 +231,9 @@ class S3HandleMock:
         s3_object = bucket_storage.get_object(key)
         if not s3_object:
             return self._mockserver.make_response('Object not found', 404)
+        # Some clients like aws sdk cpp can parse not empty body
         return self._mockserver.make_response(
-            'OK',
+            '',
             200,
             headers=s3_object.meta,
         )


### PR DESCRIPTION
AWS S3 storage does not specify strictly content of body for several endpoints like [PutObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_ResponseSyntax)
or [DeleteObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html#API_DeleteObject_ResponseSyntax). But I have encountered behaviour when some s3 clients like `aws sdk cpp` try to parse not empty body and give `xml parsing text error`. In this pr I have removed `OK` text from body for 200 responses.

List of affected methods:

1. PutObject
2. DeleteObject
3. CopyObject
4. HeadObject

