### PR TITLE
fix(logging): fix compiling with fmt 12.0.0

### DIFF
--- a/universal/src/logging/timestamp.cpp
+++ b/universal/src/logging/timestamp.cpp
@@ -12,25 +12,46 @@ unsigned long FractionalMicroseconds(TimePoint time) noexcept {
     return std::chrono::time_point_cast<std::chrono::microseconds>(time).time_since_epoch().count() % 1'000'000;
 }
 
-compiler::ThreadLocal local_cached_time = [] { return CachedTime{}; };
+namespace {
 
-template <std::tm (*TimeConverter)(std::time_t)>
-TimeString GetCurrentTimeString(TimePoint now) noexcept {
-    auto cached_time = local_cached_time.Use();
+using SecondsTimePoint = std::chrono::time_point<TimePoint::clock, std::chrono::seconds>;
 
+struct CachedTime final {
+    SecondsTimePoint time{};
+    TimeString string{};
+};
+
+template <std::tm* (*TimeConverter)(const std::time_t*, std::tm*)>
+TimeString GetCurrentTimeString(TimePoint now, compiler::ThreadLocalScope<CachedTime>& cached_time) noexcept {
     const auto rounded_now = std::chrono::time_point_cast<std::chrono::seconds>(now);
     if (rounded_now != cached_time->time) {
-        fmt::format_to(
-            cached_time->string.data, FMT_COMPILE("{:%FT%T}"), TimeConverter(std::chrono::system_clock::to_time_t(now))
-        );
-        cached_time->time = rounded_now;
+        std::tm tm{};
+        std::time_t now_t = std::chrono::system_clock::to_time_t(now);
+        if (TimeConverter(&now_t, &tm) != nullptr) {
+            fmt::format_to(cached_time->string.data, FMT_COMPILE("{:%FT%T}"), tm);
+            cached_time->time = rounded_now;
+        } else {
+            // TODO (botanegg) TimeConverter can return nullptr in some cases
+            // we should handle errors here, but function is noexcept
+            // previously we have std::terminate here due to fmt::gmtime and fmt::localtime can throws exceptions
+        }
     }
     return cached_time->string;
 }
 
-TimeString GetCurrentGMTimeString(TimePoint now) noexcept { return GetCurrentTimeString<fmt::gmtime>(now); }
+compiler::ThreadLocal thread_local_cached_gmt_time  = [] { return CachedTime{}; };
+compiler::ThreadLocal thread_local_cached_local_time  = [] { return CachedTime{}; };
+}  // namespace
 
-TimeString GetCurrentLocalTimeString(TimePoint now) noexcept { return GetCurrentTimeString<fmt::localtime>(now); }
+TimeString GetCurrentGMTimeString(TimePoint now) noexcept {
+    auto cached_time = thread_local_cached_gmt_time.Use();
+    return GetCurrentTimeString<gmtime_r>(now, cached_time);
+}
+
+TimeString GetCurrentLocalTimeString(TimePoint now) noexcept {
+    auto cached_time = thread_local_cached_local_time.Use();
+    return GetCurrentTimeString<localtime_r>(now, cached_time);
+}
 
 }  // namespace logging
 

--- a/universal/src/logging/timestamp.hpp
+++ b/universal/src/logging/timestamp.hpp
@@ -13,18 +13,12 @@ using TimePoint = std::chrono::system_clock::time_point;
 
 unsigned long FractionalMicroseconds(TimePoint time) noexcept;
 
-using SecondsTimePoint = std::chrono::time_point<TimePoint::clock, std::chrono::seconds>;
 constexpr std::string_view kTimeTemplate = "0000-00-00T00:00:00";
 
 struct TimeString final {
     char data[kTimeTemplate.size()]{};
 
     std::string_view ToStringView() const noexcept { return {data, std::size(data)}; }
-};
-
-struct CachedTime final {
-    SecondsTimePoint time{};
-    TimeString string{};
 };
 
 TimeString GetCurrentGMTimeString(TimePoint now) noexcept;


### PR DESCRIPTION
Use localtime_r instead of deprecated fmt::localtime Fix potential UB (fmt gmtime/localtime could throw in noexcept context) Separate GMT/local caches to fix inconsistency
Hide implementation in anonymous namespace

Closes #1056








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

