### PR TITLE
fix kafka: add missing rdkafka_mock.h header

### DIFF
--- a/kafka/wrapper/include/librdkafka/rdkafka_mock.h
+++ b/kafka/wrapper/include/librdkafka/rdkafka_mock.h
@@ -1,0 +1,1 @@
+#include <rdkafka_mock.h>


### PR DESCRIPTION
Causes build to fail, with a typical error message about the missing header.
```cmake
cmake_minimum_required(VERSION 3.14)
project(XXX LANGUAGES CXX)

set(USERVER_PROJECT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/submodules/userver")
if(EXISTS ${USERVER_PROJECT_DIR})
	add_subdirectory(${USERVER_PROJECT_DIR})
else()
	message(FATAL_ERROR "Unable to locate userver in the submodules directory")
endif()

file(GLOB_RECURSE XXX_SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
add_executable(${PROJECT_NAME} ${XXX_SRC_FILES})
target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_23)

userver_setup_environment()
target_link_libraries(${PROJECT_NAME} PUBLIC userver::core userver::kafka)
```
```cpp
// src/main.cpp

#include <userver/components/minimal_server_component_list.hpp>
#include <userver/utils/daemon_run.hpp>

int main(int argc, char* argv[])
{
	auto components_list = userver::components::MinimalServerComponentList();
	return userver::utils::DaemonMain(argc, argv, components_list);
}
```
```sh
cmake -B build -DUSERVER_FEATURE_UTEST=OFF -DUSERVER_FEATURE_STACKTRACE=OFF -DUSERVER_FEATURE_KAFKA=ON
cmake --build build -- -j 16
```
```
submodules/userver/kafka/src/kafka/impl/holders.cpp:7:10: fatal error: librdkafka/rdkafka_mock.h: No such file or directory
    7 | #include <librdkafka/rdkafka_mock.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```
63de2c97445c5f8e20a24eb01979ef73e5c04fd9 adds the include directive for this header, but the wrapper header `rdkafka_mock.h` itself was not provided.