### PR TITLE
feat testsuite: add service_start_timeout fixture

### DIFF
--- a/testsuite/pytest_plugins/pytest_userver/plugins/service.py
+++ b/testsuite/pytest_plugins/pytest_userver/plugins/service.py
@@ -97,6 +97,18 @@ def service_non_http_health_checks(  # pylint: disable=invalid-name
 
     return net.get_health_checks_info(service_config)
 
+@pytest.fixture(scope='session')
+def service_start_timeout() -> float:
+    """
+    Returns service start timeout in seconds.
+
+    Override this fixture to change the service start timeout.
+
+    @ingroup userver_testsuite_fixtures
+    """
+
+    return 100.0
+
 
 @pytest.fixture(scope='session')
 async def service_daemon_scope(
@@ -107,6 +119,7 @@ async def service_daemon_scope(
     service_config_path_temp,
     service_binary,
     service_non_http_health_checks,
+    service_start_timeout,
 ):
     """
     Prepares the start of the service daemon.
@@ -148,11 +161,15 @@ async def service_daemon_scope(
     if service_http_ping_url:
         health_check = None
 
+    # In yandex-taxi-testsuite, each poll retry duration is 0.05 seconds.
+    poll_retries = int(service_start_timeout / 0.05)
+
     async with create_daemon_scope(
         args=[str(service_binary), '--config', str(service_config_path_temp)],
         ping_url=service_http_ping_url,
         health_check=health_check,
         env=service_env,
+        poll_retries=poll_retries,
     ) as scope:
         yield scope
 


### PR DESCRIPTION
The fixture `service_start_timeout` is necessary to adjust service start timeout, because service start duration can be any.