### PR TITLE
Fix: Find protobuf config if possible

### DIFF
--- a/cmake/SetupProtobuf.cmake
+++ b/cmake/SetupProtobuf.cmake
@@ -50,7 +50,10 @@ if(NOT USERVER_FORCE_DOWNLOAD_PROTOBUF)
     if(USERVER_DOWNLOAD_PACKAGE_PROTOBUF)
         find_package(Protobuf QUIET)
     else()
-        find_package(Protobuf)
+        find_package(Protobuf CONFIG QUIET)
+        if (NOT Protobuf_FOUND)
+            find_package(Protobuf)
+        endif()
         if(NOT Protobuf_FOUND)
             message(
                 FATAL_ERROR


### PR DESCRIPTION
CMake package config in newer protobuf package versions do not expose any variables, relying on target properties instead.

------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

https://yandex.ru/legal/cla