### PR TITLE
feat mysql: add secure connection option impl

### DIFF
--- a/mysql/src/storages/mysql/component.yaml
+++ b/mysql/src/storages/mysql/component.yaml
@@ -10,3 +10,7 @@ properties:
         type: integer
         description: maximum number of created connections
         default: 10
+    use_secure_connection:
+        type: boolean
+        description: whether to use TLS for connections
+        defaultDescription: true

--- a/mysql/src/storages/mysql/impl/connection.cpp
+++ b/mysql/src/storages/mysql/impl/connection.cpp
@@ -95,6 +95,11 @@ void SetNativeOptions(MYSQL* mysql, const settings::ConnectionSettings& connecti
     if (connection_settings.use_compression) {
         mysql_optionsv(mysql, MYSQL_OPT_COMPRESS, nullptr);
     }
+
+    if (!connection_settings.use_secure_connection) {
+        my_bool verify_server_cert = 0;
+        mysql_optionsv(mysql, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify_server_cert);
+    }
 }
 
 compiler::ThreadLocal mysql_local_scope = [] { return MysqlThreadEnd{}; };

--- a/mysql/src/storages/mysql/settings/settings.cpp
+++ b/mysql/src/storages/mysql/settings/settings.cpp
@@ -49,8 +49,8 @@ ConnectionSettings Parse(const yaml_config::YamlConfig& doc, formats::parse::To<
     ConnectionSettings settings{};
     // TODO : named const
     settings.statements_cache_size = doc["statements_cache_size"].As<std::size_t>(20);
-    // TODO
-    settings.use_secure_connection = false;
+
+    settings.use_secure_connection = doc["use_secure_connection"].As<bool>(true);
     // TODO
     settings.use_compression = false;
     // TODO

--- a/mysql/src/storages/mysql/settings/settings.hpp
+++ b/mysql/src/storages/mysql/settings/settings.hpp
@@ -26,7 +26,7 @@ enum class IpMode { kIpV4, kIpV6, kAny };
 
 struct ConnectionSettings final {
     std::size_t statements_cache_size;
-    // TODO : implement ssl somehow
+    /// Whether to verify server TLS/SSL certificate.
     bool use_secure_connection;
     // TODO : implement compression somehow
     bool use_compression;

--- a/samples/mysql_service/static_config.yaml
+++ b/samples/mysql_service/static_config.yaml
@@ -10,6 +10,7 @@ components_manager:
         sample-sql-component:
             initial_pool_size: 3
             max_pool_size: 15
+            use_secure_connection: false
 # /// [MySQL service sample - static config]
         http-client:
         http-client-core:


### PR DESCRIPTION
This PR adds implementation of `use_secure_connection` for mysql driver. Previously this flag was introduced in settings but was not used at all.  Mainly we use only one flag of underlying `libmariadb-connector-c`: `MYSQL_OPT_SSL_VERIFY_SERVER_CERT`, which tells do not verify SSL certificates.

It is very useful in testing env where mysql database is running inside of docker container and there is no need to worry about SSL.

P.S. sample service was working fine because mysql database was running on localhost and in this case libmariadb using a unix socket and no SSL needed at all.

