### PR TITLE
fix engine: don't lock in ~TaskContext when there are no plugins

### DIFF
--- a/core/src/engine/plugin_manager.hpp
+++ b/core/src/engine/plugin_manager.hpp
@@ -46,7 +46,7 @@ public:
             empty = plugins_.empty();
         }
 
-        if (empty) {
+        if (!empty) {
             has_any_plugin_ = true;
         }
     }


### PR DESCRIPTION
When benchmarking the samples/hello-service, without the patch:
```
taskset -c 150-181 ./twrk -c 64 -t 32 -d 100s http://localhost:12345/hello -s pipeline.lua -- 16
Running 2m test @ http://localhost:12345/hello
  32 threads and 64 connections
  Thread Stats   Avg     Stdev       Max       Min   +/- Stdev
    Latency    14.20ms    8.57ms   75.14ms  554.00us   65.69%
    Req/Sec     1.35k   161.78      3.42k   750.00     71.55%
  4288071 requests in 1.67m, 1.03GB read
Requests/sec:  42880.68
Transfer/sec:     10.51MB
```
, and with the patch
```
taskset -c 150-181 ./twrk -c 64 -t 32 -d 100s http://localhost:12345/hello -s pipeline.lua -- 16
Running 2m test @ http://localhost:12345/hello
  32 threads and 64 connections
  Thread Stats   Avg     Stdev       Max       Min   +/- Stdev
    Latency   690.73us  587.60us   21.77ms    1.05ms   13.23%
    Req/Sec    17.75k   267.73     18.55k    14.10k    72.55%
  56517507 requests in 1.67m, 13.53GB read
Requests/sec: 565174.67
Transfer/sec:    138.52MB
```

x13 improvement in a single not even _line_ of code, but rather a _symbol_ of code, yay!