### PR TITLE
fix: add missing <iterator> include

### DIFF
--- a/universal/include/userver/utils/traceful_exception.hpp
+++ b/universal/include/userver/utils/traceful_exception.hpp
@@ -4,6 +4,7 @@
 /// @brief @copybrief utils::TracefulException
 
 #include <exception>
+#include <iterator>
 #include <string>
 #include <type_traits>
 

--- a/universal/src/utils/check_syscall.hpp
+++ b/universal/src/utils/check_syscall.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cerrno>
+#include <iterator>
 #include <system_error>
 
 #include <fmt/format.h>


### PR DESCRIPTION
The source fails to compile under clang/libc++ with -std=c++23. This patch adds missing include directives.




------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

