### PR TITLE
fix: llvm-17/libc++ does not implement atomit += for double

### DIFF
--- a/core/src/utils/statistics/impl/histogram_view_utils.hpp
+++ b/core/src/utils/statistics/impl/histogram_view_utils.hpp
@@ -54,7 +54,7 @@ inline void AddNonAtomic(std::atomic<double>& to, std::uint64_t x) {
 }
 
 inline void AddAtomic(std::atomic<double>& to, double x) {
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L && (!defined(__clang_major__) || __clang_major__ >= 18)
     to += x;
 #else
     double expected = to.load();


### PR DESCRIPTION
This PR disables `+=` use for atomic<double> for llvm-17/libc++.





------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

