### PR TITLE
Prevent unnecessary copy inside of ServerImpl::WriteTotalHandlerStatistics function's range-based for loop

### DIFF
--- a/core/src/server/server.cpp
+++ b/core/src/server/server.cpp
@@ -306,7 +306,7 @@ void ServerImpl::WriteTotalHandlerStatistics(utils::statistics::Writer& writer) 
         UASSERT(main_port_info_.request_handler);
         const auto& handlers = main_port_info_.request_handler->GetHandlerInfoIndex().GetHandlers().Lock();
 
-        for (const auto handler_ptr : *handlers) {
+        for (const auto& handler_ptr : *handlers) {
             for (const auto method : handler_ptr->GetAllowedMethods()) {
                 total.Add(handlers::HttpHandlerStatisticsSnapshot{handler_ptr->GetHandlerStatistics().GetByMethod(method
                 )});


### PR DESCRIPTION
Small change targeted to prevent unnecessary copy of "const userver::v2_15_rc::utils::NotNull<const userver::v2_15_rc::server::handlers::HttpHandlerBase*>" object inside range-based for loop in ServerImpl::WriteTotalHandlerStatistic.


EDIT: Resolves an issue #1099 (note: use reference type to prevent copying)