### PR TITLE
feat grpc: ability to provide SSL certificate for GRPC client

### DIFF
--- a/grpc/include/userver/ugrpc/client/external_credentials_provider.hpp
+++ b/grpc/include/userver/ugrpc/client/external_credentials_provider.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+/// @file userver/ugrpc/client/external_credentials_provider.hpp
+/// @brief @copybrief ugrpc::client::ExternalCredentialsProvider
+
+#include <grpcpp/security/credentials.h>
+#include <optional>
+#include <string_view>
+#include <userver/components/component_base.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace ugrpc::client {
+
+// clang-format off
+
+/// @ingroup userver_components
+///
+/// @brief Provides GRPC SSL credentials options to @ref ugrpc::client::ClientFactoryComponent
+/// Should be implemented by userver framework client as a component.
+
+// clang-format on
+
+class ExternalCredentialsProvider : public components::ComponentBase {
+public:
+    static constexpr std::string_view kName = "external-grpc-client-credentials-provider";
+
+    using components::ComponentBase::ComponentBase;
+
+    /// The method is called by @ref ugrpc::client::ClientFactoryComponent.
+    /// Implement the method, in order to override SSL credentials specified in GRPC client factory config.
+    /// Returned credentials have a precedence over the credentials from GPRC client factory config.
+    /// If returned value is not `std::nullopt`, SSL is turned on with the provided credentials in GRPC client factory.
+    /// Otherwise, SSL credentials from GRPC client factory config is used.
+    virtual std::optional<grpc::SslCredentialsOptions> GetSslCredentialsOptions() = 0;
+};
+
+}  // namespace ugrpc::client
+
+USERVER_NAMESPACE_END

--- a/grpc/src/ugrpc/client/client_factory_component.cpp
+++ b/grpc/src/ugrpc/client/client_factory_component.cpp
@@ -7,6 +7,7 @@
 #include <userver/logging/log.hpp>
 #include <userver/storages/secdist/component.hpp>
 #include <userver/testsuite/testsuite_support.hpp>
+#include <userver/ugrpc/client/external_credentials_provider.hpp>
 #include <userver/yaml_config/merge_schemas.hpp>
 
 #include <userver/ugrpc/client/common_component.hpp>
@@ -83,6 +84,20 @@ ClientFactoryComponent::ClientFactoryComponent(
     if (!testsuite_grpc.IsTlsEnabled() && client_factory_config.auth_type == AuthType::kSsl) {
         LOG_INFO() << "Disabling TLS/SSL dues to testsuite config for gRPC";
         client_factory_config.auth_type = AuthType::kInsecure;
+    }
+
+    if (auto* external_credentials_provider = context.FindComponentOptional<ExternalCredentialsProvider>();
+        external_credentials_provider) {
+        LOG_INFO() << "Requesting external SSL credentials options for gRPC";
+        if (auto ssl_credentials_options = external_credentials_provider->GetSslCredentialsOptions();
+            ssl_credentials_options.has_value()) {
+            LOG_INFO() << "Using external SSL credentials options for gRPC";
+            client_factory_config.ssl_credentials_options = std::move(ssl_credentials_options.value());
+            if (testsuite_grpc.IsTlsEnabled()) {
+                LOG_INFO() << "gRPC SSL is turned on, because external credentials are provided";
+                client_factory_config.auth_type = AuthType::kSsl;
+            }
+        }
     }
 
     auto credentials = MakeCredentials(client_factory_config.auth_type, client_factory_config.ssl_credentials_options);


### PR DESCRIPTION
Currently, there is the only option to provide SSL certificate for GRPC client: from file.
It makes impossible to use a certificate received from an external secret data provider without saving it to disk, while saving private key to disk could potentially lead to a security issue.

It is suggested to declare an abstract component `ugrpc::client::ExternalCredentialsProvider`, which is used by `ugrpc::client::ClientFactoryComponent`. If `ugrpc::client::ExternalCredentialsProvider` returns a certificate, then SSL auth is enabled and certificate file path specified for factory config is ignored.

A minimal example:

```
// .hpp/.ccp

#include <userver/ugrpc/client/external_credentials_provider.hpp>

class GrpcClientCredentialsProvider final : public userver::ugrpc::client::ExternalCredentialsProvider {
 public:
  GrpcClientCredentialsProvider(const userver::components::ComponentConfig& config,
                                const userver::components::ComponentContext& context);

  std::optional<grpc::SslCredentialsOptions> GetSslCredentialsOptions() override {
    grpc::SslCredentialsOptions options;
    options.pem_cert_chain = ...;
    options.pem_private_key = ...;
    options.pem_root_certs = ...;
    return options;
  }
  
  ...
};
```

```
// static_config.yaml

    components:
        ...

        external-grpc-client-credentials-provider:

        ...
```