### PR TITLE
feat ydb: extend ydb::CoordinationSession semaphore methods

### DIFF
--- a/ydb/include/userver/ydb/coordination.hpp
+++ b/ydb/include/userver/ydb/coordination.hpp
@@ -61,13 +61,13 @@ public:
     );
 
     /// Create semaphore
-    void CreateSemaphore(std::string_view name, std::uint64_t limit);
+    void CreateSemaphore(std::string_view name, std::uint64_t limit, std::string_view data = {});
 
     /// Update semaphore
     void UpdateSemaphore(std::string_view name, std::string_view data);
 
     /// Delete semaphore
-    void DeleteSemaphore(std::string_view name);
+    void DeleteSemaphore(std::string_view name, bool force = false);
 
 private:
     NYdb::NCoordination::TSession session_;

--- a/ydb/src/ydb/coordination.cpp
+++ b/ydb/src/ydb/coordination.cpp
@@ -56,16 +56,16 @@ NYdb::NCoordination::TSemaphoreDescription CoordinationSession::DescribeSemaphor
     return ExtractResult(session_.DescribeSemaphore(impl::ToString(name), settings), "DescribeSemaphore");
 }
 
-void CoordinationSession::CreateSemaphore(std::string_view name, std::uint64_t limit) {
-    ExtractResult(session_.CreateSemaphore(impl::ToString(name), limit), "CreateSemaphore");
+void CoordinationSession::CreateSemaphore(std::string_view name, std::uint64_t limit, std::string_view data) {
+    ExtractResult(session_.CreateSemaphore(impl::ToString(name), limit, impl::ToString(data)), "CreateSemaphore");
 }
 
 void CoordinationSession::UpdateSemaphore(std::string_view name, std::string_view data) {
     ExtractResult(session_.UpdateSemaphore(impl::ToString(name), impl::ToString(data)), "UpdateSemaphore");
 }
 
-void CoordinationSession::DeleteSemaphore(std::string_view name) {
-    ExtractResult(session_.DeleteSemaphore(impl::ToString(name)), "DeleteSemaphore");
+void CoordinationSession::DeleteSemaphore(std::string_view name, bool force) {
+    ExtractResult(session_.DeleteSemaphore(impl::ToString(name), force), "DeleteSemaphore");
 }
 
 CoordinationClient::CoordinationClient(std::shared_ptr<impl::Driver> driver)


### PR DESCRIPTION
Updated `ydb::CoordinationSession` semaphore methods (`CreateSemaphore`, `DeleteSemaphore`)

1) **CreateSemaphore**: Added `std::string_view data` argument (default is empty). Allows attaching [user-defined metadata](https://github.com/ydb-platform/ydb/blob/093a5c2d32357ce9957a4cf16c13cc36eb2b6c60/ydb/public/api/protos/ydb_coordination.proto#L264-L265) to the semaphore upon creation. [SDK method](https://github.com/ydb-platform/ydb-cpp-sdk/blob/e091a10085dff2c96f3c99641db83498e7fa2a09/include/ydb-cpp-sdk/client/coordination/coordination.h#L354-L355)
2) **DeleteSemaphore**: Added `bool force` argument (default is `false`). Enables [force deletion](https://github.com/ydb-platform/ydb/blob/093a5c2d32357ce9957a4cf16c13cc36eb2b6c60/ydb/public/api/protos/ydb_coordination.proto#L292-L293) of the semaphore. [SDK method](https://github.com/ydb-platform/ydb-cpp-sdk/blob/e091a10085dff2c96f3c99641db83498e7fa2a09/include/ydb-cpp-sdk/client/coordination/coordination.h#L360-L361)


