### PR TITLE
fix: fix yaml_config mode when accessing array by index

### DIFF
--- a/universal/src/yaml_config/impl/validate_static_config_test.cpp
+++ b/universal/src/yaml_config/impl/validate_static_config_test.cpp
@@ -425,6 +425,33 @@ properties:
     UEXPECT_NO_THROW(Validate(static_config, schema));
 }
 
+TEST(StaticConfigValidator, ArrayWithEnvPassed) {
+    const std::string kStaticConfig = R"(
+component:
+  values:
+    - value#env: ENV_VALUE
+)";
+
+    const std::string kSchema = R"(
+type: object
+description: test component with nested array
+additionalProperties: false
+properties:
+    values:
+      type: array
+      description: values
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          value:
+            type: string
+            description: value
+)";
+
+    UEXPECT_NO_THROW(Validate(kStaticConfig, kSchema));
+}
+
 TEST(StaticConfigValidator, Enum) {
     const std::string correct_static_config = R"(
 mode: on

--- a/universal/src/yaml_config/yaml_config.cpp
+++ b/universal/src/yaml_config/yaml_config.cpp
@@ -227,7 +227,7 @@ YamlConfig YamlConfig::operator[](size_t index) const {
         return MakeMissingConfig(*this, index)[value.As<std::string>()];
     }
 
-    return {std::move(value), config_vars_};
+    return {std::move(value), config_vars_, mode_};
 }
 
 std::size_t YamlConfig::GetSize() const { return yaml_.GetSize(); }

--- a/universal/src/yaml_config/yaml_config_test.cpp
+++ b/universal/src/yaml_config/yaml_config_test.cpp
@@ -93,6 +93,30 @@ TEST(YamlConfig, SampleEnv) {
     /// [sample env]
 }
 
+TEST(YamlConfig, SampleEnvInArray) {
+    auto node = formats::yaml::FromString(R"(
+    some_elements:
+        - some#env: ENV_VARIABLE_NAME_1
+        - some#env: ENV_VARIABLE_NAME_2
+  )");
+
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    ::setenv("ENV_VARIABLE_NAME_1", "100", 1);
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    ::setenv("ENV_VARIABLE_NAME_2", "100", 1);
+
+    const yaml_config::YamlConfig yaml(std::move(node), {}, yaml_config::YamlConfig::Mode::kEnvAllowed);
+    const auto& array = yaml["some_elements"];
+    for (const auto& element : array) {
+        EXPECT_EQ(element["some"].As<int>(), 100);
+    }
+
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    ::unsetenv("ENV_VARIABLE_NAME_1");
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    ::unsetenv("ENV_VARIABLE_NAME_2");
+}
+
 TEST(YamlConfig, SampleMultiple) {
     const auto node = formats::yaml::FromString(R"(
 # /// [sample multiple]


### PR DESCRIPTION
When accessing YamlConfig array by index returned value always contained `kSecure` mode, despite the original config mode