### PR TITLE
Fix string error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ guaranteed to execute immediately:
 ```cpp
 #include <userver/easy.hpp>
 #include "schemas/key_value.hpp"
+#include <string>
 
 int main(int argc, char* argv[]) {
     using namespace userver;


### PR DESCRIPTION
Что было исправлено:

Добавлен #include <string> в примере (README.md, 3 строка кода, 36 строка README)

Почему:

Во избежание ошибки "error: 'string' is not a member of 'std'" при компиляции примера.





------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

