### PR TITLE
feat kafka: add bulk send producer method

### DIFF
--- a/kafka/include/userver/kafka/exceptions.hpp
+++ b/kafka/include/userver/kafka/exceptions.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <exception>
+#include <map>
 #include <stdexcept>
 #include <string_view>
 
@@ -25,6 +27,29 @@ protected:
 
 private:
     const bool is_retryable_{false};
+};
+
+/// @brief Base exception thrown by Producer::Send in bulk mode
+/// in case of one or more send errors.
+class BulkSendException : public std::runtime_error {
+    static constexpr const char* kWhat{"Some messages was not delivered."};
+
+public:
+    using ExceptionMap = std::map<std::size_t, std::exception_ptr>;
+
+    explicit BulkSendException(ExceptionMap nested_exceptions);
+
+    /// @return nested errors.
+    /// Nested exceptions are subclasses of SendException.
+    const ExceptionMap& GetExceptions() const noexcept;
+
+private:
+    /// @brief A mapping from the message's index in the bulk send operation
+    /// to the exception that occurred during its delivering.
+    /// @details Key: 0-based index of the element in the input batch.
+    /// Value: Pointer to the exception.
+    /// @note Contains only indices that resulted in an error.
+    const ExceptionMap nested_exceptions_;
 };
 
 class DeliveryTimeoutException final : public SendException {

--- a/kafka/include/userver/kafka/impl/messages.hpp
+++ b/kafka/include/userver/kafka/impl/messages.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace kafka::impl {
+
+/// @brief Message collection adapter.
+class Messages {
+public:
+    Messages() = default;
+
+    virtual std::size_t Size() const noexcept = 0;
+    virtual std::string_view operator[](std::size_t index) const noexcept = 0;
+
+    virtual ~Messages() = default;
+};
+
+template<typename Container>
+class MessagesAdapter final : public Messages {
+public:
+    static_assert(std::is_convertible_v<decltype(std::declval<const Container&>()[0]), std::string_view>,
+        "Container must support operator[] and return a type convertible to std::string_view");
+
+    static_assert(std::is_integral_v<decltype(std::declval<const Container&>().size())>,
+        "Container must support method size() and return an integral type");
+
+    explicit MessagesAdapter(const Container& data) noexcept : data_{data} {}
+
+    std::size_t Size() const noexcept override { return data_.size(); }
+    std::string_view operator[](std::size_t index) const noexcept override { return data_[index]; }
+
+private:
+    const Container& data_;
+};
+
+}  // namespace kafka::impl
+
+USERVER_NAMESPACE_END

--- a/kafka/include/userver/kafka/producer.hpp
+++ b/kafka/include/userver/kafka/producer.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
+#include <utility>
 
 #include <userver/engine/task/task_processor_fwd.hpp>
 #include <userver/engine/task/task_with_result.hpp>
 #include <userver/kafka/exceptions.hpp>
 #include <userver/kafka/headers.hpp>
+#include <userver/kafka/impl/messages.hpp>
 #include <userver/utils/fast_pimpl.hpp>
-#include <userver/utils/span.hpp>
 #include <userver/utils/statistics/writer.hpp>
 
 USERVER_NAMESPACE_BEGIN
@@ -133,13 +135,20 @@ public:
     ///
     /// @note Use BulkSendException::GetExceptions method to get a list
     /// of occured nested exceptions.
-    void Send(
+    template<typename Messages>
+    std::enable_if_t<
+        std::is_convertible_v<decltype(std::declval<const Messages&>()[0]), std::string_view>
+        &&
+        std::is_integral_v<decltype(std::declval<const Messages&>().size())>
+    > Send(
         utils::zstring_view topic_name,
         std::string_view key,
-        utils::span<const std::string> messages,
+        const Messages& messages,
         std::optional<std::uint32_t> partition = kUnassignedPartition,
         HeaderViews headers = {}
-    ) const;
+    ) const {
+        SendWrapper(topic_name, key, impl::MessagesAdapter{messages}, partition, std::move(headers));
+    }
 
     /// @brief Same as Producer::Send, but returns the task which can be
     /// used to wait the message delivery manually.
@@ -175,9 +184,17 @@ private:
     void SendImpl(
         utils::zstring_view topic_name,
         std::string_view key,
-        utils::span<const std::string> messages,
+        const impl::Messages& messages,
         std::optional<std::uint32_t> partition,
         std::vector<impl::HeadersHolder>&& headers_holders
+    ) const;
+
+    void SendWrapper(
+        utils::zstring_view topic_name,
+        std::string_view key,
+        const impl::Messages& messages,
+        std::optional<std::uint32_t> partition,
+        HeaderViews headers
     ) const;
 
     const std::string name_;

--- a/kafka/include/userver/kafka/producer.hpp
+++ b/kafka/include/userver/kafka/producer.hpp
@@ -104,7 +104,22 @@ public:
     ///
     /// @note Use SendException::IsRetryable method to understand whether there is
     /// a sense to retry the message sending.
-    /// @snippet kafka/tests/producer_kafkatest.cpp Producer retryable error
+    ///
+    /// @code{.cpp}
+    /// bool delivered{false};
+    /// while (!delivered && !deadline.IsReached()) {
+    ///     try {
+    ///         producer.Send(topic, key, message);
+    ///         delivered = true;
+    ///     } catch (const kafka::SendException& e) {
+    ///         if (e.IsRetryable()) {
+    ///             engine::InterruptibleSleepFor(std::chrono::milliseconds{10});
+    ///             continue;
+    ///         }
+    ///         break;
+    ///     }
+    /// }
+    /// @endcode
     void Send(
         utils::zstring_view topic_name,
         std::string_view key,

--- a/kafka/include/userver/kafka/producer.hpp
+++ b/kafka/include/userver/kafka/producer.hpp
@@ -7,6 +7,7 @@
 #include <userver/kafka/exceptions.hpp>
 #include <userver/kafka/headers.hpp>
 #include <userver/utils/fast_pimpl.hpp>
+#include <userver/utils/span.hpp>
 #include <userver/utils/statistics/writer.hpp>
 
 USERVER_NAMESPACE_BEGIN
@@ -110,6 +111,36 @@ public:
         HeaderViews headers = {}
     ) const;
 
+    /// @brief Sends given messages to topic `topic_name` by given `key`
+    /// and `partition` (if passed) with payload contains the `messages`
+    /// data. Asynchronously waits until the messages are delivered or the delivery
+    /// error occurred.
+    ///
+    /// No payload data is copied. Method holds the data until messages are
+    /// delivered.
+    ///
+    /// Thread-safe and can be called from any number of threads
+    /// concurrently.
+    ///
+    /// If `partition` not passed, partition is chosen by internal
+    /// Kafka partitioner.
+    ///
+    /// @warning if `enable_idempotence` option is enabled, do not use both
+    /// explicit partitions and Kafka-chosen ones.
+    ///
+    /// @throws BulkSendException if some messages was not delivered
+    /// and acked by Kafka Broker in configured timeout.
+    ///
+    /// @note Use BulkSendException::GetExceptions method to get a list
+    /// of occured nested exceptions.
+    void Send(
+        utils::zstring_view topic_name,
+        std::string_view key,
+        utils::span<const std::string> messages,
+        std::optional<std::uint32_t> partition = kUnassignedPartition,
+        HeaderViews headers = {}
+    ) const;
+
     /// @brief Same as Producer::Send, but returns the task which can be
     /// used to wait the message delivery manually.
     ///
@@ -139,6 +170,14 @@ private:
         std::string_view message,
         std::optional<std::uint32_t> partition,
         impl::HeadersHolder&& headers_holder
+    ) const;
+
+    void SendImpl(
+        utils::zstring_view topic_name,
+        std::string_view key,
+        utils::span<const std::string> messages,
+        std::optional<std::uint32_t> partition,
+        std::vector<impl::HeadersHolder>&& headers_holders
     ) const;
 
     const std::string name_;

--- a/kafka/src/kafka/exceptions.cpp
+++ b/kafka/src/kafka/exceptions.cpp
@@ -13,6 +13,13 @@ SendException::SendException(const char* what, bool is_retryable)
       is_retryable_(is_retryable)
 {}
 
+BulkSendException::BulkSendException(BulkSendException::ExceptionMap nested_exceptions)
+    : std::runtime_error(kWhat),
+      nested_exceptions_(std::move(nested_exceptions))
+{}
+
+const BulkSendException::ExceptionMap& BulkSendException::GetExceptions() const noexcept { return nested_exceptions_; }
+
 DeliveryTimeoutException::DeliveryTimeoutException()
     : SendException(kWhat, /*is_retryable=*/true)
 {}

--- a/kafka/src/kafka/impl/producer_impl.cpp
+++ b/kafka/src/kafka/impl/producer_impl.cpp
@@ -140,7 +140,7 @@ DeliveryResult ProducerImpl::Send(
     LOG(operation_log_level_) << fmt::format("Message to topic '{}' is requested to send", topic_name);
     auto deadline = engine::Deadline::FromDuration(delivery_timeout_);
     auto delivery_result_future =
-        ScheduleMessageDelivery(topic_name, key, message, partition, std::move(headers_holder), deadline, QueueFullHandlingPolicy::Throw);
+        ScheduleMessageDelivery(topic_name, key, message, partition, std::move(headers_holder), deadline);
 
     WaitUntilDeliveryReported(delivery_result_future);
 
@@ -165,7 +165,7 @@ std::vector<DeliveryResult> ProducerImpl::Send(
     auto deadline = engine::Deadline::FromDuration(delivery_timeout_);
     for (std::size_t i = 0; i < messages.Size(); ++i) {
         delivery_result_futures.emplace_back(
-            ScheduleMessageDelivery(topic_name, key, messages[i], partition, std::move(headers_holders[i]), deadline, QueueFullHandlingPolicy::Retry)
+            ScheduleMessageDelivery(topic_name, key, messages[i], partition, std::move(headers_holders[i]), deadline)
         );
     }
 
@@ -187,8 +187,7 @@ engine::Future<DeliveryResult> ProducerImpl::ScheduleMessageDelivery(
     std::string_view message,
     std::optional<std::uint32_t> partition,
     HeadersHolder headers_holder,
-    engine::Deadline deadline,
-    QueueFullHandlingPolicy queue_full_handling_policy
+    engine::Deadline deadline
 ) const {
     auto waiter = std::make_unique<DeliveryWaiter>();
     auto wait_handle = waiter->GetFuture();
@@ -244,7 +243,7 @@ engine::Future<DeliveryResult> ProducerImpl::ScheduleMessageDelivery(
         if (enqueue_error == RD_KAFKA_RESP_ERR_NO_ERROR) {
             [[maybe_unused]] const auto headers_holder_ptr = headers_holder.release();
             [[maybe_unused]] const auto waiter_ptr = waiter.release();
-        } else if (queue_full_handling_policy == QueueFullHandlingPolicy::Retry && enqueue_error == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
+        } else if (enqueue_error == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
             LOG_LIMITED_WARNING("Kafka local queue is full");
             /// waiting for a while for the queue to clear up
             engine::Yield();

--- a/kafka/src/kafka/impl/producer_impl.cpp
+++ b/kafka/src/kafka/impl/producer_impl.cpp
@@ -8,7 +8,6 @@
 #include <userver/engine/wait_any.hpp>
 #include <userver/kafka/impl/configuration.hpp>
 #include <userver/tracing/span.hpp>
-#include <userver/utils/span.hpp>
 #include <userver/utils/trivial_map.hpp>
 
 #include <kafka/impl/log_level.hpp>
@@ -141,7 +140,7 @@ DeliveryResult ProducerImpl::Send(
     LOG(operation_log_level_) << fmt::format("Message to topic '{}' is requested to send", topic_name);
     auto deadline = engine::Deadline::FromDuration(delivery_timeout_);
     auto delivery_result_future =
-        ScheduleMessageDelivery(topic_name, key, message, partition, std::move(headers_holder), deadline);
+        ScheduleMessageDelivery(topic_name, key, message, partition, std::move(headers_holder), deadline, QueueFullHandlingPolicy::Throw);
 
     WaitUntilDeliveryReported(delivery_result_future);
 
@@ -151,27 +150,27 @@ DeliveryResult ProducerImpl::Send(
 std::vector<DeliveryResult> ProducerImpl::Send(
     utils::zstring_view topic_name,
     std::string_view key,
-    utils::span<const std::string> messages,
+    const Messages& messages,
     std::optional<std::uint32_t> partition,
     std::vector<HeadersHolder> headers_holders
 ) const {
-    UASSERT(messages.size() == headers_holders.size());
+    UASSERT(messages.Size() == headers_holders.size());
 
     LOG(operation_log_level_) <<
-        fmt::format("Messages {} to topic '{}' are requested to send", messages.size(), topic_name);
+        fmt::format("Messages {} to topic '{}' are requested to send", messages.Size(), topic_name);
 
     std::vector<engine::Future<DeliveryResult>> delivery_result_futures;
-    delivery_result_futures.reserve(messages.size());
+    delivery_result_futures.reserve(messages.Size());
 
     auto deadline = engine::Deadline::FromDuration(delivery_timeout_);
-    for (std::size_t i = 0; i < messages.size(); ++i) {
+    for (std::size_t i = 0; i < messages.Size(); ++i) {
         delivery_result_futures.emplace_back(
-            ScheduleMessageDelivery(topic_name, key, messages[i], partition, std::move(headers_holders[i]), deadline)
+            ScheduleMessageDelivery(topic_name, key, messages[i], partition, std::move(headers_holders[i]), deadline, QueueFullHandlingPolicy::Retry)
         );
     }
 
     std::vector<DeliveryResult> delivery_results;
-    delivery_results.reserve(messages.size());
+    delivery_results.reserve(messages.Size());
 
     for (auto& delivery_result_future : delivery_result_futures) {
         WaitUntilDeliveryReported(delivery_result_future);
@@ -188,7 +187,8 @@ engine::Future<DeliveryResult> ProducerImpl::ScheduleMessageDelivery(
     std::string_view message,
     std::optional<std::uint32_t> partition,
     HeadersHolder headers_holder,
-    engine::Deadline deadline
+    engine::Deadline deadline,
+    QueueFullHandlingPolicy queue_full_handling_policy
 ) const {
     auto waiter = std::make_unique<DeliveryWaiter>();
     auto wait_handle = waiter->GetFuture();
@@ -244,7 +244,7 @@ engine::Future<DeliveryResult> ProducerImpl::ScheduleMessageDelivery(
         if (enqueue_error == RD_KAFKA_RESP_ERR_NO_ERROR) {
             [[maybe_unused]] const auto headers_holder_ptr = headers_holder.release();
             [[maybe_unused]] const auto waiter_ptr = waiter.release();
-        } else if (enqueue_error == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
+        } else if (queue_full_handling_policy == QueueFullHandlingPolicy::Retry && enqueue_error == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
             LOG_LIMITED_WARNING("Kafka local queue is full");
             /// waiting for a while for the queue to clear up
             engine::Yield();

--- a/kafka/src/kafka/impl/producer_impl.cpp
+++ b/kafka/src/kafka/impl/producer_impl.cpp
@@ -8,6 +8,7 @@
 #include <userver/engine/wait_any.hpp>
 #include <userver/kafka/impl/configuration.hpp>
 #include <userver/tracing/span.hpp>
+#include <userver/utils/span.hpp>
 #include <userver/utils/trivial_map.hpp>
 
 #include <kafka/impl/log_level.hpp>
@@ -138,12 +139,47 @@ DeliveryResult ProducerImpl::Send(
     HeadersHolder headers_holder
 ) const {
     LOG(operation_log_level_) << fmt::format("Message to topic '{}' is requested to send", topic_name);
+    auto deadline = engine::Deadline::FromDuration(delivery_timeout_);
     auto delivery_result_future =
-        ScheduleMessageDelivery(topic_name, key, message, partition, std::move(headers_holder));
+        ScheduleMessageDelivery(topic_name, key, message, partition, std::move(headers_holder), deadline);
 
     WaitUntilDeliveryReported(delivery_result_future);
 
     return delivery_result_future.get();
+}
+
+std::vector<DeliveryResult> ProducerImpl::Send(
+    utils::zstring_view topic_name,
+    std::string_view key,
+    utils::span<const std::string> messages,
+    std::optional<std::uint32_t> partition,
+    std::vector<HeadersHolder> headers_holders
+) const {
+    UASSERT(messages.size() == headers_holders.size());
+
+    LOG(operation_log_level_) <<
+        fmt::format("Messages {} to topic '{}' are requested to send", messages.size(), topic_name);
+
+    std::vector<engine::Future<DeliveryResult>> delivery_result_futures;
+    delivery_result_futures.reserve(messages.size());
+
+    auto deadline = engine::Deadline::FromDuration(delivery_timeout_);
+    for (std::size_t i = 0; i < messages.size(); ++i) {
+        delivery_result_futures.emplace_back(
+            ScheduleMessageDelivery(topic_name, key, messages[i], partition, std::move(headers_holders[i]), deadline)
+        );
+    }
+
+    std::vector<DeliveryResult> delivery_results;
+    delivery_results.reserve(messages.size());
+
+    for (auto& delivery_result_future : delivery_result_futures) {
+        WaitUntilDeliveryReported(delivery_result_future);
+
+        delivery_results.emplace_back(delivery_result_future.get());
+    }
+
+    return delivery_results;
 }
 
 engine::Future<DeliveryResult> ProducerImpl::ScheduleMessageDelivery(
@@ -151,7 +187,8 @@ engine::Future<DeliveryResult> ProducerImpl::ScheduleMessageDelivery(
     std::string_view key,
     std::string_view message,
     std::optional<std::uint32_t> partition,
-    HeadersHolder headers_holder
+    HeadersHolder headers_holder,
+    engine::Deadline deadline
 ) const {
     auto waiter = std::make_unique<DeliveryWaiter>();
     auto wait_handle = waiter->GetFuture();
@@ -181,6 +218,7 @@ engine::Future<DeliveryResult> ProducerImpl::ScheduleMessageDelivery(
     ///
     /// Headers holder **must** be released if `rd_kafka_producev` succeeded.
 
+    while (!deadline.IsReached() && !engine::current_task::ShouldCancel()) {
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-statement-expression"
@@ -203,12 +241,19 @@ engine::Future<DeliveryResult> ProducerImpl::ScheduleMessageDelivery(
 #pragma clang diagnostic pop
 #endif
 
-    if (enqueue_error == RD_KAFKA_RESP_ERR_NO_ERROR) {
-        [[maybe_unused]] const auto headers_holder_ptr = headers_holder.release();
-        [[maybe_unused]] const auto waiter_ptr = waiter.release();
-    } else {
-        LOG_WARNING("Failed to enqueue message to Kafka local queue: {}", rd_kafka_err2str(enqueue_error));
-        waiter->SetDeliveryResult(DeliveryResult{enqueue_error});
+        if (enqueue_error == RD_KAFKA_RESP_ERR_NO_ERROR) {
+            [[maybe_unused]] const auto headers_holder_ptr = headers_holder.release();
+            [[maybe_unused]] const auto waiter_ptr = waiter.release();
+        } else if (enqueue_error == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
+            LOG_LIMITED_WARNING("Kafka local queue is full");
+            /// waiting for a while for the queue to clear up
+            engine::Yield();
+            continue;
+        } else {
+            LOG_WARNING("Failed to enqueue message to Kafka local queue: {}", rd_kafka_err2str(enqueue_error));
+            waiter->SetDeliveryResult(DeliveryResult{enqueue_error});
+        }
+        break;
     }
 
     return wait_handle;

--- a/kafka/src/kafka/impl/producer_impl.hpp
+++ b/kafka/src/kafka/impl/producer_impl.hpp
@@ -6,9 +6,11 @@
 
 #include <librdkafka/rdkafka.h>
 
+#include <userver/engine/deadline.hpp>
 #include <userver/kafka/impl/stats.hpp>
 #include <userver/logging/level.hpp>
 #include <userver/utils/periodic_task.hpp>
+#include <userver/utils/span.hpp>
 
 #include <kafka/impl/concurrent_event_waiter.hpp>
 #include <kafka/impl/delivery_waiter.hpp>
@@ -40,6 +42,16 @@ public:
         HeadersHolder headers
     ) const;
 
+    /// @brief Send messages and waits for its delivery.
+    /// While waiting handles other messages delivery reports, errors and logs.
+    [[nodiscard]] std::vector<DeliveryResult> Send(
+        utils::zstring_view topic_name,
+        std::string_view key,
+        utils::span<const std::string> messages,
+        std::optional<std::uint32_t> partition,
+        std::vector<HeadersHolder> headers
+    ) const;
+
     /// @brief Waits until scheduled messages are delivered for
     /// at most 2 x `delivery_timeout`.
     ///
@@ -58,7 +70,8 @@ private:
         std::string_view key,
         std::string_view message,
         std::optional<std::uint32_t> partition,
-        HeadersHolder headers
+        HeadersHolder headers,
+        engine::Deadline deadline
     ) const;
 
     /// @brief Poll a delivery or error event from producer's queue.

--- a/kafka/src/kafka/impl/producer_impl.hpp
+++ b/kafka/src/kafka/impl/producer_impl.hpp
@@ -63,11 +63,6 @@ public:
     void EventCallback();
 
 private:
-    enum class QueueFullHandlingPolicy {
-        Throw,
-        Retry,
-    };
-
     /// @brief Schedules the message delivery.
     /// @returns the future for delivery result, which must be awaited.
     [[nodiscard]] engine::Future<DeliveryResult> ScheduleMessageDelivery(
@@ -76,8 +71,7 @@ private:
         std::string_view message,
         std::optional<std::uint32_t> partition,
         HeadersHolder headers,
-        engine::Deadline deadline,
-        QueueFullHandlingPolicy queue_full_handling_policy
+        engine::Deadline deadline
     ) const;
 
     /// @brief Poll a delivery or error event from producer's queue.

--- a/kafka/src/kafka/impl/producer_impl.hpp
+++ b/kafka/src/kafka/impl/producer_impl.hpp
@@ -7,10 +7,10 @@
 #include <librdkafka/rdkafka.h>
 
 #include <userver/engine/deadline.hpp>
+#include <userver/kafka/impl/messages.hpp>
 #include <userver/kafka/impl/stats.hpp>
 #include <userver/logging/level.hpp>
 #include <userver/utils/periodic_task.hpp>
-#include <userver/utils/span.hpp>
 
 #include <kafka/impl/concurrent_event_waiter.hpp>
 #include <kafka/impl/delivery_waiter.hpp>
@@ -47,7 +47,7 @@ public:
     [[nodiscard]] std::vector<DeliveryResult> Send(
         utils::zstring_view topic_name,
         std::string_view key,
-        utils::span<const std::string> messages,
+        const Messages& messages,
         std::optional<std::uint32_t> partition,
         std::vector<HeadersHolder> headers
     ) const;
@@ -63,6 +63,11 @@ public:
     void EventCallback();
 
 private:
+    enum class QueueFullHandlingPolicy {
+        Throw,
+        Retry,
+    };
+
     /// @brief Schedules the message delivery.
     /// @returns the future for delivery result, which must be awaited.
     [[nodiscard]] engine::Future<DeliveryResult> ScheduleMessageDelivery(
@@ -71,7 +76,8 @@ private:
         std::string_view message,
         std::optional<std::uint32_t> partition,
         HeadersHolder headers,
-        engine::Deadline deadline
+        engine::Deadline deadline,
+        QueueFullHandlingPolicy queue_full_handling_policy
     ) const;
 
     /// @brief Poll a delivery or error event from producer's queue.

--- a/kafka/src/kafka/producer.cpp
+++ b/kafka/src/kafka/producer.cpp
@@ -7,7 +7,6 @@
 #include <userver/testsuite/testpoint.hpp>
 #include <userver/tracing/span.hpp>
 #include <userver/utils/async.hpp>
-#include <userver/utils/span.hpp>
 #include <userver/utils/text_light.hpp>
 
 #include <kafka/impl/producer_impl.hpp>
@@ -138,18 +137,18 @@ void Producer::Send(
     }).Get();
 }
 
-void Producer::Send(
+void Producer::SendWrapper(
     utils::zstring_view topic_name,
     std::string_view key,
-    utils::span<const std::string> messages,
+    const impl::Messages& messages,
     std::optional<std::uint32_t> partition,
     HeaderViews headers
 ) const {
     utils::Async(
         producer_task_processor_,
         "producer_send_bulk",
-        [this, topic_name, key, messages, partition, &headers] {
-            SendImpl(topic_name, key, messages, partition, BuildHeaderHolders(headers, messages.size()));
+        [this, topic_name, key, &messages, partition, &headers] {
+            SendImpl(topic_name, key, messages, partition, BuildHeaderHolders(headers, messages.Size()));
         }
     ).Get();
 }
@@ -211,7 +210,7 @@ void Producer::SendImpl(
 void Producer::SendImpl(
     utils::zstring_view topic_name,
     std::string_view key,
-    utils::span<const std::string> messages,
+    const impl::Messages& messages,
     std::optional<std::uint32_t> partition,
     std::vector<impl::HeadersHolder>&& headers_holders
 ) const {
@@ -220,12 +219,12 @@ void Producer::SendImpl(
 
     std::vector<std::vector<OwningHeader>> headers_copies;
     if (testsuite::AreTestpointsAvailable()) {
-        for (std::size_t i = 0; i < messages.size(); ++i) {
+        for (std::size_t i = 0; i < messages.Size(); ++i) {
             headers_copies.emplace_back(BuildOwningHeaders(headers_holders[i]));
         }
     }
     if (testsuite::AreTestpointsAvailable()) {
-        for (std::size_t i = 0; i < messages.size(); ++i) {
+        for (std::size_t i = 0; i < messages.Size(); ++i) {
             SendToTestPoint(name_, topic_name, key, messages[i], partition, headers_copies[i], "::started");
         }
     }
@@ -236,7 +235,7 @@ void Producer::SendImpl(
     HandleDeliveryErrors(delivery_results);
 
     if (testsuite::AreTestpointsAvailable()) {
-        for (std::size_t i = 0; i < messages.size(); ++i) {
+        for (std::size_t i = 0; i < messages.Size(); ++i) {
             SendToTestPoint(name_, topic_name, key, messages[i], partition, headers_copies[i]);
         }
     }

--- a/kafka/src/kafka/producer.cpp
+++ b/kafka/src/kafka/producer.cpp
@@ -7,6 +7,7 @@
 #include <userver/testsuite/testpoint.hpp>
 #include <userver/tracing/span.hpp>
 #include <userver/utils/async.hpp>
+#include <userver/utils/span.hpp>
 #include <userver/utils/text_light.hpp>
 
 #include <kafka/impl/producer_impl.hpp>
@@ -54,26 +55,52 @@ void SendToTestPoint(
     }());
 }
 
-[[noreturn]] void ThrowSendError(const impl::DeliveryResult& delivery_result) {
+std::exception_ptr BuildSendError(const impl::DeliveryResult& delivery_result) {
     const auto error = delivery_result.GetMessageError();
     UASSERT(error != RD_KAFKA_RESP_ERR_NO_ERROR);
 
     switch (error) {
         case RD_KAFKA_RESP_ERR__MSG_TIMED_OUT:
-            throw DeliveryTimeoutException{};
+            return std::make_exception_ptr(DeliveryTimeoutException{});
         case RD_KAFKA_RESP_ERR__QUEUE_FULL:
-            throw QueueFullException{};
+            return std::make_exception_ptr(QueueFullException{});
         case RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE:
-            throw MessageTooLargeException{};
+            return std::make_exception_ptr(MessageTooLargeException{});
         case RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC:
-            throw kafka::UnknownTopicException{};
+            return std::make_exception_ptr(UnknownTopicException{});
         case RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION:
-            throw kafka::UnknownPartitionException{};
+            return std::make_exception_ptr(UnknownPartitionException{});
         default:
-            throw kafka::SendException{rd_kafka_err2str(error)};
+            return std::make_exception_ptr(SendException{rd_kafka_err2str(error)});
+    }
+}
+
+[[noreturn]] void ThrowSendError(const impl::DeliveryResult& delivery_result) {
+    std::rethrow_exception(BuildSendError(delivery_result));
+}
+
+auto BuildOwningHeaders(const impl::HeadersHolder& headers) {
+    auto reader = HeadersReader{headers.GetHandle()};
+    return std::vector<OwningHeader>{reader.begin(), reader.end()};
+}
+
+auto BuildHeaderHolders(HeaderViews headers, std::size_t count) {
+    std::vector<impl::HeadersHolder> holders;
+    holders.reserve(count);
+    for (std::size_t i = 0; i < count; ++i) holders.emplace_back(impl::HeadersHolder{headers});
+    return holders;
+}
+
+void HandleDeliveryErrors(const std::vector<impl::DeliveryResult>& delivery_results) {
+    std::map<std::size_t, std::exception_ptr> exceptions;
+    for (std::size_t i = 0; i < delivery_results.size(); ++i) {
+        const auto& delivery_result = delivery_results[i];
+        if (!delivery_result.IsSuccess()) {
+            exceptions[i] = BuildSendError(delivery_result);
+        }
     }
 
-    UASSERT(false);
+    if (!exceptions.empty()) throw BulkSendException{std::move(exceptions)};
 }
 
 }  // namespace
@@ -109,6 +136,22 @@ void Producer::Send(
     utils::Async(producer_task_processor_, "producer_send", [this, topic_name, key, message, partition, &headers] {
         SendImpl(topic_name, key, message, partition, impl::HeadersHolder{headers});
     }).Get();
+}
+
+void Producer::Send(
+    utils::zstring_view topic_name,
+    std::string_view key,
+    utils::span<const std::string> messages,
+    std::optional<std::uint32_t> partition,
+    HeaderViews headers
+) const {
+    utils::Async(
+        producer_task_processor_,
+        "producer_send_bulk",
+        [this, topic_name, key, messages, partition, &headers] {
+            SendImpl(topic_name, key, messages, partition, BuildHeaderHolders(headers, messages.size()));
+        }
+    ).Get();
 }
 
 engine::TaskWithResult<void> Producer::SendAsync(
@@ -148,8 +191,7 @@ void Producer::SendImpl(
 
     std::vector<OwningHeader> headers_copy;
     if (testsuite::AreTestpointsAvailable()) {
-        auto reader = HeadersReader{headers_holder.GetHandle()};
-        headers_copy = std::vector<OwningHeader>{reader.begin(), reader.end()};
+        headers_copy = BuildOwningHeaders(headers_holder);
     }
     if (testsuite::AreTestpointsAvailable()) {
         SendToTestPoint(name_, topic_name, key, message, partition, headers_copy, "::started");
@@ -163,6 +205,40 @@ void Producer::SendImpl(
 
     if (testsuite::AreTestpointsAvailable()) {
         SendToTestPoint(name_, topic_name, key, message, partition, headers_copy);
+    }
+}
+
+void Producer::SendImpl(
+    utils::zstring_view topic_name,
+    std::string_view key,
+    utils::span<const std::string> messages,
+    std::optional<std::uint32_t> partition,
+    std::vector<impl::HeadersHolder>&& headers_holders
+) const {
+    tracing::Span::CurrentSpan().AddTag("kafka_producer", name_);
+    tracing::Span::CurrentSpan().AddTag("kafka_send_key", std::string{key});
+
+    std::vector<std::vector<OwningHeader>> headers_copies;
+    if (testsuite::AreTestpointsAvailable()) {
+        for (std::size_t i = 0; i < messages.size(); ++i) {
+            headers_copies.emplace_back(BuildOwningHeaders(headers_holders[i]));
+        }
+    }
+    if (testsuite::AreTestpointsAvailable()) {
+        for (std::size_t i = 0; i < messages.size(); ++i) {
+            SendToTestPoint(name_, topic_name, key, messages[i], partition, headers_copies[i], "::started");
+        }
+    }
+
+    const std::vector<impl::DeliveryResult> delivery_results =
+        producer_->Send(topic_name, key, messages, partition, std::move(headers_holders));
+
+    HandleDeliveryErrors(delivery_results);
+
+    if (testsuite::AreTestpointsAvailable()) {
+        for (std::size_t i = 0; i < messages.size(); ++i) {
+            SendToTestPoint(name_, topic_name, key, messages[i], partition, headers_copies[i]);
+        }
     }
 }
 

--- a/kafka/tests/producer_kafkatest.cpp
+++ b/kafka/tests/producer_kafkatest.cpp
@@ -16,8 +16,6 @@
 
 USERVER_NAMESPACE_BEGIN
 
-using namespace std::literals;
-
 namespace {
 
 class ProducerTest : public kafka::utest::KafkaCluster {};
@@ -31,7 +29,7 @@ UTEST_F(ProducerTest, OneProducerOneSendSync) {
 
 UTEST_F(ProducerTest, OneProducerBulkSendSync) {
     auto producer = MakeProducer("kafka-producer");
-    UEXPECT_NO_THROW(producer.Send(GenerateTopic(), "test-key", std::vector{"test-msg-1"s, "test-msg-2"s}));
+    UEXPECT_NO_THROW(producer.Send(GenerateTopic(), "test-key", std::vector{"test-msg-1", "test-msg-2"}));
 }
 
 UTEST_F(ProducerTest, OneProducerOneSendAsync) {
@@ -67,7 +65,7 @@ UTEST_F(ProducerTest, OneProducerHeadersBulkSendSync) {
     UEXPECT_NO_THROW(producer.Send(
         GenerateTopic(),
         "test-key",
-        std::vector{"test-msg-1"s, "test-msg-2"s},
+        std::vector<std::string_view>{"test-msg-1", "test-msg-2"},
         /*partition=*/kafka::kUnassignedPartition,
         {{"key-1", "value-1"}, {"key-2", "value-2"}, {"key-3", "value-3"}}
     ));
@@ -208,7 +206,26 @@ UTEST_F(ProducerTest, FullQueue) {
          key = fmt::format("test-key-{}", kMaxQueueMessages),
          message = fmt::format("test-msg-{}", kMaxQueueMessages)] { producer.Send(topic, key, message); };
 
-    UEXPECT_NO_THROW(make_send_request());
+    UEXPECT_THROW(make_send_request(), kafka::QueueFullException);
+
+    /// [Producer retryable error]
+    bool delivered{false};
+    const auto deadline = engine::Deadline::FromDuration(producer_configuration.delivery_timeout);
+    while (!delivered && !deadline.IsReached()) {
+        try {
+            make_send_request();
+            delivered = true;
+        } catch (const kafka::SendException& e) {
+            if (e.IsRetryable()) {
+                engine::InterruptibleSleepFor(std::chrono::milliseconds{10});
+                continue;
+            }
+            break;
+        }
+    }
+    /// [Producer retryable error]
+
+    EXPECT_TRUE(delivered);
     UEXPECT_NO_THROW(engine::WaitAllChecked(results));
 }
 
@@ -284,7 +301,7 @@ UTEST_F(ProducerTest, OneProducerManyBulkSendSync) {
     const auto topic = GenerateTopic();
 
     for (std::size_t send{0}; send < kSendCount; ++send) {
-	auto messages = std::vector{fmt::format("test-msg1-{}", send), fmt::format("test-msg2-{}", send)};
+        auto messages = std::vector{fmt::format("test-msg1-{}", send), fmt::format("test-msg2-{}", send)};
         UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send), messages)) << send;
     }
 }
@@ -347,7 +364,7 @@ UTEST_F(ProducerTest, ManyProducersManyBulkSendSync) {
     for (std::size_t send{0}; send < kSendCount; ++send) {
         const auto& topic = topics.at(send % kTopicCount);
         auto& producer = producers.at(send % kProducerCount);
-	auto messages = std::vector{fmt::format("test-msg1-{}", send), fmt::format("test-msg2-{}", send)};
+        auto messages = std::vector{fmt::format("test-msg1-{}", send), fmt::format("test-msg2-{}", send)};
         UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send), messages)) << send;
     }
 }
@@ -434,7 +451,7 @@ UTEST_F_MT(ProducerTest, OneProducerManyBulkSendSyncMt, 1 + 4) {
     for (std::size_t group{0}; group + 1 < GetThreadCount(); ++group) {
         results.emplace_back(utils::Async(fmt::format("producer_test_send_sync_{}", group), [&producer, &topics] {
             for (std::size_t send{0}; send < kSendPerTask; ++send) {
-		auto messages = std::vector{fmt::format("test-msg1-{}", send), fmt::format("test-msg2-{}", send)};
+                auto messages = std::vector{fmt::format("test-msg1-{}", send), fmt::format("test-msg2-{}", send)};
                 producer.Send(
                     topics.at(send % topics.size()),
                     fmt::format("test-key-{}", send),

--- a/kafka/tests/producer_kafkatest.cpp
+++ b/kafka/tests/producer_kafkatest.cpp
@@ -16,6 +16,8 @@
 
 USERVER_NAMESPACE_BEGIN
 
+using namespace std::literals;
+
 namespace {
 
 class ProducerTest : public kafka::utest::KafkaCluster {};
@@ -25,6 +27,11 @@ class ProducerTest : public kafka::utest::KafkaCluster {};
 UTEST_F(ProducerTest, OneProducerOneSendSync) {
     auto producer = MakeProducer("kafka-producer");
     UEXPECT_NO_THROW(producer.Send(GenerateTopic(), "test-key", "test-msg"));
+}
+
+UTEST_F(ProducerTest, OneProducerBulkSendSync) {
+    auto producer = MakeProducer("kafka-producer");
+    UEXPECT_NO_THROW(producer.Send(GenerateTopic(), "test-key", std::vector{"test-msg-1"s, "test-msg-2"s}));
 }
 
 UTEST_F(ProducerTest, OneProducerOneSendAsync) {
@@ -52,6 +59,17 @@ UTEST_F(ProducerTest, OneProducerHeadersDuplicateKeys) {
         "test-msg",
         /*partition=*/kafka::kUnassignedPartition,
         {{"key-1", "value-1"}, {"key-1", "value-2"}, {"key-1", "value-3"}}
+    ));
+}
+
+UTEST_F(ProducerTest, OneProducerHeadersBulkSendSync) {
+    auto producer = MakeProducer("kafka-producer");
+    UEXPECT_NO_THROW(producer.Send(
+        GenerateTopic(),
+        "test-key",
+        std::vector{"test-msg-1"s, "test-msg-2"s},
+        /*partition=*/kafka::kUnassignedPartition,
+        {{"key-1", "value-1"}, {"key-2", "value-2"}, {"key-3", "value-3"}}
     ));
 }
 
@@ -141,6 +159,18 @@ UTEST_F(ProducerTest, TooLargeMessage) {
     UEXPECT_THROW(producer.Send(GenerateTopic(), big_key, big_message), kafka::MessageTooLargeException);
 }
 
+UTEST_F(ProducerTest, TooLargeMessageBulk) {
+    constexpr std::uint32_t kMessageMaxBytes{3000};
+
+    kafka::impl::ProducerConfiguration producer_configuration{};
+    producer_configuration.message_max_bytes = kMessageMaxBytes;
+
+    auto producer = MakeProducer("kafka-producer", producer_configuration);
+    const std::string small_message{"small-message"};
+    const std::string big_message(kMessageMaxBytes, 'm');
+    UEXPECT_THROW(producer.Send(GenerateTopic(), "test-key", std::vector{big_message, small_message}), kafka::BulkSendException);
+}
+
 UTEST_F(ProducerTest, UnknownPartition) {
     auto producer = MakeProducer("kafka-producer");
     UEXPECT_THROW(
@@ -178,27 +208,26 @@ UTEST_F(ProducerTest, FullQueue) {
          key = fmt::format("test-key-{}", kMaxQueueMessages),
          message = fmt::format("test-msg-{}", kMaxQueueMessages)] { producer.Send(topic, key, message); };
 
-    UEXPECT_THROW(make_send_request(), kafka::QueueFullException);
-
-    /// [Producer retryable error]
-    bool delivered{false};
-    const auto deadline = engine::Deadline::FromDuration(producer_configuration.delivery_timeout);
-    while (!delivered && !deadline.IsReached()) {
-        try {
-            make_send_request();
-            delivered = true;
-        } catch (const kafka::SendException& e) {
-            if (e.IsRetryable()) {
-                engine::InterruptibleSleepFor(std::chrono::milliseconds{10});
-                continue;
-            }
-            break;
-        }
-    }
-    /// [Producer retryable error]
-
-    EXPECT_TRUE(delivered);
+    UEXPECT_NO_THROW(make_send_request());
     UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+}
+
+UTEST_F(ProducerTest, FullQueueBulk) {
+    constexpr std::uint32_t kMaxQueueMessages{7};
+
+    kafka::impl::ProducerConfiguration producer_configuration{};
+    producer_configuration.delivery_timeout = std::chrono::seconds{6};
+    producer_configuration.queue_buffering_max = std::chrono::seconds{3};
+    producer_configuration.queue_buffering_max_messages = kMaxQueueMessages;
+
+    auto producer = MakeProducer("kafka-producer", producer_configuration);
+    const std::string topic = GenerateTopic();
+
+    std::vector<std::string> messages;
+    for (std::uint32_t send{0}; send < kMaxQueueMessages + 1; ++send) {
+        messages.emplace_back(fmt::format("test-msg-{}", send));
+    }
+    UEXPECT_NO_THROW(producer.Send(topic, "test-key", messages));
 }
 
 UTEST_F(ProducerTest, SendCancel) {
@@ -248,6 +277,18 @@ UTEST_F(ProducerTest, OneProducerManySendSync) {
     }
 }
 
+UTEST_F(ProducerTest, OneProducerManyBulkSendSync) {
+    constexpr std::size_t kSendCount{100};
+
+    auto producer = MakeProducer("kafka-producer");
+    const auto topic = GenerateTopic();
+
+    for (std::size_t send{0}; send < kSendCount; ++send) {
+	auto messages = std::vector{fmt::format("test-msg1-{}", send), fmt::format("test-msg2-{}", send)};
+        UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send), messages)) << send;
+    }
+}
+
 UTEST_F(ProducerTest, OneProducerManySendAsync) {
     constexpr std::size_t kSendCount{100};
 
@@ -286,6 +327,28 @@ UTEST_F(ProducerTest, ManyProducersManySendSync) {
         auto& producer = producers.at(send % kProducerCount);
         UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send), fmt::format("test-msg-{}", send))
         ) << send;
+    }
+}
+
+UTEST_F(ProducerTest, ManyProducersManyBulkSendSync) {
+    constexpr std::size_t kProducerCount{4};
+    constexpr std::size_t kSendCount{100};
+    constexpr std::size_t kTopicCount{kSendCount / 10};
+
+    kafka::impl::ProducerConfiguration producer_configuration{};
+    producer_configuration.queue_buffering_max = std::chrono::seconds{0};
+    const std::deque<kafka::Producer> producers = MakeProducers(
+        kProducerCount,
+        [](std::size_t i) { return fmt::format("kafka-producer-{}", i); },
+        producer_configuration
+    );
+    const std::vector<std::string> topics = GenerateTopics(kTopicCount);
+
+    for (std::size_t send{0}; send < kSendCount; ++send) {
+        const auto& topic = topics.at(send % kTopicCount);
+        auto& producer = producers.at(send % kProducerCount);
+	auto messages = std::vector{fmt::format("test-msg1-{}", send), fmt::format("test-msg2-{}", send)};
+        UEXPECT_NO_THROW(producer.Send(topic, fmt::format("test-key-{}", send), messages)) << send;
     }
 }
 
@@ -350,6 +413,32 @@ UTEST_F_MT(ProducerTest, OneProducerManySendSyncMt, 1 + 4) {
                     topics.at(send % topics.size()),
                     fmt::format("test-key-{}", send),
                     fmt::format("test-msg-{}", send)
+                );
+            }
+        }));
+    }
+
+    UEXPECT_NO_THROW(engine::WaitAllChecked(results));
+}
+
+UTEST_F_MT(ProducerTest, OneProducerManyBulkSendSyncMt, 1 + 4) {
+    auto producer = MakeProducer("kafka-producer");
+
+    constexpr std::size_t kSendCount{100};
+    constexpr std::size_t kTopicCount{4};
+    constexpr std::size_t kSendPerTask{kSendCount / kTopicCount};
+    const std::vector<std::string> topics = GenerateTopics(kTopicCount);
+
+    std::vector<engine::TaskWithResult<void>> results;
+    results.reserve(GetThreadCount());
+    for (std::size_t group{0}; group + 1 < GetThreadCount(); ++group) {
+        results.emplace_back(utils::Async(fmt::format("producer_test_send_sync_{}", group), [&producer, &topics] {
+            for (std::size_t send{0}; send < kSendPerTask; ++send) {
+		auto messages = std::vector{fmt::format("test-msg1-{}", send), fmt::format("test-msg2-{}", send)};
+                producer.Send(
+                    topics.at(send % topics.size()),
+                    fmt::format("test-key-{}", send),
+                    messages
                 );
             }
         }));

--- a/kafka/tests/producer_kafkatest.cpp
+++ b/kafka/tests/producer_kafkatest.cpp
@@ -200,32 +200,9 @@ UTEST_F(ProducerTest, FullQueue) {
             .emplace_back(producer.SendAsync(topic, fmt::format("test-key-{}", send), fmt::format("test-msg-{}", send))
             );
     }
-    auto make_send_request =
-        [&producer,
-         &topic,
-         key = fmt::format("test-key-{}", kMaxQueueMessages),
-         message = fmt::format("test-msg-{}", kMaxQueueMessages)] { producer.Send(topic, key, message); };
 
-    UEXPECT_THROW(make_send_request(), kafka::QueueFullException);
-
-    /// [Producer retryable error]
-    bool delivered{false};
-    const auto deadline = engine::Deadline::FromDuration(producer_configuration.delivery_timeout);
-    while (!delivered && !deadline.IsReached()) {
-        try {
-            make_send_request();
-            delivered = true;
-        } catch (const kafka::SendException& e) {
-            if (e.IsRetryable()) {
-                engine::InterruptibleSleepFor(std::chrono::milliseconds{10});
-                continue;
-            }
-            break;
-        }
-    }
-    /// [Producer retryable error]
-
-    EXPECT_TRUE(delivered);
+    UEXPECT_NO_THROW(producer.Send(
+        topic, fmt::format("test-key-{}", kMaxQueueMessages), fmt::format("test-msg-{}", kMaxQueueMessages)));
     UEXPECT_NO_THROW(engine::WaitAllChecked(results));
 }
 

--- a/scripts/kafka/ubuntu_install_kafka.sh
+++ b/scripts/kafka/ubuntu_install_kafka.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 # Exit on any error and treat unset variables as errors, print all commands
-set -euox pipefail
+set -o errexit -o nounset -o pipefail -o posix -x
+
+KAFKA_VERSION=4.0.1
+KAFKA_HOME=/etc/kafka
 
 DEBIAN_FRONTEND=noninteractive sudo apt install -y openjdk-17-jdk
 
-curl https://dlcdn.apache.org/kafka/4.0.1/kafka_2.13-4.0.1.tgz -o kafka.tgz
-mkdir -p /etc/kafka
-tar xf kafka.tgz --directory=/etc/kafka
-cp -r /etc/kafka/kafka_2.13-4.0.1/* /etc/kafka/
-rm -rf /etc/kafka/kafka_2.13-4.0.1
+curl "https://dlcdn.apache.org/kafka/$KAFKA_VERSION/kafka_2.13-$KAFKA_VERSION.tgz" -o kafka.tgz
+mkdir -p "$KAFKA_HOME"
+tar -xzf kafka.tgz --directory="$KAFKA_HOME" --strip-components=1
 rm kafka.tgz


### PR DESCRIPTION
Добавлен метод `Producer::Send` для синхронной отправки пачки сообщений в указанный топик Kafka. В случае ошибки отправки выкидывается исключение `BulkSendException`, которое содержит подробности об ошибках отправки сообщений из пачки.

`Producer::Send` пытается обработать ошибки переполнения локальной очереди librdkafka в пределах настроенного `delivery.timeout.ms`.

В отличие от старых методов `Send` и `SendAsync` метод порождает только одну корутину на всю пачку сообщений.








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

