### PR TITLE
Removed "-dev" from the image name in devcontainer

### DIFF
--- a/service_template/.devcontainer/devcontainer.json
+++ b/service_template/.devcontainer/devcontainer.json
@@ -33,7 +33,7 @@
   "forwardPorts": [
     8080
   ],
-  "image": "ghcr.io/userver-framework/ubuntu-22.04-userver-pg-dev",
+  "image": "ghcr.io/userver-framework/ubuntu-22.04-userver-pg",
   "mounts": [],
   "onCreateCommand": "sudo git config --global --add safe.directory /home/user/service_template",
   "remoteUser": "user",


### PR DESCRIPTION
Users don't need a "dev" devcontainer.