### PR TITLE
Fix missing fmt::join error

### DIFF
--- a/core/src/server/middlewares/graceful_shutdown_headers.cpp
+++ b/core/src/server/middlewares/graceful_shutdown_headers.cpp
@@ -1,6 +1,7 @@
 #include <server/middlewares/graceful_shutdown_headers.hpp>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <dynamic_config/variables/GRACEFUL_SHUTDOWN_HEADERS.hpp>
 


### PR DESCRIPTION
It is just to test the change. Real fix will come from Yandex repo.





------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

