### PR TITLE
Fixed a compile warning into the periodic_task.

### DIFF
--- a/core/src/utils/periodic_task.cpp
+++ b/core/src/utils/periodic_task.cpp
@@ -325,7 +325,7 @@ void StartPeriodicTask(
     if (testsuite_tasks.IsEnabled()) {
         testsuite_tasks.RegisterTask("periodic/" + name, std::move(callback));
     } else {
-        periodic_task.Start(std::move(name), std::move(settings), std::move(callback));
+        periodic_task.Start(std::move(name), settings, std::move(callback));
     }
 }
 


### PR DESCRIPTION
Hello, @apolukhin.

Could you review and accept my change, pls?

[1848/2256] Building CXX object core/CMakeFiles/userver-core.dir/src/utils/periodic_task.cpp.o /home/proydakov/repository/userver/core/src/utils/periodic_task.cpp: In function ‘void userver::v2_16_rc::utils::StartPeriodicTask(PeriodicTask&, std::string, const PeriodicTask::Settings&, PeriodicTask::Callback, userver::v2_16_rc::testsuite::TestsuiteTasks&)’: /home/proydakov/repository/userver/core/src/utils/periodic_task.cpp:328:55: warning: redundant move in initialization [-Wredundant-move]
  328 |         periodic_task.Start(std::move(name), std::move(settings), std::move(callback));
      |                                              ~~~~~~~~~^~~~~~~~~~
/home/proydakov/repository/userver/core/src/utils/periodic_task.cpp:328:55: note: remove ‘std::move’ call
At global scope:

Best regards, Evgeny Proydakov.

------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

