### PR TITLE
fix codegen: fix -flto=auto support for GCC

### DIFF
--- a/cmake/embedded_config.cmake
+++ b/cmake/embedded_config.cmake
@@ -19,12 +19,12 @@ set(TEMPLATE
 __asm__(
 #if defined(__APPLE__)
 \".const_data\\n\"
-\".global _@NAME_C_ESCAPED@_start\\n\"
-\".global _@NAME_C_ESCAPED@_end\\n\"
-\".global _@NAME_C_ESCAPED@_size\\n\"
 #else
 \".section .rodata\\n\"
 #endif
+\".global \" APPLE_PREFIX \"@NAME_C_ESCAPED@_begin\\n\"
+\".global \" APPLE_PREFIX \"@NAME_C_ESCAPED@_end\\n\"
+\".global \" APPLE_PREFIX \"@NAME_C_ESCAPED@_size\\n\"
 \".balign 16\\n\"
 APPLE_PREFIX \"@NAME_C_ESCAPED@_begin:\\n\"
 R\"(


### PR DESCRIPTION
Unify .global directives across platforms and align symbol names with
actual labels (_begin, _end, _size). Previously, macOS used mismatched
_start symbols and non‑Apple platforms omitted .global entirely, causing
link‑time errors when LTO (-flto=auto) was enabled with GCC.

Closes #1151








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

