### PR TITLE
fix httpclient: strip socket flags during socktype equality check

### DIFF
--- a/core/src/curl-ev/easy.cpp
+++ b/core/src/curl-ev/easy.cpp
@@ -106,6 +106,18 @@ bool AddHeaderDoReplace(
     return false;
 }
 
+// Mask out flags, keep only base type (SOCK_STREAM, etc.)
+int StripSocketFlags(int x)
+{
+#ifdef SOCK_CLOEXEC
+    x &= ~SOCK_CLOEXEC;
+#endif
+#ifdef SOCK_NONBLOCK
+    x &= ~SOCK_NONBLOCK;
+#endif
+    return x;
+}
+
 }  // namespace
 
 using BusyMarker = utils::statistics::BusyMarker;
@@ -818,7 +830,7 @@ native::curl_socket_t easy::opensocket(
         LOG_TRACE() << "skip throttle check";
     }
 
-    if (purpose == native::CURLSOCKTYPE_IPCXN && address->socktype == SOCK_STREAM) {
+    if (purpose == native::CURLSOCKTYPE_IPCXN && StripSocketFlags(address->socktype) == SOCK_STREAM) {
         // Note to self: Why is address->protocol always set to zero?
         s = self->open_tcp_socket(address);
         if (s != -1 && multi_handle) {


### PR DESCRIPTION
The previous equality check for socket type did not account for certain flags, causing mismatches. Now we strip those flags before comparing.

Closes #1153








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

