### PR TITLE
docs universal: remove incorrect deprecated tag

### DIFF
--- a/universal/include/userver/utils/meta_light.hpp
+++ b/universal/include/userver/utils/meta_light.hpp
@@ -75,7 +75,6 @@ template <typename T, template <typename...> typename Template>
 concept IsInstantiationOf = impl::IsInstantiationOf<Template, T>::value;
 
 /// @brief Returns `true` if the type (with remove cv-qualifiers) is an instantiation of the specified template.
-/// @deprecated Use @ref meta::IsCvInstantiationOf instead.
 template <typename T, template <typename...> typename Template>
 concept IsCvInstantiationOf = IsInstantiationOf<std::remove_cv_t<T>, Template>;
 


### PR DESCRIPTION
The element references itself.

Probably a copypaste
https://github.com/userver-framework/userver/blob/574b400e40ee5e7cdbc633f2dbbc5f69680ffe60/universal/include/userver/utils/meta_light.hpp#L99-L103