### PR TITLE
fix universal: use std::addressof in FindTransparentOrNullptr

### DIFF
--- a/universal/include/userver/utils/impl/transparent_hash.hpp
+++ b/universal/include/userver/utils/impl/transparent_hash.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <string_view>
 
 #if defined(USERVER_IMPL_ORIGINAL_CXX_STANDARD)
@@ -85,7 +86,7 @@ template <typename TransparentMap, typename Key>
 auto* FindTransparentOrNullptr(TransparentMap&& map, const Key& key) {
     static_assert(!std::is_rvalue_reference_v<TransparentMap>, "Dangling");
     const auto iterator = FindTransparent(map, key);
-    return iterator == map.end() ? nullptr : &iterator->second;
+    return iterator == map.end() ? nullptr : std::addressof(iterator->second);
 }
 
 template <typename TransparentMap, typename Key, typename Value>

--- a/universal/src/utils/impl/transparent_hash_test.cpp
+++ b/universal/src/utils/impl/transparent_hash_test.cpp
@@ -86,6 +86,21 @@ TEST(TransparentMap, FindTransparentOrNullptr) {
     EXPECT_EQ(FindTransparentOrNullptr(const_map, "bar"), nullptr);
 }
 
+TEST(TransparentMap, FindTransparentOrNullptrAddressof) {
+    struct Overloaded {
+        bool used = false;
+        auto operator&() {
+            used = true;
+            return this;
+        };
+    };
+
+    utils::impl::TransparentMap<std::string, Overloaded> m{{{"1"}, {.used = false}}};
+    const auto* ptr = FindTransparentOrNullptr(m, "1");
+    ASSERT_TRUE(ptr);
+    EXPECT_FALSE(ptr->used);
+}
+
 TEST(TransparentMap, CustomValue) {
     using Map = utils::impl::TransparentMap<StringViewable, int>;
     static_assert(meta::IsUniqueMap<Map>);


### PR DESCRIPTION
Fixes #1210