### PR TITLE
fix universal: make ForwardLike conform to the standard

### DIFF
--- a/universal/include/userver/utils/forward_like.hpp
+++ b/universal/include/userver/utils/forward_like.hpp
@@ -4,26 +4,35 @@
 /// @brief @copybrief utils::ForwardLike
 
 #include <type_traits>
-#include <utility>
 
 USERVER_NAMESPACE_BEGIN
 
 namespace utils {
 
-// Analogue of std::forward_like from c++23.
-template <typename TOwner, typename TMember>
-decltype(auto) ForwardLike(TMember& member) {
-    if constexpr (std::is_lvalue_reference_v<TOwner> || std::is_lvalue_reference_v<TMember>) {
-        return member;
-    } else {
-        return std::move(member);
-    }
-}
+namespace impl {
+
+template <typename T, typename U>
+struct ForwardLikeHelper;
+
+template <typename T, typename U>
+struct ForwardLikeHelper<T&, U&> : std::type_identity<U&> {};
+
+template <typename T, typename U>
+struct ForwardLikeHelper<const T&, U&> : std::type_identity<const U&> {};
+
+template <typename T, typename U>
+struct ForwardLikeHelper<T&&, U&> : std::type_identity<U&&> {};
+
+template <typename T, typename U>
+struct ForwardLikeHelper<const T&&, U&> : std::type_identity<const U&&> {};
+
+}  // namespace impl
 
 // Analogue of std::forward_like from c++23.
 template <typename TOwner, typename TMember>
-decltype(auto) ForwardLike(const TMember& member) {
-    return member;
+constexpr auto&& ForwardLike(TMember&& member) noexcept {
+    using RType = impl::ForwardLikeHelper<TOwner&&, TMember&>::type;
+    return static_cast<RType>(member);
 }
 
 }  // namespace utils

--- a/universal/include/userver/utils/struct_subsets.hpp
+++ b/universal/include/userver/utils/struct_subsets.hpp
@@ -34,6 +34,24 @@ constexpr auto IsDefinedAndAggregate(Args...) -> bool {
     return false;
 }
 
+template <typename Superset, typename Field, typename T>
+auto&& GetSupersetField(T &t, InternalTag) noexcept {
+    if constexpr (std::is_reference_v<Field>) {
+        return std::forward<Field>(t);
+    } else {
+        return utils::ForwardLike<Superset>(t);
+    }
+}
+
+template <typename T>
+struct SubsetField : std::type_identity<T> {};
+
+template <typename T>
+struct SubsetFieldRef : std::type_identity<const T&> {};
+
+template <typename T>
+struct SubsetFieldRef<T&&> : std::type_identity<T&&> {};
+
 }  // namespace utils::impl
 
 USERVER_NAMESPACE_END
@@ -41,8 +59,9 @@ USERVER_NAMESPACE_END
 /// @cond
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define USERVER_IMPL_STRUCT_MAP(r, data, elem) \
-    USERVER_NAMESPACE::utils::ForwardLike<OtherDeps, decltype(other.elem)>(other.elem),
+#define USERVER_IMPL_STRUCT_MAP(r, data, elem)                                         \
+    USERVER_NAMESPACE::utils::impl::GetSupersetField<OtherDeps, decltype(other.elem)>( \
+        other.elem, USERVER_NAMESPACE::utils::impl::InternalTag{}),
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define USERVER_IMPL_MAKE_FROM_SUPERSET(Self, ...)                                                     \
@@ -56,14 +75,14 @@ USERVER_NAMESPACE_END
     }
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define USERVER_IMPL_STRUCT_SUBSET_MAP(r, data, elem) \
-    /* NOLINTNEXTLINE(bugprone-macro-parentheses) */  \
-    decltype(data::elem) elem;
+#define USERVER_IMPL_STRUCT_SUBSET_MAP(r, data, elem)                             \
+    /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                              \
+    USERVER_NAMESPACE::utils::impl::SubsetField<decltype(data::elem)>::type elem;
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define USERVER_IMPL_STRUCT_SUBSET_REF_MAP(r, data, elem) \
-    /* NOLINTNEXTLINE(bugprone-macro-parentheses) */      \
-    std::add_const_t<decltype(data::elem)>& elem;
+#define USERVER_IMPL_STRUCT_SUBSET_REF_MAP(r, data, elem)                            \
+    /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                                 \
+    USERVER_NAMESPACE::utils::impl::SubsetFieldRef<decltype(data::elem)>::type elem;
 
 /// @endcond
 

--- a/universal/src/utils/forward_like_test.cpp
+++ b/universal/src/utils/forward_like_test.cpp
@@ -1,0 +1,171 @@
+#include <userver/utils/forward_like.hpp>
+
+#include <type_traits>
+#include <utility>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace {
+    
+template <typename T, typename U>
+using ForwardLikeResult = decltype(utils::ForwardLike<T>(std::declval<U>()));
+
+static_assert(std::is_same_v<ForwardLikeResult<int, int>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, const int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, volatile int>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, const volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, int&>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, const int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, volatile int&>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, const volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, int&&>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, const int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, volatile int&&>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int, const volatile int&&>, const volatile int&&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<const int, int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, const int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, const volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, const int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, const volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, const int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, volatile int&&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int, const volatile int&&>, const volatile int&&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, int>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, const int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, volatile int>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, const volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, int&>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, const int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, volatile int&>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, const volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, int&&>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, const int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, volatile int&&>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int, const volatile int&&>, const volatile int&&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, const int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, const volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, const int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, const volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, const int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, volatile int&&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int, const volatile int&&>, const volatile int&&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<int&, int>, int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, const int>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, volatile int>, volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, const volatile int>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, int&>, int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, const int&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, volatile int&>, volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, const volatile int&>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, int&&>, int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, const int&&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, volatile int&&>, volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&, const volatile int&&>, const volatile int&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<const int&, int>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, const int>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, volatile int>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, const volatile int>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, int&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, const int&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, volatile int&>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, const volatile int&>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, int&&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, const int&&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, volatile int&&>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&, const volatile int&&>, const volatile int&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, int>, int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, const int>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, volatile int>, volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, const volatile int>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, int&>, int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, const int&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, volatile int&>, volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, const volatile int&>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, int&&>, int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, const int&&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, volatile int&&>, volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&, const volatile int&&>, const volatile int&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, int>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, const int>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, volatile int>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, const volatile int>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, int&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, const int&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, volatile int&>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, const volatile int&>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, int&&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, const int&&>, const int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, volatile int&&>, const volatile int&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&, const volatile int&&>, const volatile int&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<int&&, int>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, const int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, volatile int>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, const volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, int&>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, const int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, volatile int&>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, const volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, int&&>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, const int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, volatile int&&>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<int&&, const volatile int&&>, const volatile int&&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, const int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, const volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, const int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, const volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, const int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, volatile int&&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const int&&, const volatile int&&>, const volatile int&&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, int>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, const int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, volatile int>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, const volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, int&>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, const int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, volatile int&>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, const volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, int&&>, int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, const int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, volatile int&&>, volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<volatile int&&, const volatile int&&>, const volatile int&&>);
+
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, const int>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, const volatile int>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, const int&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, const volatile int&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, const int&&>, const int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, volatile int&&>, const volatile int&&>);
+static_assert(std::is_same_v<ForwardLikeResult<const volatile int&&, const volatile int&&>, const volatile int&&>);
+
+}  // namespace
+
+USERVER_NAMESPACE_END

--- a/universal/src/utils/struct_subsets_test.cpp
+++ b/universal/src/utils/struct_subsets_test.cpp
@@ -4,6 +4,8 @@
 
 #include <userver/utils/from_string.hpp>
 
+#include <utility>
+
 USERVER_NAMESPACE_BEGIN
 
 namespace {
@@ -234,6 +236,146 @@ TEST(DefineStructSubsetRef, Sample) {
     EXPECT_EQ(Bar(dependencies), 4);
     /// [ref usage]
 }
+
+namespace rvalue {
+
+struct Movable {
+    int value;
+    Movable(int v) : value(v) {}
+    Movable(Movable&& that) noexcept : value(std::exchange(that.value, 0)) {}
+};
+
+struct Deps {
+    Movable a;
+    Movable& b;
+    Movable&& c;
+    const Movable&& d;
+
+    USERVER_ALLOW_CONVERSIONS_TO_SUBSET();
+};
+
+struct TestData {
+    Movable b{42};
+    Movable c{43};
+    Movable d{44};
+    Deps deps = {.a = {41}, .b = b, .c = std::move(c), .d = std::move(d)};
+};
+
+USERVER_DEFINE_STRUCT_SUBSET(SmolDeps, Deps, c, d);
+
+static_assert(std::is_same_v<decltype(SmolDeps::c), Movable&&>);
+static_assert(std::is_same_v<decltype(SmolDeps::d), const Movable&&>);
+
+TEST(DefineStructSubset, RRefCopy) {
+    TestData data;
+    auto& [b, c, d, deps] = data;
+
+    SmolDeps smol = deps;
+    EXPECT_EQ(deps.a.value, 41);
+    EXPECT_EQ(deps.b.value, 42);
+    EXPECT_EQ(deps.c.value, 43);
+    EXPECT_EQ(deps.d.value, 44);
+    smol.c.value = 1;
+    EXPECT_EQ(c.value, 1);
+}
+
+TEST(DefineStructSubset, RRefCopyConst) {
+    TestData data;
+    const auto& [b, c, d, deps] = data;
+
+    SmolDeps smol = deps;
+    EXPECT_EQ(deps.a.value, 41);
+    EXPECT_EQ(deps.b.value, 42);
+    EXPECT_EQ(deps.c.value, 43);
+    EXPECT_EQ(deps.d.value, 44);
+    smol.c.value = 1;
+    EXPECT_EQ(c.value, 1);
+}
+
+TEST(DefineStructSubset, RRefMove) {
+    TestData data;
+    auto& [b, c, d, deps] = data;
+
+    SmolDeps smol = std::move(deps);
+    EXPECT_EQ(deps.a.value, 41);
+    EXPECT_EQ(deps.b.value, 42);
+    EXPECT_EQ(deps.c.value, 43);
+    EXPECT_EQ(deps.d.value, 44);
+    smol.c.value = 1;
+    EXPECT_EQ(c.value, 1);
+}
+
+TEST(DefineStructSubset, RRefMoveConst) {
+    TestData data;
+    const auto& [b, c, d, deps] = data;
+
+    SmolDeps smol = std::move(deps);
+    EXPECT_EQ(deps.a.value, 41);
+    EXPECT_EQ(deps.b.value, 42);
+    EXPECT_EQ(deps.c.value, 43);
+    EXPECT_EQ(deps.d.value, 44);
+    smol.c.value = 1;
+    EXPECT_EQ(c.value, 1);
+}
+
+USERVER_DEFINE_STRUCT_SUBSET(SmolDepsRef, Deps, c, d);
+
+static_assert(std::is_same_v<decltype(SmolDepsRef::c), Movable&&>);
+static_assert(std::is_same_v<decltype(SmolDepsRef::d), const Movable&&>);
+
+TEST(DefineStructSubsetRef, RRefCopy) {
+    TestData data;
+    auto& [b, c, d, deps] = data;
+
+    SmolDepsRef smol = deps;
+    EXPECT_EQ(deps.a.value, 41);
+    EXPECT_EQ(deps.b.value, 42);
+    EXPECT_EQ(deps.c.value, 43);
+    EXPECT_EQ(deps.d.value, 44);
+    smol.c.value = 1;
+    EXPECT_EQ(c.value, 1);
+}
+
+TEST(DefineStructSubsetRef, RRefCopyConst) {
+    TestData data;
+    const auto& [b, c, d, deps] = data;
+
+    SmolDepsRef smol = deps;
+    EXPECT_EQ(deps.a.value, 41);
+    EXPECT_EQ(deps.b.value, 42);
+    EXPECT_EQ(deps.c.value, 43);
+    EXPECT_EQ(deps.d.value, 44);
+    smol.c.value = 1;
+    EXPECT_EQ(c.value, 1);
+}
+
+TEST(DefineStructSubsetRef, RRefMove) {
+    TestData data;
+    auto& [b, c, d, deps] = data;
+
+    SmolDepsRef smol = std::move(deps);
+    EXPECT_EQ(deps.a.value, 41);
+    EXPECT_EQ(deps.b.value, 42);
+    EXPECT_EQ(deps.c.value, 43);
+    EXPECT_EQ(deps.d.value, 44);
+    smol.c.value = 1;
+    EXPECT_EQ(c.value, 1);
+}
+
+TEST(DefineStructSubsetRef, RRefMoveConst) {
+    TestData data;
+    const auto& [b, c, d, deps] = data;
+
+    SmolDepsRef smol = std::move(deps);
+    EXPECT_EQ(deps.a.value, 41);
+    EXPECT_EQ(deps.b.value, 42);
+    EXPECT_EQ(deps.c.value, 43);
+    EXPECT_EQ(deps.d.value, 44);
+    smol.c.value = 1;
+    EXPECT_EQ(c.value, 1);
+}
+
+}  // namespace rvalue
 
 }  // namespace
 


### PR DESCRIPTION
Fixes #1202

(Optional) Additionally, added support for `&&` members in `USERVER_IMPL_STRUCT_SUBSET_(REF_)MAP`