### PR TITLE
docs universal: adjust RateCounter description

### DIFF
--- a/universal/include/userver/utils/statistics/rate_counter.hpp
+++ b/universal/include/userver/utils/statistics/rate_counter.hpp
@@ -15,7 +15,7 @@ class Writer;
 
 /// @ingroup userver_universal
 ///
-/// @brief Atomic counter of type Rate with relaxed memory ordering
+/// @brief Atomic counter of type Rate with relaxed memory ordering by default
 ///
 /// This class is represented as Rate metric when serializing to statistics.
 /// Otherwise it is the same class as @ref utils::statistics::RelaxedCounter.


### PR DESCRIPTION
https://github.com/userver-framework/userver/blob/5bcfaae06449e642a098b6738aa3296fd6166496/universal/include/userver/utils/statistics/rate_counter.hpp#L48
https://github.com/userver-framework/userver/blob/5bcfaae06449e642a098b6738aa3296fd6166496/universal/include/userver/utils/statistics/rate_counter.hpp#L54
These parameters were added in [this commit](https://github.com/userver-framework/userver/commit/e74e89ee910c64ad703c09f62466d9c59723bdf4), and then turned out to be unnecessary in [this one](https://github.com/userver-framework/userver/commit/05dbbb9d913a804c7bce066b8e164fbc037068ea).

Since they are no longer in use and their presence contradicts [the class description](https://github.com/userver-framework/userver/blob/5bcfaae06449e642a098b6738aa3296fd6166496/universal/include/userver/utils/statistics/rate_counter.hpp#L18), they should be deleted.