### PR TITLE
debian trixie doesn't have libgrpc++1, use libgrpc++1.51t64 instead

### DIFF
--- a/scripts/docs/en/deps/debian-13.md
+++ b/scripts/docs/en/deps/debian-13.md
@@ -18,7 +18,7 @@ libcurl4-openssl-dev
 libev-dev
 libfmt-dev
 libgmock-dev
-libgrpc++1
+libgrpc++1.51t64
 libgrpc++-dev
 libgrpc-dev
 libgtest-dev


### PR DESCRIPTION
following the official instruction ([debian 13](https://userver.tech/de/db9/md_en_2userver_2build_2dependencies.html#autotoc_md183)), it fails to install on debian trixie:
```
6.292 Error: Unable to locate package libgrpc++1
```
apparently, debian changed package names at some point, and t64 suffix denotes fix for problem 2038 (see also [64-bit time](https://wiki.debian.org/ReleaseGoals/64bit-time)), as packages had to change their ABI