### PR TITLE
feat build: on debian trixie, system abseil package uses its own string_view

### DIFF
--- a/universal/src/utils/regex.cpp
+++ b/universal/src/utils/regex.cpp
@@ -7,6 +7,7 @@
 
 #include <fmt/format.h>
 #include <re2/re2.h>
+#include <re2/stringpiece.h>
 #include <boost/container/small_vector.hpp>
 
 #include <userver/utils/assert.hpp>
@@ -37,6 +38,10 @@ re2::RE2::Options MakeRE2Options() {
     return options;
 }
 
+re2::StringPiece ToRE2(std::string_view s) noexcept {
+    return {s.data(), s.size()};
+}
+
 }  // namespace
 
 class regex::Impl {
@@ -44,7 +49,7 @@ public:
     Impl() = default;
 
     explicit Impl(std::string_view pattern)
-        : regex_(std::make_shared<const re2::RE2>(pattern, MakeRE2Options()))
+        : regex_(std::make_shared<const re2::RE2>(ToRE2(pattern), MakeRE2Options()))
     {
         if (regex_->ok()) {
             return;
@@ -151,25 +156,25 @@ std::string_view match_results::suffix() const {
 
 ////////////////////////////////////////////////////////////////
 
-bool regex_match(std::string_view str, const regex& pattern) { return re2::RE2::FullMatch(str, pattern.impl_->Get()); }
+bool regex_match(std::string_view str, const regex& pattern) { return re2::RE2::FullMatch(ToRE2(str), pattern.impl_->Get()); }
 
 bool regex_match(std::string_view str, match_results& m, const regex& pattern) {
     m.impl_->Prepare(str, pattern);
     const bool success =
         pattern.impl_->Get()
-            .Match(str, 0, str.size(), re2::RE2::Anchor::ANCHOR_BOTH, m.impl_->groups.data(), m.impl_->groups.size());
+            .Match(ToRE2(str), 0, str.size(), re2::RE2::Anchor::ANCHOR_BOTH, m.impl_->groups.data(), m.impl_->groups.size());
     return success;
 }
 
 bool regex_search(std::string_view str, const regex& pattern) {
-    return re2::RE2::PartialMatch(str, pattern.impl_->Get());
+    return re2::RE2::PartialMatch(ToRE2(str), pattern.impl_->Get());
 }
 
 bool regex_search(std::string_view str, match_results& m, const regex& pattern) {
     m.impl_->Prepare(str, pattern);
     const bool success =
         pattern.impl_->Get()
-            .Match(str, 0, str.size(), re2::RE2::Anchor::UNANCHORED, m.impl_->groups.data(), m.impl_->groups.size());
+            .Match(ToRE2(str), 0, str.size(), re2::RE2::Anchor::UNANCHORED, m.impl_->groups.data(), m.impl_->groups.size());
     return success;
 }
 
@@ -181,7 +186,7 @@ std::string regex_replace(std::string_view str, const regex& pattern, std::strin
     re2::StringPiece match;
 
     while (true) {
-        const bool success = regex.Match(str, 0, str.size(), re2::RE2::Anchor::UNANCHORED, &match, 1);
+        const bool success = regex.Match(ToRE2(str), 0, str.size(), re2::RE2::Anchor::UNANCHORED, &match, 1);
         if (!success) {
             res += str;
             break;
@@ -210,7 +215,7 @@ std::string regex_replace(std::string_view str, const regex& pattern, Re2Replace
     res.reserve(str.size() + str.size() / 4);
 
     res.assign(str);
-    re2::RE2::GlobalReplace(&res, pattern.impl_->Get(), repl.replacement);
+    re2::RE2::GlobalReplace(&res, pattern.impl_->Get(), ToRE2(repl.replacement));
 
     return res;
 }


### PR DESCRIPTION
there were some compiler errors appear when I try to trying to build userver on debian 13 trixie:

<details>
  <summary>error message</summary>

```
#8 54.15 FAILED: universal/CMakeFiles/userver-universal.dir/src/utils/regex.cpp.o 
#8 54.15 /usr/bin/ccache /usr/bin/c++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_ENABLE_ASSERT_HANDLER -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_STACKTRACE_BACKTRACE_DYN_LINK -DBOOST_STACKTRACE_BACKTRACE_NO_LIB -DBOOST_STACKTRACE_LINK -DCRYPTOPP_ENABLE_NAMESPACE_WEAK=1 -DOPENSSL_SUPPRESS_DEPRECATED="" -DPIC=1 -DUSERVER=1 -DUSERVER_NAMESPACE=userver -DUSERVER_NAMESPACE_BEGIN="namespace userver { inline namespace v3_1_rc { " -DUSERVER_NAMESPACE_END="} }" -D_GLIBCXX_ASSERTIONS -I/userver/universal/include -I/userver/third_party/function_backports/include -I/userver/third_party/move_only_function_backport/include -I/userver/universal/src -I/userver/build_debug/universal -I/userver/build_debug/universal/gdb_autogen -I/userver/scripts/gdb/include -isystem /userver/third_party/rapidjson/include -isystem /usr/include/c++/14 -isystem /usr/include/x86_64-linux-gnu/c++/14 -isystem /usr/include/c++/14/backward -isystem /usr/lib/gcc/x86_64-linux-gnu/14/include -isystem /usr/local/include -isystem /usr/include/x86_64-linux-gnu -isystem /usr/include -g -std=c++20 -fvisibility-inlines-hidden -pipe -g -fPIC -fdata-sections -ffunction-sections -gz=zstd -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize=address -static-libasan -mcx16 -Wall -Wextra -Wpedantic -ftemplate-backtrace-limit=0 -Wdisabled-optimization -Winvalid-pch -Wimplicit-fallthrough -Wlogical-op -Wformat=2 -Wno-error=deprecated-declarations -Wno-useless-cast -Wno-psabi -fmacro-prefix-map=/userver/build_debug/= -fmacro-prefix-map=/= -MD -MT universal/CMakeFiles/userver-universal.dir/src/utils/regex.cpp.o -MF universal/CMakeFiles/userver-universal.dir/src/utils/regex.cpp.o.d -fmodules-ts -fmodule-mapper=universal/CMakeFiles/userver-universal.dir/src/utils/regex.cpp.o.modmap -MD -fdeps-format=p1689r5 -x c++ -o universal/CMakeFiles/userver-universal.dir/src/utils/regex.cpp.o -c /userver/universal/src/utils/regex.cpp
#8 54.15 /userver/universal/src/utils/regex.cpp: In function 'bool userver::v3_1_rc::utils::regex_match(std::string_view, const regex&)':
#8 54.15 /userver/universal/src/utils/regex.cpp:154:90: error: no matching function for call to 're2::RE2::FullMatch(std::string_view&, const re2::RE2&)'
#8 54.15   154 | bool regex_match(std::string_view str, const regex& pattern) { return re2::RE2::FullMatch(str, pattern.impl_->Get()); }
#8 54.15       |                                                                       ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 In file included from /userver/universal/src/utils/regex.cpp:9:
#8 54.15 /usr/include/re2/re2.h:411:15: note: candidate: 'template<class ... A> static bool re2::RE2::FullMatch(absl::debian7::string_view, const re2::RE2&, A&& ...)'
#8 54.15   411 |   static bool FullMatch(absl::string_view text, const RE2& re, A&&... a) {
#8 54.15       |               ^~~~~~~~~
#8 54.15 /usr/include/re2/re2.h:411:15: note:   template argument deduction/substitution failed:
#8 54.15 /userver/universal/src/utils/regex.cpp:154:91: note:   cannot convert 'str' (type 'std::string_view' {aka 'std::basic_string_view<char>'}) to type 'absl::debian7::string_view'
#8 54.15   154 | bool regex_match(std::string_view str, const regex& pattern) { return re2::RE2::FullMatch(str, pattern.impl_->Get()); }
#8 54.15       |                                                                                           ^~~
#8 54.15 /userver/universal/src/utils/regex.cpp: In function 'bool userver::v3_1_rc::utils::regex_match(std::string_view, match_results&, const regex&)':
#8 54.15 /userver/universal/src/utils/regex.cpp:160:20: error: cannot convert 'std::string_view' {aka 'std::basic_string_view<char>'} to 'absl::debian7::string_view'
#8 54.15   160 |             .Match(str, 0, str.size(), re2::RE2::Anchor::ANCHOR_BOTH, m.impl_->groups.data(), m.impl_->groups.size());
#8 54.15       |                    ^~~
#8 54.15       |                    |
#8 54.15       |                    std::string_view {aka std::basic_string_view<char>}
#8 54.15 /usr/include/re2/re2.h:585:32: note:   initializing argument 1 of 'bool re2::RE2::Match(absl::debian7::string_view, size_t, size_t, Anchor, absl::debian7::string_view*, int) const'
#8 54.15   585 |   bool Match(absl::string_view text,
#8 54.15       |              ~~~~~~~~~~~~~~~~~~^~~~
#8 54.15 /userver/universal/src/utils/regex.cpp: In function 'bool userver::v3_1_rc::utils::regex_search(std::string_view, const regex&)':
#8 54.15 /userver/universal/src/utils/regex.cpp:165:34: error: no matching function for call to 're2::RE2::PartialMatch(std::string_view&, const re2::RE2&)'
#8 54.15   165 |     return re2::RE2::PartialMatch(str, pattern.impl_->Get());
#8 54.15       |            ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/re2/re2.h:427:15: note: candidate: 'template<class ... A> static bool re2::RE2::PartialMatch(absl::debian7::string_view, const re2::RE2&, A&& ...)'
#8 54.15   427 |   static bool PartialMatch(absl::string_view text, const RE2& re, A&&... a) {
#8 54.15       |               ^~~~~~~~~~~~
#8 54.15 /usr/include/re2/re2.h:427:15: note:   template argument deduction/substitution failed:
#8 54.15 /userver/universal/src/utils/regex.cpp:165:35: note:   cannot convert 'str' (type 'std::string_view' {aka 'std::basic_string_view<char>'}) to type 'absl::debian7::string_view'
#8 54.15   165 |     return re2::RE2::PartialMatch(str, pattern.impl_->Get());
#8 54.15       |                                   ^~~
#8 54.15 /userver/universal/src/utils/regex.cpp: In function 'bool userver::v3_1_rc::utils::regex_search(std::string_view, match_results&, const regex&)':
#8 54.15 /userver/universal/src/utils/regex.cpp:172:20: error: cannot convert 'std::string_view' {aka 'std::basic_string_view<char>'} to 'absl::debian7::string_view'
#8 54.15   172 |             .Match(str, 0, str.size(), re2::RE2::Anchor::UNANCHORED, m.impl_->groups.data(), m.impl_->groups.size());
#8 54.15       |                    ^~~
#8 54.15       |                    |
#8 54.15       |                    std::string_view {aka std::basic_string_view<char>}
#8 54.15 /usr/include/re2/re2.h:585:32: note:   initializing argument 1 of 'bool re2::RE2::Match(absl::debian7::string_view, size_t, size_t, Anchor, absl::debian7::string_view*, int) const'
#8 54.15   585 |   bool Match(absl::string_view text,
#8 54.15       |              ~~~~~~~~~~~~~~~~~~^~~~
#8 54.15 /userver/universal/src/utils/regex.cpp: In function 'std::string userver::v3_1_rc::utils::regex_replace(std::string_view, const regex&, std::string_view)':
#8 54.15 /userver/universal/src/utils/regex.cpp:184:42: error: cannot convert 'std::string_view' {aka 'std::basic_string_view<char>'} to 'absl::debian7::string_view'
#8 54.15   184 |         const bool success = regex.Match(str, 0, str.size(), re2::RE2::Anchor::UNANCHORED, &match, 1);
#8 54.15       |                                          ^~~
#8 54.15       |                                          |
#8 54.15       |                                          std::string_view {aka std::basic_string_view<char>}
#8 54.15 /usr/include/re2/re2.h:585:32: note:   initializing argument 1 of 'bool re2::RE2::Match(absl::debian7::string_view, size_t, size_t, Anchor, absl::debian7::string_view*, int) const'
#8 54.15   585 |   bool Match(absl::string_view text,
#8 54.15       |              ~~~~~~~~~~~~~~~~~~^~~~
#8 54.15 /userver/universal/src/utils/regex.cpp: In function 'std::string userver::v3_1_rc::utils::regex_replace(std::string_view, const regex&, Re2Replacement)':
#8 54.15 /userver/universal/src/utils/regex.cpp:213:62: error: cannot convert 'std::string_view' {aka 'std::basic_string_view<char>'} to 'absl::debian7::string_view'
#8 54.15   213 |     re2::RE2::GlobalReplace(&res, pattern.impl_->Get(), repl.replacement);
#8 54.15       |                                                         ~~~~~^~~~~~~~~~~
#8 54.15       |                                                              |
#8 54.15       |                                                              std::string_view {aka std::basic_string_view<char>}
#8 54.15 /usr/include/re2/re2.h:499:46: note:   initializing argument 3 of 'static int re2::RE2::GlobalReplace(std::string*, const re2::RE2&, absl::debian7::string_view)'
#8 54.15   499 |                            absl::string_view rewrite);
#8 54.15       |                            ~~~~~~~~~~~~~~~~~~^~~~~~~
#8 54.15 In file included from /usr/include/c++/14/bits/char_traits.h:57,
#8 54.15                  from /usr/include/c++/14/string_view:48,
#8 54.15                  from /userver/universal/include/userver/utils/regex.hpp:8,
#8 54.15                  from /userver/universal/src/utils/regex.cpp:1:
#8 54.15 /usr/include/c++/14/bits/stl_construct.h: In instantiation of 'constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = const re2::RE2; _Args = {basic_string_view<char, char_traits<char> >&, re2::RE2::Options}]':
#8 54.15 /usr/include/c++/14/bits/alloc_traits.h:706:19:   required from 'static constexpr void std::allocator_traits<std::allocator<void> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = const re2::RE2; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; allocator_type = std::allocator<void>]'
#8 54.15   706 |         { std::_Construct(__p, std::forward<_Args>(__args)...); }
#8 54.15       |           ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/shared_ptr_base.h:607:39:   required from 'std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; _Tp = const re2::RE2; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]'
#8 54.15   607 |           allocator_traits<_Alloc>::construct(__a, _M_ptr(),
#8 54.15       |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
#8 54.15   608 |               std::forward<_Args>(__args)...); // might throw
#8 54.15       |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
#8 54.15 /usr/include/c++/14/bits/shared_ptr_base.h:969:16:   required from 'std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = const re2::RE2; _Alloc = std::allocator<void>; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]'
#8 54.15   969 |           auto __pi = ::new (__mem)
#8 54.15       |                       ^~~~~~~~~~~~~
#8 54.15   970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
#8 54.15       |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/shared_ptr_base.h:1713:14:   required from 'std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; _Tp = const re2::RE2; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]'
#8 54.15  1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
#8 54.15       |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/shared_ptr.h:463:59:   required from 'std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; _Tp = const re2::RE2]'
#8 54.15   463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
#8 54.15       |                                                                  ^
#8 54.15 /usr/include/c++/14/bits/shared_ptr.h:1007:14:   required from 'std::shared_ptr<std::_NonArray<_Tp> > std::make_shared(_Args&& ...) [with _Tp = const re2::RE2; _Args = {basic_string_view<char, char_traits<char> >&, re2::RE2::Options}; _NonArray<_Tp> = const re2::RE2]'
#8 54.15  1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
#8 54.15       |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15  1008 |                              std::forward<_Args>(__args)...);
#8 54.15       |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /userver/universal/src/utils/regex.cpp:47:50:   required from here
#8 54.15    47 |         : regex_(std::make_shared<const re2::RE2>(pattern, MakeRE2Options()))
#8 54.15       |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/stl_construct.h:115:28: error: no matching function for call to 'construct_at(const re2::RE2*&, std::basic_string_view<char>&, re2::RE2::Options)'
#8 54.15   115 |           std::construct_at(__p, std::forward<_Args>(__args)...);
#8 54.15       |           ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/stl_construct.h:94:5: note: candidate: 'template<class _Tp, class ... _Args> constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...)'
#8 54.15    94 |     construct_at(_Tp* __location, _Args&&... __args)
#8 54.15       |     ^~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/stl_construct.h:94:5: note:   template argument deduction/substitution failed:
#8 54.15 /usr/include/c++/14/bits/stl_construct.h: In substitution of 'template<class _Tp, class ... _Args> constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...) [with _Tp = const re2::RE2; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}]':
#8 54.15 /usr/include/c++/14/bits/stl_construct.h:115:21:   required from 'constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = const re2::RE2; _Args = {basic_string_view<char, char_traits<char> >&, re2::RE2::Options}]'
#8 54.15   115 |           std::construct_at(__p, std::forward<_Args>(__args)...);
#8 54.15       |           ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/alloc_traits.h:706:19:   required from 'static constexpr void std::allocator_traits<std::allocator<void> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = const re2::RE2; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; allocator_type = std::allocator<void>]'
#8 54.15   706 |         { std::_Construct(__p, std::forward<_Args>(__args)...); }
#8 54.15       |           ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/shared_ptr_base.h:607:39:   required from 'std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; _Tp = const re2::RE2; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]'
#8 54.15   607 |           allocator_traits<_Alloc>::construct(__a, _M_ptr(),
#8 54.15       |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
#8 54.15   608 |               std::forward<_Args>(__args)...); // might throw
#8 54.15       |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
#8 54.15 /usr/include/c++/14/bits/shared_ptr_base.h:969:16:   required from 'std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = const re2::RE2; _Alloc = std::allocator<void>; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]'
#8 54.15   969 |           auto __pi = ::new (__mem)
#8 54.15       |                       ^~~~~~~~~~~~~
#8 54.15   970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
#8 54.15       |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/shared_ptr_base.h:1713:14:   required from 'std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; _Tp = const re2::RE2; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]'
#8 54.15  1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
#8 54.15       |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/shared_ptr.h:463:59:   required from 'std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; _Tp = const re2::RE2]'
#8 54.15   463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
#8 54.15       |                                                                  ^
#8 54.15 /usr/include/c++/14/bits/shared_ptr.h:1007:14:   required from 'std::shared_ptr<std::_NonArray<_Tp> > std::make_shared(_Args&& ...) [with _Tp = const re2::RE2; _Args = {basic_string_view<char, char_traits<char> >&, re2::RE2::Options}; _NonArray<_Tp> = const re2::RE2]'
#8 54.15  1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
#8 54.15       |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15  1008 |                              std::forward<_Args>(__args)...);
#8 54.15       |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /userver/universal/src/utils/regex.cpp:47:50:   required from here
#8 54.15    47 |         : regex_(std::make_shared<const re2::RE2>(pattern, MakeRE2Options()))
#8 54.15       |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/stl_construct.h:96:17: error: no matching function for call to 're2::RE2::RE2(std::basic_string_view<char>&, re2::RE2::Options)'
#8 54.15    96 |     -> decltype(::new((void*)0) _Tp(std::declval<_Args>()...))
#8 54.15       |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/re2/re2.h:289:3: note: candidate: 're2::RE2::RE2(absl::debian7::string_view, const Options&)'
#8 54.15   289 |   RE2(absl::string_view pattern, const Options& options);
#8 54.15       |   ^~~
#8 54.15 /usr/include/re2/re2.h:289:25: note:   no known conversion for argument 1 from 'std::basic_string_view<char>' to 'absl::debian7::string_view'
#8 54.15   289 |   RE2(absl::string_view pattern, const Options& options);
#8 54.15       |       ~~~~~~~~~~~~~~~~~~^~~~~~~
#8 54.15 /usr/include/re2/re2.h:288:3: note: candidate: 're2::RE2::RE2(absl::debian7::string_view)'
#8 54.15   288 |   RE2(absl::string_view pattern);
#8 54.15       |   ^~~
#8 54.15 /usr/include/re2/re2.h:288:3: note:   candidate expects 1 argument, 2 provided
#8 54.15 /usr/include/re2/re2.h:287:3: note: candidate: 're2::RE2::RE2(const std::string&)'
#8 54.15   287 |   RE2(const std::string& pattern);
#8 54.15       |   ^~~
#8 54.15 /usr/include/re2/re2.h:287:3: note:   candidate expects 1 argument, 2 provided
#8 54.15 /usr/include/re2/re2.h:286:3: note: candidate: 're2::RE2::RE2(const char*)'
#8 54.15   286 |   RE2(const char* pattern);
#8 54.15       |   ^~~
#8 54.15 /usr/include/re2/re2.h:286:3: note:   candidate expects 1 argument, 2 provided
#8 54.15 /usr/include/c++/14/bits/stl_construct.h: In instantiation of 'constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = const re2::RE2; _Args = {basic_string_view<char, char_traits<char> >&, re2::RE2::Options}]':
#8 54.15 /usr/include/c++/14/bits/alloc_traits.h:706:19:   required from 'static constexpr void std::allocator_traits<std::allocator<void> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = const re2::RE2; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; allocator_type = std::allocator<void>]'
#8 54.15   706 |         { std::_Construct(__p, std::forward<_Args>(__args)...); }
#8 54.15       |           ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/shared_ptr_base.h:607:39:   required from 'std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; _Tp = const re2::RE2; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]'
#8 54.15   607 |           allocator_traits<_Alloc>::construct(__a, _M_ptr(),
#8 54.15       |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
#8 54.15   608 |               std::forward<_Args>(__args)...); // might throw
#8 54.15       |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
#8 54.15 /usr/include/c++/14/bits/shared_ptr_base.h:969:16:   required from 'std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = const re2::RE2; _Alloc = std::allocator<void>; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]'
#8 54.15   969 |           auto __pi = ::new (__mem)
#8 54.15       |                       ^~~~~~~~~~~~~
#8 54.15   970 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
#8 54.15       |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/shared_ptr_base.h:1713:14:   required from 'std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; _Tp = const re2::RE2; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]'
#8 54.15  1713 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
#8 54.15       |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/shared_ptr.h:463:59:   required from 'std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {std::basic_string_view<char, std::char_traits<char> >&, re2::RE2::Options}; _Tp = const re2::RE2]'
#8 54.15   463 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
#8 54.15       |                                                                  ^
#8 54.15 /usr/include/c++/14/bits/shared_ptr.h:1007:14:   required from 'std::shared_ptr<std::_NonArray<_Tp> > std::make_shared(_Args&& ...) [with _Tp = const re2::RE2; _Args = {basic_string_view<char, char_traits<char> >&, re2::RE2::Options}; _NonArray<_Tp> = const re2::RE2]'
#8 54.15  1007 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
#8 54.15       |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15  1008 |                              std::forward<_Args>(__args)...);
#8 54.15       |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /userver/universal/src/utils/regex.cpp:47:50:   required from here
#8 54.15    47 |         : regex_(std::make_shared<const re2::RE2>(pattern, MakeRE2Options()))
#8 54.15       |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/c++/14/bits/stl_construct.h:119:7: error: no matching function for call to 're2::RE2::RE2(std::basic_string_view<char>&, re2::RE2::Options)'
#8 54.15   119 |       ::new((void*)__p) _Tp(std::forward<_Args>(__args)...);
#8 54.15       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 54.15 /usr/include/re2/re2.h:289:3: note: candidate: 're2::RE2::RE2(absl::debian7::string_view, const Options&)'
#8 54.15   289 |   RE2(absl::string_view pattern, const Options& options);
#8 54.15       |   ^~~
#8 54.15 /usr/include/re2/re2.h:289:25: note:   no known conversion for argument 1 from 'std::basic_string_view<char>' to 'absl::debian7::string_view'
#8 54.15   289 |   RE2(absl::string_view pattern, const Options& options);
#8 54.15       |       ~~~~~~~~~~~~~~~~~~^~~~~~~
#8 54.15 /usr/include/re2/re2.h:288:3: note: candidate: 're2::RE2::RE2(absl::debian7::string_view)'
#8 54.15   288 |   RE2(absl::string_view pattern);
#8 54.15       |   ^~~
#8 54.15 /usr/include/re2/re2.h:288:3: note:   candidate expects 1 argument, 2 provided
#8 54.15 /usr/include/re2/re2.h:287:3: note: candidate: 're2::RE2::RE2(const std::string&)'
#8 54.15   287 |   RE2(const std::string& pattern);
#8 54.15       |   ^~~
#8 54.15 /usr/include/re2/re2.h:287:3: note:   candidate expects 1 argument, 2 provided
#8 54.15 /usr/include/re2/re2.h:286:3: note: candidate: 're2::RE2::RE2(const char*)'
#8 54.15   286 |   RE2(const char* pattern);
#8 54.15       |   ^~~
#8 54.15 /usr/include/re2/re2.h:286:3: note:   candidate expects 1 argument, 2 provided

```

</details>

it seems like in system abseil package, `absl::string_view` and `std::string_view` are distinct types and not aliases, therefore it fails to build (found similar issue https://github.com/p4lang/p4c/issues/5411)