### PR TITLE
improve HTTP/2 + TLS support

### DIFF
--- a/core/include/userver/engine/io/common.hpp
+++ b/core/include/userver/engine/io/common.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <span>
 
 #include <userver/engine/deadline.hpp>
 #include <userver/utils/assert.hpp>
@@ -106,12 +107,20 @@ public:
     /// @note Can return less than len if stream is closed by peer.
     [[nodiscard]] virtual size_t WriteAll(const void* buf, size_t len, Deadline deadline) = 0;
 
-    [[nodiscard]] virtual size_t WriteAll(std::initializer_list<IoData> list, Deadline deadline) {
+    /// @brief Sends IoData array using vector I/O (e.g. writev).
+    /// @note Can return less than total bytes if stream is closed by peer.
+    [[nodiscard]] virtual size_t WriteAll(std::span<const IoData> list, Deadline deadline) {
         size_t result{0};
         for (const auto& io_data : list) {
             result += WriteAll(io_data.data, io_data.len, deadline);
         }
         return result;
+    }
+
+    /// @brief Sends IoData initializer list using vector I/O (e.g. writev).
+    /// @note Can return less than total bytes if stream is closed by peer.
+    [[nodiscard]] virtual size_t WriteAll(std::initializer_list<IoData> list, Deadline deadline) {
+        return WriteAll(std::span<const IoData>{list.begin(), list.size()}, deadline);
     }
 };
 

--- a/core/include/userver/engine/io/socket.hpp
+++ b/core/include/userver/engine/io/socket.hpp
@@ -5,7 +5,7 @@
 
 #include <sys/socket.h>
 
-#include <initializer_list>
+#include <span>
 
 #include <userver/engine/deadline.hpp>
 #include <userver/engine/io/common.hpp>
@@ -102,7 +102,9 @@ public:
     /// @snippet src/engine/io/socket_test.cpp send vector data in socket
     [[nodiscard]] size_t SendAll(std::initializer_list<IoData> list, Deadline deadline);
 
-    [[nodiscard]] size_t WriteAll(std::initializer_list<IoData> list, Deadline deadline) override {
+    [[nodiscard]] size_t SendAll(std::span<const IoData> list, Deadline deadline);
+
+    [[nodiscard]] size_t WriteAll(std::span<const IoData> list, Deadline deadline) override {
         return SendAll(list, deadline);
     }
 

--- a/core/include/userver/engine/io/tls_wrapper.hpp
+++ b/core/include/userver/engine/io/tls_wrapper.hpp
@@ -3,6 +3,7 @@
 /// @file userver/engine/io/tls_wrapper.hpp
 /// @brief TLS socket wrappers
 
+#include <span>
 #include <string>
 #include <vector>
 
@@ -115,7 +116,11 @@ public:
         return SendAll(buf, len, deadline);
     }
 
-    [[nodiscard]] size_t WriteAll(std::initializer_list<IoData> list, Deadline deadline) override;
+    [[nodiscard]] size_t WriteAll(std::span<const IoData> list, Deadline deadline) override;
+
+    [[nodiscard]] size_t WriteAll(std::initializer_list<IoData> list, Deadline deadline) override {
+        return WriteAll(std::span<const IoData>{list.begin(), list.size()}, deadline);
+    }
 
     int GetRawFd();
 

--- a/core/src/engine/io/socket.cpp
+++ b/core/src/engine/io/socket.cpp
@@ -287,8 +287,12 @@ std::optional<size_t> Socket::RecvNoblock(void* buf, size_t len) {
     throw IoException("Attempt to RecvNoblock from closed socket");
 }
 
+size_t Socket::SendAll(std::span<const IoData> list, Deadline deadline) {
+    return SendAll(list.data(), list.size(), deadline);
+}
+
 size_t Socket::SendAll(std::initializer_list<IoData> list, Deadline deadline) {
-    return SendAll(list.begin(), list.size(), deadline);
+    return SendAll(std::span<const IoData>{list.begin(), list.size()}, deadline);
 }
 
 size_t Socket::SendAll(const IoData* list, std::size_t list_size, Deadline deadline) {

--- a/core/src/engine/io/tls_wrapper.cpp
+++ b/core/src/engine/io/tls_wrapper.cpp
@@ -582,7 +582,7 @@ size_t TlsWrapper::SendAll(const void* buf, size_t len, Deadline deadline) {
     );
 }
 
-[[nodiscard]] size_t TlsWrapper::WriteAll(std::initializer_list<IoData> list, Deadline deadline) {
+[[nodiscard]] size_t TlsWrapper::WriteAll(std::span<const IoData> list, Deadline deadline) {
     static constexpr std::size_t kBufSize = 4'096;
     std::byte buf[kBufSize];
 

--- a/core/src/server/http/http2_session.cpp
+++ b/core/src/server/http/http2_session.cpp
@@ -239,10 +239,7 @@ int Http2Session::OnDataFrameSend(
     auto& stream = *static_cast<Stream*>(source->ptr);
 
     const auto frame_header{ToStringView(framehd, kFrameHeaderSize)};
-    // TODO: doesn't work with TLS?!
-    UASSERT(dynamic_cast<engine::io::Socket*>(parser.socket_));
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-    stream.Send(*static_cast<engine::io::Socket*>(parser.socket_), frame_header, max_len);
+    stream.Send(*parser.socket_, frame_header, max_len);
     return 0;
 }
 

--- a/core/src/server/http/http2_stream.cpp
+++ b/core/src/server/http/http2_stream.cpp
@@ -106,7 +106,7 @@ ssize_t Stream::GetMaxSize(std::size_t max_len, std::uint32_t* flags) {
     return res;
 }
 
-void Stream::Send(engine::io::Socket& socket, std::string_view data_frame_header, std::size_t max_len) {
+void Stream::Send(engine::io::RwBase& socket, std::string_view data_frame_header, std::size_t max_len) {
     boost::container::small_vector<engine::io::IoData, 16> parts{};
     parts.push_back({data_frame_header.data(), data_frame_header.size()});
     auto budget = max_len;
@@ -126,7 +126,7 @@ void Stream::Send(engine::io::Socket& socket, std::string_view data_frame_header
         budget -= part.size();
     }
     UASSERT(!parts.empty());
-    [[maybe_unused]] const auto res = socket.SendAll(parts.data(), parts.size(), {});
+    [[maybe_unused]] const auto res = socket.WriteAll(std::span<const engine::io::IoData>{parts.data(), parts.size()}, {});
     const auto send_parts_count = pos_in_first_chunk_ == 0 ? parts.size() - 1 : parts.size() - 2;  // data_frame_header
                                                                                                    // doesn't matter
     chunks_.erase(chunks_.begin(), chunks_.begin() + send_parts_count);

--- a/core/src/server/http/http2_stream.hpp
+++ b/core/src/server/http/http2_stream.hpp
@@ -43,7 +43,7 @@ public:
     bool CheckUrlComplete();
     void PushChunk(std::string&& chunk);
     ssize_t GetMaxSize(std::size_t max_len, std::uint32_t* flags);
-    void Send(engine::io::Socket& socket, std::string_view data_frame_header, std::size_t max_len);
+    void Send(engine::io::RwBase& socket, std::string_view data_frame_header, std::size_t max_len);
     nghttp2_data_provider* GetNativeProvider() { return &nghttp2_provider_; }
 
 private:

--- a/core/src/server/server.cpp
+++ b/core/src/server/server.cpp
@@ -161,8 +161,11 @@ ServerImpl::ServerImpl(
     for (auto& port : config_.listener.ports) {
         port.ReadTlsSettings(secdist);
         port.InitSslCtx();
-    }
 
+        if (port.ssl_ctx) {
+            port.ssl_ctx->SetHttpVersion(config.listener.connection_config.http_version);
+        }
+    }
     main_port_info_.Init(config_, config_.listener, component_context, false);
     if (config_.max_response_size_in_flight) {
         main_port_info_.data_accounter.SetMaxPendingResponsesSizeInBytes(*config_.max_response_size_in_flight);
@@ -424,3 +427,4 @@ void Server::WriteMetrics(utils::statistics::Writer& writer) const {
 }  // namespace server
 
 USERVER_NAMESPACE_END
+

--- a/universal/include/userver/crypto/ssl_ctx.hpp
+++ b/universal/include/userver/crypto/ssl_ctx.hpp
@@ -4,11 +4,13 @@
 /// @brief @copybrief crypto::SslCtx
 
 #include <memory>
+#include <span>
 #include <string_view>
 #include <vector>
 
 #include <userver/crypto/certificate.hpp>
 #include <userver/crypto/private_key.hpp>
+#include <userver/http/http_version.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -43,6 +45,9 @@ public:
 
     void* GetRawSslCtx() const noexcept;
 
+    void SetHttpVersion(http::HttpVersion);
+    [[nodiscard]] std::span<const unsigned char> GetAlpn() const noexcept;
+
 private:
     void AddCertAuthorities(const std::vector<Certificate>& cert_authorities);
     void EnableVerifyClientCertificate();
@@ -55,8 +60,10 @@ private:
     std::unique_ptr<Impl> impl_{};
 
     explicit SslCtx(std::unique_ptr<Impl>&& impl);
+    std::span<const unsigned char> alpn_;
 };
 
 }  // namespace crypto
 
 USERVER_NAMESPACE_END
+

--- a/universal/src/crypto/ssl_ctx.cpp
+++ b/universal/src/crypto/ssl_ctx.cpp
@@ -64,6 +64,64 @@ std::unique_ptr<SslCtx::Impl> SslCtx::Impl::MakeSslCtx() {
 
 void* SslCtx::GetRawSslCtx() const noexcept { return static_cast<void*>(impl_->Get()); }
 
+
+// https://www.rfc-editor.org/rfc/rfc7540#section-3.1
+static constexpr unsigned char kAlpnHttp1Only[] = "\x08http/1.1";
+// https://www.rfc-editor.org/rfc/rfc9112.html#section-12.4
+static constexpr unsigned char kAlpnHttp2Only[] = "\x02h2";
+static constexpr unsigned char kAlpnHttp2FallbackHttp1[] = "\x02h2\x08http/1.1";
+
+static int AlpnSelectCallback(SSL *,
+    const unsigned char **out,
+    unsigned char *outlen,
+    const unsigned char *in,
+    unsigned int inlen,
+    void *arg) {
+
+    auto * context = reinterpret_cast<SslCtx*>(arg);
+
+    if (SSL_select_next_proto(const_cast<unsigned char **>(out), outlen, context->GetAlpn().data(), context->GetAlpn().size(),
+                              in, inlen)
+        != OPENSSL_NPN_NEGOTIATED)
+    {
+        LOG_ERROR() << crypto::FormatSslError("SSL_select_next_proto failed");
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+
+    LOG_INFO() << "successfully negotiated ALPN";
+
+    return SSL_TLSEXT_ERR_OK;
+}
+
+void SslCtx::SetHttpVersion(http::HttpVersion http_version) {
+
+    switch (http_version) {
+        case http::HttpVersion::k10:
+        case http::HttpVersion::k11:
+            alpn_ = kAlpnHttp1Only;
+            LOG_INFO() << "set ALPN for HTTP/1.1 only";
+            break;
+        case http::HttpVersion::k2:
+            alpn_ = kAlpnHttp2FallbackHttp1;
+            LOG_INFO() << "set ALPN for HTTP/2 with fallback to HTTP/1.1";
+            break;
+        case http::HttpVersion::k2Tls:
+        case http::HttpVersion::k2PriorKnowledge:
+            LOG_INFO() << "set ALPN for HTTP/2 only";
+            alpn_ = kAlpnHttp2Only;
+            break;
+        default:
+            LOG_INFO() << "skip setting ALPN";
+            return;
+    }
+
+    SSL_CTX_set_alpn_select_cb(impl_->Get(), AlpnSelectCallback, this);
+}
+
+std::span<const unsigned char> SslCtx::GetAlpn() const noexcept {
+    return alpn_;
+}
+
 SslCtx::SslCtx(std::unique_ptr<Impl>&& impl)
     : impl_(std::move(impl))
 {}
@@ -197,3 +255,4 @@ SslCtx SslCtx::CreateServerTlsContext(
 }  // namespace crypto
 
 USERVER_NAMESPACE_END
+


### PR DESCRIPTION
I've got userver working with plain HTTP/2 and HTTP/1.1 + TLS on their own, however, HTTP/2 + TLS didn't work quite well for me, I've used the following config:
```
      listener:
        port: 8443
        task_processor: main-task-processor
        tls:
          cert: ng200ok.crt
          private-key: ng200ok.pem
        connection:
          http-version: '2'
          http2-session:
            max_concurrent_streams: 100
            max_frame_size: 16384
            initial_window_size: 65536
```
that I get with curl - it doesn't use HTTP/2, only fallbacks to HTTP/1.1:

<details>
  <summary>curl log</summary>

```
curl -lvsk --http2 https://127.0.0.1:8443/hello\?name\=userver
*   Trying 127.0.0.1:8443...
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / X25519MLKEM768 / RSASSA-PSS
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=RU; ST=Russia; L=Moscow; O=Security; OU=IT Department; CN=*.example.org
*  start date: May  6 07:30:13 2026 GMT
*  expire date: Jul  4 07:30:13 2301 GMT
*  issuer: C=RU; ST=Russia; L=Moscow; O=Security; OU=IT Department; CN=*.example.org
*  SSL certificate verify result: self-signed certificate (18), continuing anyway.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
* Connected to 127.0.0.1 (127.0.0.1) port 8443
* using HTTP/1.x
> GET /hello?name=userver HTTP/1.1
> Host: 127.0.0.1:8443
> User-Agent: curl/8.14.1
> Accept: */*
>
* Request completely sent off
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
< HTTP/1.1 200 OK
< Date: Wed, 06 May 2026 10:34:45 UTC
< Content-Type: application/octet-stream
< Server: userver/3.1-rc (20260506035656; rv:f078534)
< traceparent: 00-99db4a3530c2ed800d5a06288191e71a-55592ba5e52f48c7-01
< X-YaRequestId: e89e6d21a3bbb20100c5a1dbf5b78c19
< X-YaTraceId: 99db4a3530c2ed800d5a06288191e71a
< X-YaSpanId: 55592ba5e52f48c7
< Accept-Encoding: gzip, zstd, identity
< Connection: keep-alive
< Content-Length: 16
<
Hello, userver!
* Connection #0 to host 127.0.0.1 left intact
```

</details>

okay, this seems to be due to the fact userver never specifies ALPN, so I've added one via [SSL_CTX_set_alpn_select_cb](https://docs.openssl.org/3.1/man3/SSL_CTX_set_alpn_select_cb/) in 2d29453acdf519bbfce93b7141d73533000cb8c9 (this is more or less same as nginx and envoy are doing)

it started to progress a little bit, curl now switches to HTTP/2, but results in an error in the middle:

<details>
  <summary>curl log</summary>

```
curl -lvsk --http2 https://127.0.0.1:8443/hello\?name\=userver
*   Trying 127.0.0.1:8443...
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / X25519MLKEM768 / RSASSA-PSS
* ALPN: server accepted h2
* Server certificate:
*  subject: C=RU; ST=Russia; L=Moscow; O=Security; OU=IT Department; CN=*.example.org
*  start date: May  6 07:30:13 2026 GMT
*  expire date: Jul  4 07:30:13 2301 GMT
*  issuer: C=RU; ST=Russia; L=Moscow; O=Security; OU=IT Department; CN=*.example.org
*  SSL certificate verify result: self-signed certificate (18), continuing anyway.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
* Connected to 127.0.0.1 (127.0.0.1) port 8443
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://127.0.0.1:8443/hello?name=userver
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: 127.0.0.1:8443]
* [HTTP/2] [1] [:path: /hello?name=userver]
* [HTTP/2] [1] [user-agent: curl/8.14.1]
* [HTTP/2] [1] [accept: */*]
> GET /hello?name=userver HTTP/2
> Host: 127.0.0.1:8443
> User-Agent: curl/8.14.1
> Accept: */*
>
* Request completely sent off
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
< HTTP/2 200
< date: Wed, 06 May 2026 10:41:48 UTC
< content-type: application/octet-stream
< accept-encoding: gzip, zstd, identity
< x-yaspanid: f2f8730fcc0e57eb
< x-yatraceid: 23be0fa7912b6d7d905dbccbfed1a9a7
< x-yarequestid: 875862045156a7bce9fbbf5b6791357f
< traceparent: 00-23be0fa7912b6d7d905dbccbfed1a9a7-f2f8730fcc0e57eb-01
< server: userver/3.1-rc (20260506035656; rv:f078534)
<
* TLSv1.3 (OUT), TLS alert, unexpected message (522):
* OpenSSL SSL_read: OpenSSL/3.5.5: error:0A0001BB:SSL routines::bad record type, errno 0
* Failed receiving HTTP2 data: 56(Failure when receiving data from the peer)
* OpenSSL SSL_write: SSL_ERROR_SYSCALL, errno 0
* Connection #0 to host 127.0.0.1 left intact
```

</details>

there is also error message in userver log in that case:

<details>
  <summary>userver log</summary>

```
tskv	timestamp=2026-05-06T17:41:48.410837	level=ERROR	module=TryParseRequests ( userver/core/src/server/net/connection_base.cpp:82 )	task_id=7F68B83DF400	thread_id=0x00007F68B9BFD400	stacktrace= 0# userver::v3_1_rc::utils::TracefulExceptionBase::TracefulExceptionBase(userver::v3_1_rc::utils::TracefulExceptionBase::TraceMode) in ./build-release/ng200ok\n 1# userver::v3_1_rc::engine::io::IoException::IoException(std::basic_string_view<char, std::char_traits<char> >) in ./build-release/ng200ok\n 2# userver::v3_1_rc::engine::io::TlsWrapper::WaitReadable(userver::v3_1_rc::engine::Deadline) [clone .cold] in ./build-release/ng200ok\n 3# userver::v3_1_rc::server::net::SocketBufferedReader::TryRead(userver::v3_1_rc::engine::io::RwBase&, int) in ./build-release/ng200ok\n 4# userver::v3_1_rc::server::net::ConnectionBase::TryParseRequests(userver::v3_1_rc::server::request::RequestParser&) in ./build-release/ng200ok\n 5# userver::v3_1_rc::server::net::Http2Connection::ListenForRequests() in ./build-release/ng200ok\n 6# userver::v3_1_rc::server::net::Http2Connection::Process() in ./build-release/ng200ok\n 7# userver::v3_1_rc::server::net::ListenerImpl::ProcessConnection(userver::v3_1_rc::engine::io::Socket, userver::v3_1_rc::server::net::PortConfig const&) in ./build-release/ng200ok\n 8# void std::__invoke_impl<void, userver::v3_1_rc::server::net::ListenerImpl::AcceptConnection(userver::v3_1_rc::engine::io::Socket&, userver::v3_1_rc::server::net::PortConfig const&)::{lambda(auto:1, auto:2)#1}, userver::v3_1_rc::engine::io::Socket, userver::v3_1_rc::utils::FastScopeGuard<userver::v3_1_rc::server::net::ListenerImpl::AcceptConnection(userver::v3_1_rc::engine::io::Socket&, userver::v3_1_rc::server::net::PortConfig const&)::{lambda()#1}> >(std::__invoke_other, userver::v3_1_rc::server::net::ListenerImpl::AcceptConnection(userver::v3_1_rc::engine::io::Socket&, userver::v3_1_rc::server::net::PortConfig const&)::{lambda(auto:1, auto:2)#1}&&, userver::v3_1_rc::engine::io::Socket&&, userver::v3_1_rc::utils::FastScopeGuard<userver::v3_1_rc::server::net::ListenerImpl::AcceptConnection(userver::v3_1_rc::engine::io::Socket&, userver::v3_1_rc::server::net::PortConfig const&)::{lambda()#1}>&&) [clone .isra.0] in ./build-release/ng200ok\n 9# [start of coroutine]\n	text=Error while receiving from peer ::ffff:127.0.0.1 on fd 36: WaitReadable failed: ssl/tls alert unexpected message (userver::v3_1_rc::engine::io::TlsException)
```

</details>

okay, I've figured out it's due to the TODO in the existing code: https://github.com/userver-framework/userver/blob/dd333c34e2aa8fd1df7b113d5919d83ee9bb5569/core/src/server/http/http2_session.cpp#L242

it only tries to work with `io::Socket`, but in case of TLS, implementation is actually `TlsWrapper`, so I've changed `Http2Stream` to use generic `io::RwBase` interface instead in 979c8da21ade19272fa1f39e243586c52b295d52

a small caveat was with `Http2Session` using `SendAll` method accepting `std::initializer_list`, which doesn't match generic `WriteAll` signature, so I've concluded, as userver already switched to C++20, it would be better to use `std::span` in the interface, this way it will compile and still may use iovec implementation for real socket saving system calls, this was done in f4451e5f410ea491544bd1d479586245399ad5e4.

finally, I've got working HTTP/2 over TLS via curl:


<details>
  <summary>curl log</summary>

```
curl -lvsk --http2 https://127.0.0.1:8443/hello\?name\=userver
*   Trying 127.0.0.1:8443...
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / X25519MLKEM768 / RSASSA-PSS
* ALPN: server accepted h2
* Server certificate:
*  subject: C=RU; ST=Russia; L=Moscow; O=Security; OU=IT Department; CN=*.example.org
*  start date: May  6 07:30:13 2026 GMT
*  expire date: Jul  4 07:30:13 2301 GMT
*  issuer: C=RU; ST=Russia; L=Moscow; O=Security; OU=IT Department; CN=*.example.org
*  SSL certificate verify result: self-signed certificate (18), continuing anyway.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
* Connected to 127.0.0.1 (127.0.0.1) port 8443
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://127.0.0.1:8443/hello?name=userver
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: 127.0.0.1:8443]
* [HTTP/2] [1] [:path: /hello?name=userver]
* [HTTP/2] [1] [user-agent: curl/8.14.1]
* [HTTP/2] [1] [accept: */*]
> GET /hello?name=userver HTTP/2
> Host: 127.0.0.1:8443
> User-Agent: curl/8.14.1
> Accept: */*
>
* Request completely sent off
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
< HTTP/2 200
< date: Wed, 06 May 2026 10:47:44 UTC
< content-type: application/octet-stream
< accept-encoding: gzip, zstd, identity
< x-yaspanid: cddc0300e7cef253
< x-yatraceid: 801194176f3b9060942c7d8da83e7f9a
< x-yarequestid: c8f04df591e80145958fca9c51f422d3
< traceparent: 00-801194176f3b9060942c7d8da83e7f9a-cddc0300e7cef253-01
< server: userver/3.1-rc (20260506035656; rv:f078534)
<
Hello, userver!
* Connection #0 to host 127.0.0.1 left intact
```

</details>

and it also worked in web-browser (Chromium).