### PR TITLE
feat ydb: add support for Decimal type

### DIFF
--- a/ydb/include/userver/ydb/io/decimal64.hpp
+++ b/ydb/include/userver/ydb/io/decimal64.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+/// @file userver/ydb/io/decimal64.hpp
+/// @brief YDB serialization support for `userver::decimal64::Decimal`
+///
+/// `decimal64::Decimal<Prec, RoundPolicy>` is mapped to the YDB type
+/// `Decimal(22, Prec)`. The precision is fixed at `22`, which matches the
+/// most common "money-like" YDB schema `Decimal(22, 9)` and is sufficient to
+/// hold any value representable by `decimal64::Decimal` (its mantissa fits in
+/// `int64_t`, i.e. up to 19 significant digits).
+///
+/// Schemas that use a different precision (e.g. `Decimal(35, 18)`) should use
+/// `ydb::Decimal` instead, which carries `precision` and `scale` at runtime.
+///
+/// On read, `decimal64::Decimal<Prec>::FromStringPermissive` is used, so
+/// values stored with a YDB scale larger than `Prec` are rounded according
+/// to `RoundPolicy` instead of being rejected.
+
+#include <optional>
+
+#include <ydb-cpp-sdk/client/params/params.h>
+#include <ydb-cpp-sdk/client/value/value.h>
+
+#include <userver/compiler/demangle.hpp>
+#include <userver/decimal64/decimal64.hpp>
+#include <userver/logging/log.hpp>
+
+#include <userver/ydb/impl/cast.hpp>
+#include <userver/ydb/io/traits.hpp>
+#include <userver/ydb/types.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace ydb {
+
+namespace impl {
+
+inline bool IsOptionalDecimal64(const NYdb::TValueParser& parser) {
+    return parser.GetKind() == NYdb::TTypeParser::ETypeKind::Optional;
+}
+
+template <int Prec, typename RoundPolicy>
+decimal64::Decimal<Prec, RoundPolicy> ParseDecimal64Value(const NYdb::TValueParser& parser) {
+    // YDB stores decimals with a fixed scale, which may differ from `Prec`.
+    // `FromStringPermissive` tolerates trailing zeros and rounds extra
+    // fractional digits according to `RoundPolicy`, which is what we want.
+    return decimal64::Decimal<Prec, RoundPolicy>::FromStringPermissive(parser.GetDecimal().ToString());
+}
+
+template <int Prec, typename RoundPolicy, typename Builder>
+void WriteDecimal64Value(
+    NYdb::TValueBuilderBase<Builder>& builder,
+    const decimal64::Decimal<Prec, RoundPolicy>& value
+) {
+    builder.Decimal(NYdb::TDecimalValue(
+        impl::ToString(decimal64::ToString(value)),
+        Decimal::kDefaultPrecision,
+        static_cast<std::uint8_t>(Prec)
+    ));
+}
+
+inline NYdb::TType MakeDecimal64Type(std::uint8_t scale) {
+    NYdb::TTypeBuilder builder;
+    builder.Decimal(NYdb::TDecimalType{Decimal::kDefaultPrecision, scale});
+    return builder.Build();
+}
+
+inline NYdb::TType MakeOptionalDecimal64Type(std::uint8_t scale) {
+    NYdb::TTypeBuilder builder;
+    builder.BeginOptional();
+    builder.Decimal(NYdb::TDecimalType{Decimal::kDefaultPrecision, scale});
+    builder.EndOptional();
+    return builder.Build();
+}
+
+}  // namespace impl
+
+template <int Prec, typename RoundPolicy>
+struct ValueTraits<decimal64::Decimal<Prec, RoundPolicy>> {
+    static_assert(
+        Prec >= 0 && Prec <= Decimal::kDefaultPrecision,
+        "decimal64::Decimal<Prec> must have 0 <= Prec <= ydb::Decimal::kDefaultPrecision (22) "
+        "to map to YDB Decimal(22, Prec); use ydb::Decimal for non-money-like schemas"
+    );
+
+    using Type = decimal64::Decimal<Prec, RoundPolicy>;
+
+    static Type Parse(NYdb::TValueParser& parser, const ParseContext& /*context*/) {
+        const bool is_optional = impl::IsOptionalDecimal64(parser);
+
+        if (is_optional) {
+            parser.OpenOptional();
+        }
+
+        // Will throw exception if value is null.
+        auto value = impl::ParseDecimal64Value<Prec, RoundPolicy>(parser);
+
+        if (is_optional) {
+            parser.CloseOptional();
+        }
+
+        return value;
+    }
+
+    template <typename Builder>
+    static void Write(NYdb::TValueBuilderBase<Builder>& builder, const Type& value) {
+        impl::WriteDecimal64Value(builder, value);
+    }
+
+    static NYdb::TType MakeType() { return impl::MakeDecimal64Type(static_cast<std::uint8_t>(Prec)); }
+};
+
+template <int Prec, typename RoundPolicy>
+struct ValueTraits<std::optional<decimal64::Decimal<Prec, RoundPolicy>>> {
+    static_assert(
+        Prec >= 0 && Prec <= Decimal::kDefaultPrecision,
+        "decimal64::Decimal<Prec> must have 0 <= Prec <= ydb::Decimal::kDefaultPrecision (22) "
+        "to map to YDB Decimal(22, Prec); use ydb::Decimal for non-money-like schemas"
+    );
+
+    using Type = decimal64::Decimal<Prec, RoundPolicy>;
+
+    static std::optional<Type> Parse(NYdb::TValueParser& parser, const ParseContext& context) {
+        const bool is_optional = impl::IsOptionalDecimal64(parser);
+        if (is_optional) {
+            parser.OpenOptional();
+
+            if (parser.IsNull()) {
+                parser.CloseOptional();
+                return {};
+            }
+        } else {
+            LOG_WARNING()
+                << "Trying to parse " << context.column_name << " as "
+                << compiler::GetTypeName<std::optional<Type>>() << " while actual type is not Optional";
+        }
+
+        auto value = impl::ParseDecimal64Value<Prec, RoundPolicy>(parser);
+        if (is_optional) {
+            parser.CloseOptional();
+        }
+
+        return value;
+    }
+
+    template <typename Builder>
+    static void Write(NYdb::TValueBuilderBase<Builder>& builder, const std::optional<Type>& value) {
+        if (value) {
+            builder.BeginOptional();
+            impl::WriteDecimal64Value(builder, *value);
+            builder.EndOptional();
+        } else {
+            builder.EmptyOptional(impl::MakeDecimal64Type(static_cast<std::uint8_t>(Prec)));
+        }
+    }
+
+    static NYdb::TType MakeType() { return impl::MakeOptionalDecimal64Type(static_cast<std::uint8_t>(Prec)); }
+};
+
+}  // namespace ydb
+
+USERVER_NAMESPACE_END

--- a/ydb/include/userver/ydb/io/primitives.hpp
+++ b/ydb/include/userver/ydb/io/primitives.hpp
@@ -50,6 +50,23 @@ struct PrimitiveTraits {
     static NYdb::TType MakeType();
 };
 
+template <typename DecimalLikeTrait>
+struct DecimalTraits {
+    static typename DecimalLikeTrait::Type Parse(NYdb::TValueParser& parser, const ParseContext& context);
+
+    static void Write(
+        NYdb::TValueBuilderBase<NYdb::TValueBuilder>& builder,
+        const typename DecimalLikeTrait::Type& value
+    );
+
+    static void Write(
+        NYdb::TValueBuilderBase<NYdb::TParamValueBuilder>& builder,
+        const typename DecimalLikeTrait::Type& value
+    );
+
+    static NYdb::TType MakeType();
+};
+
 struct BoolTrait {
     using Type = bool;
     static Type Parse(const NYdb::TValueParser& value_parser);
@@ -162,11 +179,43 @@ struct JsonDocumentTrait {
     static void Write(NYdb::TValueBuilderBase<Builder>& builder, const Type& value);
 };
 
+struct DecimalTrait {
+    using Type = Decimal;
+    static Type Parse(const NYdb::TValueParser& value_parser);
+    template <typename Builder>
+    static void Write(NYdb::TValueBuilderBase<Builder>& builder, const Type& value);
+};
+
 template <>
 struct ValueTraits<std::optional<JsonDocumentTrait::Type>> : OptionalPrimitiveTraits<JsonDocumentTrait> {};
 
 template <>
 struct ValueTraits<JsonDocument> : PrimitiveTraits<JsonDocumentTrait> {};
+
+template <>
+struct ValueTraits<DecimalTrait::Type> : DecimalTraits<DecimalTrait> {};
+
+// `std::optional<ydb::Decimal>` is supported on read only. Writing a NULL
+// `ydb::Decimal` would require knowing the YDB column's precision and scale,
+// which an empty optional does not carry. For nullable Decimal columns whose
+// schema is `Decimal(22, Prec)`, use `std::optional<decimal64::Decimal<Prec>>`
+// instead -- its precision/scale are encoded in the C++ type.
+template <>
+struct ValueTraits<std::optional<DecimalTrait::Type>> {
+    static std::optional<DecimalTrait::Type> Parse(NYdb::TValueParser& parser, const ParseContext& context);
+
+    template <typename Builder>
+    static void Write(NYdb::TValueBuilderBase<Builder>& /*builder*/, const std::optional<DecimalTrait::Type>& /*value*/) {
+        static_assert(
+            sizeof(Builder) == 0,
+            "Writing std::optional<ydb::Decimal> is not supported: an empty optional carries no "
+            "precision/scale, and YDB Decimal type requires them. Use std::optional<decimal64::Decimal<Prec>> "
+            "or write a non-optional ydb::Decimal{value, precision, scale}."
+        );
+    }
+
+    static NYdb::TType MakeType() = delete;
+};
 
 template <>
 struct ValueTraits<std::optional<JsonTrait::Type>> : OptionalPrimitiveTraits<JsonTrait> {};

--- a/ydb/include/userver/ydb/io/supported_types.hpp
+++ b/ydb/include/userver/ydb/io/supported_types.hpp
@@ -17,12 +17,14 @@
 ///  * ValueType::Utf8,        ydb::Utf8
 ///  * ValueType::Timestamp,   std::chrono::system_clock::time_point
 ///  * ValueType::Uuid,        boost::uuids::uuid
+///  * ValueType::Decimal,     ydb::Decimal, decimal64::Decimal<Prec, RoundPolicy>
 ///
 /// Available composite types:
 ///  * Optional,    std::optional for primitive types, List and Struct
 ///  * List,        std::vector and non-map containers
 ///  * Struct,      @ref ydb::kStructMemberNames "C++ structs"
 
+#include <userver/ydb/io/decimal64.hpp>
 #include <userver/ydb/io/insert_row.hpp>
 #include <userver/ydb/io/list.hpp>
 #include <userver/ydb/io/primitives.hpp>

--- a/ydb/include/userver/ydb/types.hpp
+++ b/ydb/include/userver/ydb/types.hpp
@@ -27,6 +27,7 @@ namespace ydb {
  * Uint64        | std::uint64_t
  * Float         | N/A
  * Double        | double
+ * Decimal       | ydb::Decimal
  * Date          | N/A
  * Datetime      | N/A
  * Timestamp     | std::chrono::system_clock::time_point
@@ -51,6 +52,47 @@ using Utf8 = utils::StrongTypedef<Utf8Tag, std::string>;
 
 class JsonDocumentTag {};
 using JsonDocument = utils::StrongTypedef<JsonDocumentTag, formats::json::Value>;
+
+// A YDB Decimal value as a (value, precision, scale) triple.
+//
+// In YDB, `precision` and `scale` are part of the column type, not of the
+// value, and must be provided when writing. `ydb::Decimal` is a thin transport
+// wrapper around `NYdb::TDecimalValue` that preserves them as-is; it is NOT
+// an arithmetic type. For numeric operations, parsing from numbers, rounding
+// etc. use `decimal64::Decimal<Prec, RoundPolicy>` (see
+// `userver/ydb/io/decimal64.hpp`), whose `ValueTraits` are also provided by
+// this library.
+//
+// `value` stores the decimal in the same string form that the YDB SDK
+// produces and accepts (e.g. `"123.456789"`). YDB returns decimals in a
+// canonical form with trailing zeros stripped, so a value written as
+// `"7.500000000"` will be read back as `"7.5"`. Consequently `operator==`
+// performs a strict string comparison and is NOT a numeric equality check.
+//
+// The default `precision = 22`, `scale = 9` matches the most common
+// "money-like" YDB schema `Decimal(22, 9)`. They are exposed as
+// `kDefaultPrecision` / `kDefaultScale` for convenience but should be
+// overridden whenever the column uses a different type, e.g.
+// `ydb::Decimal{"123.456789012345678", 35, 18}`.
+struct Decimal {
+    static constexpr std::uint8_t kDefaultPrecision = 22;
+    static constexpr std::uint8_t kDefaultScale = 9;
+
+    std::string value;
+    std::uint8_t precision{kDefaultPrecision};
+    std::uint8_t scale{kDefaultScale};
+
+    Decimal() = default;
+
+    Decimal(std::string value, std::uint8_t precision, std::uint8_t scale)
+        : value(std::move(value)), precision(precision), scale(scale) {}
+
+    friend bool operator==(const Decimal& lhs, const Decimal& rhs) {
+        return lhs.precision == rhs.precision && lhs.scale == rhs.scale && lhs.value == rhs.value;
+    }
+
+    friend bool operator!=(const Decimal& lhs, const Decimal& rhs) { return !(lhs == rhs); }
+};
 
 using InsertColumnValue = std::variant<
     std::string,
@@ -78,7 +120,8 @@ using InsertColumnValue = std::variant<
     std::optional<std::uint64_t>,
     std::optional<double>,
     std::optional<Utf8>,
-    std::optional<Timestamp>>;
+    std::optional<Timestamp>,
+    Decimal>;
 
 struct InsertColumn {
     std::string name;

--- a/ydb/src/ydb/io/primitives.cpp
+++ b/ydb/src/ydb/io/primitives.cpp
@@ -145,6 +145,46 @@ NYdb::TType PrimitiveTraits<PrimitiveTrait>::MakeType() {
     return builder.Build();
 }
 
+template <typename DecimalLikeTrait>
+typename DecimalLikeTrait::Type DecimalTraits<
+    DecimalLikeTrait>::Parse(NYdb::TValueParser& parser, const ParseContext& /*context*/) {
+    const bool is_optional = IsOptional(parser);
+
+    if (is_optional) {
+        parser.OpenOptional();
+    }
+
+    auto value = DecimalLikeTrait::Parse(parser);
+    if (is_optional) {
+        parser.CloseOptional();
+    }
+
+    return value;
+}
+
+template <typename DecimalLikeTrait>
+void DecimalTraits<DecimalLikeTrait>::Write(
+    NYdb::TValueBuilderBase<NYdb::TValueBuilder>& builder,
+    const typename DecimalLikeTrait::Type& value
+) {
+    DecimalLikeTrait::Write(builder, value);
+}
+
+template <typename DecimalLikeTrait>
+void DecimalTraits<DecimalLikeTrait>::Write(
+    NYdb::TValueBuilderBase<NYdb::TParamValueBuilder>& builder,
+    const typename DecimalLikeTrait::Type& value
+) {
+    DecimalLikeTrait::Write(builder, value);
+}
+
+template <typename DecimalLikeTrait>
+NYdb::TType DecimalTraits<DecimalLikeTrait>::MakeType() {
+    NYdb::TTypeBuilder builder;
+    builder.Decimal(NYdb::TDecimalType{Decimal::kDefaultPrecision, Decimal::kDefaultScale});
+    return builder.Build();
+}
+
 template struct OptionalPrimitiveTraits<BoolTrait>;
 template struct PrimitiveTraits<BoolTrait>;
 
@@ -332,6 +372,42 @@ JsonDocumentTrait::Type JsonDocumentTrait::Parse(const NYdb::TValueParser& value
 template <typename Builder>
 void JsonDocumentTrait::Write(NYdb::TValueBuilderBase<Builder>& builder, const Type& value) {
     builder.JsonDocument(formats::json::ToString(value.GetUnderlying()));
+}
+
+template struct DecimalTraits<DecimalTrait>;
+
+DecimalTrait::Type DecimalTrait::Parse(const NYdb::TValueParser& value_parser) {
+    const auto decimal = value_parser.GetDecimal();
+    return Decimal{decimal.ToString(), decimal.DecimalType_.Precision, decimal.DecimalType_.Scale};
+}
+
+std::optional<DecimalTrait::Type>
+ValueTraits<std::optional<DecimalTrait::Type>>::Parse(NYdb::TValueParser& parser, const ParseContext& context) {
+    const bool is_optional = IsOptional(parser);
+    if (is_optional) {
+        parser.OpenOptional();
+
+        if (parser.IsNull()) {
+            parser.CloseOptional();
+            return {};
+        }
+    } else {
+        LOG_WARNING() << "Trying to parse " << context.column_name << " as "
+                      << compiler::GetTypeName<std::optional<DecimalTrait::Type>>()
+                      << " while actual type is not Optional";
+    }
+
+    auto value = DecimalTrait::Parse(parser);
+    if (is_optional) {
+        parser.CloseOptional();
+    }
+
+    return value;
+}
+
+template <typename Builder>
+void DecimalTrait::Write(NYdb::TValueBuilderBase<Builder>& builder, const Type& value) {
+    builder.Decimal(NYdb::TDecimalValue(impl::ToString(value.value), value.precision, value.scale));
 }
 
 }  // namespace ydb

--- a/ydb/tests/decimal_test.cpp
+++ b/ydb/tests/decimal_test.cpp
@@ -1,0 +1,368 @@
+#include "test_utils.hpp"
+
+#include <userver/utest/utest.hpp>
+
+#include <userver/decimal64/decimal64.hpp>
+#include <userver/ydb/io/supported_types.hpp>
+#include <userver/ydb/types.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace {
+
+class TDecimalYdbTestCase : public ydb::ClientFixtureBase {
+protected:
+    TDecimalYdbTestCase() { InitializeTable(); }
+
+private:
+    void InitializeTable() {
+        DoCreateTable(
+            "decimal_test",
+            NYdb::NTable::TTableBuilder()
+                .AddNullableColumn("key", NYdb::EPrimitiveType::String)
+                .AddNullableColumn("value_decimal", NYdb::TDecimalType{/*precision=*/22, /*scale=*/9})
+                .SetPrimaryKeyColumn("key")
+                .Build()
+        );
+
+        const ydb::Query fill_query{
+            R"(
+              --!syntax_v1
+              UPSERT INTO decimal_test (
+                  key, value_decimal
+              ) VALUES (
+                  "key", CAST("123.456789" AS Decimal(22, 9))
+              ), (
+                  "key_null", null
+              );
+            )",
+            ydb::Query::Name{"FillTable/decimal_test"},
+        };
+
+        GetTableClient().ExecuteDataQuery(fill_query);
+    }
+};
+
+// The test fixture table uses Decimal(22, 9) To verify that `ydb::Decimal`
+// correctly handles non-default precision/scale at the serialization level,
+// this fixture uses prepared parameters declared as Decimal(35, 18).
+using TDecimalWideYdbTestCase = ydb::ClientFixtureBase;
+
+template <typename T>
+void AssertNullableColumn(ydb::Row& r, const std::string& column, T exp) {
+    auto value = r.Get<std::optional<T>>(column);
+    ASSERT_TRUE(value);
+    ASSERT_EQ(value.value(), exp);
+}
+
+template <typename T>
+void AssertNullColumn(ydb::Row& r, const std::string& key) {
+    auto value = r.Get<std::optional<T>>(key);
+    ASSERT_FALSE(value);
+}
+
+}  // namespace
+
+UTEST_F(TDecimalYdbTestCase, ResponseValueType) {
+    const ydb::Query query{R"(
+        DECLARE $search_key AS String;
+
+        SELECT
+            key,
+            value_decimal
+        FROM decimal_test
+        WHERE key = $search_key;
+    )"};
+
+    auto builder = GetTableClient().GetBuilder();
+    UASSERT_NO_THROW(builder.Add("$search_key", std::string{"key"}));
+
+    auto result = GetTableClient().ExecuteDataQuery(ydb::OperationSettings{}, query, std::move(builder));
+    auto cursor = result.GetSingleCursor();
+    ASSERT_EQ(cursor.size(), 1);
+    for (auto row : cursor) {
+        AssertNullableColumn(row, "key", std::string{"key"});
+        AssertNullableColumn(row, "value_decimal", ydb::Decimal{"123.456789", 22, 9});
+    }
+}
+
+UTEST_F(TDecimalYdbTestCase, PreparedRequestType) {
+    const ydb::Query query{R"(
+        DECLARE $search_value AS Decimal(22, 9);
+
+        SELECT key
+        FROM decimal_test
+        WHERE value_decimal = $search_value
+        LIMIT 1;
+    )"};
+
+    auto builder = GetTableClient().GetBuilder();
+    UASSERT_NO_THROW(builder.Add("$search_value", ydb::Decimal{"123.456789", 22, 9}));
+
+    auto result = GetTableClient().ExecuteDataQuery(ydb::OperationSettings{}, query, std::move(builder));
+    auto cursor = result.GetSingleCursor();
+    ASSERT_EQ(cursor.size(), 1);
+    for (auto row : cursor) {
+        AssertNullableColumn(row, "key", std::string{"key"});
+    }
+}
+
+UTEST_F(TDecimalYdbTestCase, ResponseValueTypeDecimal64) {
+    using Money = decimal64::Decimal<9>;
+
+    const ydb::Query query{R"(
+        DECLARE $search_key AS String;
+
+        SELECT
+            key,
+            value_decimal
+        FROM decimal_test
+        WHERE key = $search_key;
+    )"};
+
+    auto builder = GetTableClient().GetBuilder();
+    UASSERT_NO_THROW(builder.Add("$search_key", std::string{"key"}));
+
+    auto result = GetTableClient().ExecuteDataQuery(ydb::OperationSettings{}, query, std::move(builder));
+    auto cursor = result.GetSingleCursor();
+    ASSERT_EQ(cursor.size(), 1);
+    for (auto row : cursor) {
+        AssertNullableColumn(row, "key", std::string{"key"});
+        AssertNullableColumn(row, "value_decimal", Money{"123.456789"});
+    }
+}
+
+UTEST_F(TDecimalYdbTestCase, ResponseNullValueTypeDecimal64) {
+    using Money = decimal64::Decimal<9>;
+
+    const ydb::Query query{R"(
+        DECLARE $search_key AS String;
+
+        SELECT
+            key,
+            value_decimal
+        FROM decimal_test
+        WHERE key = $search_key;
+    )"};
+
+    auto builder = GetTableClient().GetBuilder();
+    UASSERT_NO_THROW(builder.Add("$search_key", std::string{"key_null"}));
+
+    auto result = GetTableClient().ExecuteDataQuery(ydb::OperationSettings{}, query, std::move(builder));
+    auto cursor = result.GetSingleCursor();
+    ASSERT_EQ(cursor.size(), 1);
+    for (auto row : cursor) {
+        AssertNullableColumn<std::string>(row, "key", "key_null");
+        AssertNullColumn<Money>(row, "value_decimal");
+    }
+}
+
+UTEST_F(TDecimalYdbTestCase, PreparedRequestTypeDecimal64) {
+    using Money = decimal64::Decimal<9>;
+
+    const ydb::Query query{R"(
+        DECLARE $search_value AS Decimal(22, 9);
+
+        SELECT key
+        FROM decimal_test
+        WHERE value_decimal = $search_value
+        LIMIT 1;
+    )"};
+
+    auto builder = GetTableClient().GetBuilder();
+    UASSERT_NO_THROW(builder.Add("$search_value", Money{"123.456789"}));
+
+    auto result = GetTableClient().ExecuteDataQuery(ydb::OperationSettings{}, query, std::move(builder));
+    auto cursor = result.GetSingleCursor();
+    ASSERT_EQ(cursor.size(), 1);
+    for (auto row : cursor) {
+        AssertNullableColumn(row, "key", std::string{"key"});
+    }
+}
+
+UTEST_F(TDecimalYdbTestCase, PreparedUpsertTypeDecimal64) {
+    using Money = decimal64::Decimal<9>;
+
+    const ydb::Query upsert_query{R"(
+        --!syntax_v1
+        DECLARE $search_key AS String;
+        DECLARE $data_decimal AS Decimal(22, 9);
+
+        UPSERT INTO decimal_test (
+            key,
+            value_decimal
+        ) VALUES (
+            $search_key,
+            $data_decimal
+        );
+    )"};
+
+    auto upsert_builder = GetTableClient().GetBuilder();
+    UASSERT_NO_THROW(upsert_builder.Add("$search_key", std::string{"key_new_decimal64"}));
+    UASSERT_NO_THROW(upsert_builder.Add("$data_decimal", Money{"-987.654321"}));
+
+    UASSERT_NO_THROW(
+        GetTableClient().ExecuteDataQuery(ydb::OperationSettings{}, upsert_query, std::move(upsert_builder))
+    );
+
+    auto result = GetTableClient().ExecuteDataQuery(ydb::Query{R"(
+        SELECT
+            key,
+            value_decimal
+        FROM decimal_test
+        WHERE key = "key_new_decimal64";
+    )"});
+
+    auto cursor = result.GetSingleCursor();
+    ASSERT_EQ(cursor.size(), 1);
+    for (auto row : cursor) {
+        AssertNullableColumn(row, "key", std::string{"key_new_decimal64"});
+        AssertNullableColumn(row, "value_decimal", Money{"-987.654321"});
+    }
+}
+
+UTEST_F(TDecimalYdbTestCase, PreparedUpsertNullTypeDecimal64) {
+    using Money = decimal64::Decimal<9>;
+
+    const ydb::Query upsert_query{R"(
+        --!syntax_v1
+        DECLARE $search_key AS String;
+        DECLARE $data_decimal AS Decimal(22, 9)?;
+
+        UPSERT INTO decimal_test (
+            key,
+            value_decimal
+        ) VALUES (
+            $search_key,
+            $data_decimal
+        );
+    )"};
+
+    auto upsert_builder = GetTableClient().GetBuilder();
+    UASSERT_NO_THROW(upsert_builder.Add("$search_key", std::string{"key_new_decimal64_null"}));
+    UASSERT_NO_THROW(upsert_builder.Add("$data_decimal", std::optional<Money>{}));
+
+    UASSERT_NO_THROW(
+        GetTableClient().ExecuteDataQuery(ydb::OperationSettings{}, upsert_query, std::move(upsert_builder))
+    );
+
+    auto result = GetTableClient().ExecuteDataQuery(ydb::Query{R"(
+        SELECT
+            key,
+            value_decimal
+        FROM decimal_test
+        WHERE key = "key_new_decimal64_null";
+    )"});
+
+    auto cursor = result.GetSingleCursor();
+    ASSERT_EQ(cursor.size(), 1);
+    for (auto row : cursor) {
+        AssertNullableColumn<std::string>(row, "key", "key_new_decimal64_null");
+        AssertNullColumn<Money>(row, "value_decimal");
+    }
+}
+
+UTEST_F(TDecimalYdbTestCase, InsertRowUpsertType) {
+    const ydb::Query query{R"(
+        --!syntax_v1
+        DECLARE $items AS List<
+            Struct<
+                'key': String,
+                'value_decimal': Decimal(22, 9)
+            >
+        >;
+
+        UPSERT INTO decimal_test
+        SELECT * FROM AS_TABLE($items);
+    )"};
+
+    auto builder = GetTableClient().GetBuilder();
+    auto row = ydb::InsertRow{
+        ydb::InsertColumn{"key", std::string{"key_new_insertrow"}},
+        ydb::InsertColumn{"value_decimal", ydb::Decimal{"42.000000001", 22, 9}},
+    };
+    std::vector<ydb::InsertRow> rows{row};
+    UASSERT_NO_THROW(builder.Add("$items", rows));
+
+    UASSERT_NO_THROW(GetTableClient().ExecuteDataQuery(ydb::OperationSettings{}, query, std::move(builder)));
+
+    auto result = GetTableClient().ExecuteDataQuery(ydb::Query{R"(
+        SELECT
+            key,
+            value_decimal
+        FROM decimal_test
+        WHERE key = "key_new_insertrow";
+    )"});
+
+    auto cursor = result.GetSingleCursor();
+    ASSERT_EQ(cursor.size(), 1);
+    for (auto row : cursor) {
+        AssertNullableColumn(row, "key", std::string{"key_new_insertrow"});
+        AssertNullableColumn(row, "value_decimal", ydb::Decimal{"42.000000001", 22, 9});
+    }
+}
+
+UTEST_F(TDecimalYdbTestCase, PreparedUpsertType) {
+    const ydb::Query upsert_query{R"(
+        --!syntax_v1
+        DECLARE $search_key AS String;
+        DECLARE $data_decimal AS Decimal(22, 9);
+
+        UPSERT INTO decimal_test (
+            key,
+            value_decimal
+        ) VALUES (
+            $search_key,
+            $data_decimal
+        );
+    )"};
+
+    auto upsert_builder = GetTableClient().GetBuilder();
+    UASSERT_NO_THROW(upsert_builder.Add("$search_key", std::string{"key_new_decimal"}));
+    UASSERT_NO_THROW(upsert_builder.Add("$data_decimal", ydb::Decimal{"-987.654321", 22, 9}));
+
+    UASSERT_NO_THROW(
+        GetTableClient().ExecuteDataQuery(ydb::OperationSettings{}, upsert_query, std::move(upsert_builder))
+    );
+
+    auto result = GetTableClient().ExecuteDataQuery(ydb::Query{R"(
+        SELECT
+            key,
+            value_decimal
+        FROM decimal_test
+        WHERE key = "key_new_decimal";
+    )"});
+
+    auto cursor = result.GetSingleCursor();
+    ASSERT_EQ(cursor.size(), 1);
+    for (auto row : cursor) {
+        AssertNullableColumn(row, "key", std::string{"key_new_decimal"});
+        AssertNullableColumn(row, "value_decimal", ydb::Decimal{"-987.654321", 22, 9});
+    }
+}
+
+// Verifies that `ydb::Decimal` correctly serializes non-default precision/scale.
+// The test fixture table uses Decimal(22, 9), so this test uses a prepared
+// parameter declared as `Decimal(35, 18)` and selects it back without storing it
+// in the fixture table. This checks that precision/scale round-trip through the SDK.
+UTEST_F(TDecimalWideYdbTestCase, RuntimePrecisionScale) {
+    const ydb::Query query{R"(
+        DECLARE $v AS Decimal(35, 18);
+
+        SELECT $v AS value_decimal;
+    )"};
+
+    const ydb::Decimal input{"-12345678901234567.123456789012345678", 35, 18};
+
+    auto builder = GetTableClient().GetBuilder();
+    UASSERT_NO_THROW(builder.Add("$v", input));
+
+    auto result = GetTableClient().ExecuteDataQuery(ydb::OperationSettings{}, query, std::move(builder));
+    auto cursor = result.GetSingleCursor();
+    ASSERT_EQ(cursor.size(), 1);
+    for (auto row : cursor) {
+        AssertNullableColumn(row, "value_decimal", input);
+    }
+}
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
# Add YDB Decimal support to `userver/ydb`

Related to #964.

This PR adds support for YDB `Decimal` values in the `userver/ydb` client.

YDB `Decimal` is parameterized by:

- `precision` — total number of digits, from `1` to `35`;
- `scale` — number of digits after the decimal point.

Both `precision` and `scale` are part of the YDB type, not the value, and therefore must be provided when writing values.

## Supported C++ representations

This PR introduces support for two C++ representations.

### `ydb::Decimal`

A lightweight POD-like wrapper around:

```cpp
(value, precision, scale)
```

It mirrors `NYdb::TDecimalValue` and preserves YDB type parameters as-is.

This type is useful when:

- the schema precision/scale are known only at runtime;
- a thin wrapper over the YDB SDK representation is needed;
- no numeric semantics are required.

### `decimal64::Decimal<Prec, RoundPolicy>`

The existing userver decimal type can now be used directly as a YDB column type.

By default, it maps to:

```text
Decimal(22, Prec)
```

where `22` is used as the default precision because it matches the common “money” schema.

Reads use `FromStringPermissive` to tolerate the canonical decimal string representation returned by the YDB SDK.

## Supported operations

Both representations are supported in:

  * prepared parameters via `builder.Add(...)`;
  * result row parsing via `row.Get<...>`.

NULL handling:

  * `std::optional<decimal64::Decimal<Prec, RoundPolicy>>` is supported for nullable Decimal parameters;
  * `std::optional<ydb::Decimal>` is supported on read only. Writing it is intentionally a compile-time error, because an empty optional does not carry precision/scale.

Additionally, `ydb::Decimal` is supported in:

  * `ydb::InsertRow`;
  * bulk upsert.

`decimal64::Decimal<Prec, RoundPolicy>` is not supported in `InsertRow`, because `std::variant` cannot hold a class template directly.

## What changed

| File | Change |
|---|---|
| `ydb/include/userver/ydb/types.hpp` | Added `ydb::Decimal`; added `Decimal` and `std::optional<Decimal>` to `InsertColumnValue`; updated documentation table |
| `ydb/include/userver/ydb/io/primitives.hpp` | Added `DecimalTrait`, `DecimalTraits<>`, `OptionalDecimalTraits<>`; added `ValueTraits` specializations for `ydb::Decimal` |
| `ydb/src/ydb/io/primitives.cpp` | Implemented Decimal traits |
| `ydb/include/userver/ydb/io/decimal64.hpp` | Added new header-only `ValueTraits` specializations for `decimal64::Decimal<Prec, RoundPolicy>` and `std::optional<...>` |
| `ydb/include/userver/ydb/io/supported_types.hpp` | Included the new decimal64 header; updated documentation table |

`ydb/src/ydb/io/insert_row.cpp` was intentionally left unchanged. Its existing `std::visit` over `InsertColumnValue` automatically handles the newly added variant alternatives.

## Design notes

### Separate Decimal traits

`DecimalTraits` and `OptionalDecimalTraits` are intentionally separate from the existing `PrimitiveTraits` family.

YDB `Decimal` is not a primitive type:

```cpp
ETypeKind::Decimal != ETypeKind::Primitive
```

Also, its type construction requires:

```cpp
TDecimalType{precision, scale}
```

instead of an `EPrimitiveType`.

### Default precision for `decimal64`

For `decimal64::Decimal<Prec, RoundPolicy>`, the YDB precision is currently hardcoded to:

```cpp
ydb::Decimal::kDefaultPrecision = 22
```

If a schema uses a different precision, `ydb::Decimal` should be used for now.

A compile-time wrapper such as:

```cpp
ydb::WithPrecision<P, S>
```

can be added later if needed.

### Equality semantics

`ydb::Decimal::operator==` performs strict string comparison, not numeric comparison.

This is intentional, because `ydb::Decimal` preserves the raw YDB representation rather than providing numeric semantics.

YDB may return decimals in canonical form. For example:

```text
"7.500000000" -> "7.5"
```

Therefore, `decimal64::Decimal<Prec>` should be used when numeric equality is required.

The tests follow the same rule.

## Testing

Added `ydb/tests/decimal_test.cpp` with integration tests in a dedicated `TDecimalYdbTestCase` fixture.

Coverage includes:

  * reading non-null Decimal values:
    * `ydb::Decimal`;
    * `decimal64::Decimal<9>`;
  * reading NULL Decimal values for both representations;
  * prepared `SELECT ... WHERE value = $param` with Decimal binding;
  * prepared UPSERT with `ydb::Decimal`;
  * prepared UPSERT with `decimal64::Decimal<9>`;
  * prepared UPSERT with NULL `std::optional<decimal64::Decimal<9>>`;
  * bulk UPSERT through `ydb::InsertRow` with non-null `ydb::Decimal`;
  * runtime precision/scale coverage via a prepared `Decimal(35, 18)` parameter.
  
## Out of scope

The original issue mentions YDB types beyond `Decimal`.

This PR only adds support for `Decimal`.

