### PR TITLE
crypto: fix issues in error handling

### DIFF
--- a/universal/src/crypto/certificate.cpp
+++ b/universal/src/crypto/certificate.cpp
@@ -49,7 +49,7 @@ Certificate Certificate::LoadFromString(std::string_view certificate) {
     Openssl::Init();
 
     if (!utils::text::StartsWith(certificate, kBeginMarker)) {
-        throw KeyParseError(FormatSslError("Not a certificate"));
+        throw KeyParseError("Not a certificate");
     }
 
     auto certbio = MakeBioString(certificate);
@@ -64,7 +64,7 @@ Certificate Certificate::LoadFromString(std::string_view certificate) {
 Certificate Certificate::LoadFromStringSkippingAttributes(std::string_view certificate) {
     const auto start = certificate.find(kBeginMarker);
     if (start == std::string::npos) {
-        throw KeyParseError(FormatSslError("Not a certificate"));
+        throw KeyParseError("Not a certificate");
     }
     return LoadFromString(certificate.substr(start));
 }
@@ -82,7 +82,7 @@ CertificatesChain LoadCertificatesChainFromString(std::string_view chain) {
         start = end;  // Move past the current certificate
     }
     if (certificates.empty()) {
-        throw KeyParseError(FormatSslError("There are no certificates in chain"));
+        throw KeyParseError("There are no certificates in chain");
     }
 
     return certificates;
@@ -91,7 +91,7 @@ CertificatesChain LoadCertificatesChainFromString(std::string_view chain) {
 std::string Certificate::GetSubject() const {
     X509* x509 = GetNative();
     if (!x509) {
-        throw KeyParseError(FormatSslError("Invalid certificate"));
+        throw KeyParseError("Invalid certificate");
     }
 
     X509_NAME* subject_name = X509_get_subject_name(x509);

--- a/universal/src/crypto/certificate.cpp
+++ b/universal/src/crypto/certificate.cpp
@@ -75,7 +75,9 @@ CertificatesChain LoadCertificatesChainFromString(std::string_view chain) {
     std::size_t start = 0;
     while ((start = chain.find(kBeginMarker, start)) != std::string::npos) {
         auto end = chain.find(kEndMarker, start);
-        UINVARIANT(end != std::string::npos, "No matching end marker found for certificate");
+        if (end == std::string::npos) {
+            throw KeyParseError("No matching end marker found for certificate");
+        }
 
         end += kEndMarker.length();
         certificates.push_back(Certificate::LoadFromString(chain.substr(start, end - start)));

--- a/universal/src/crypto/public_key.cpp
+++ b/universal/src/crypto/public_key.cpp
@@ -166,7 +166,7 @@ PublicKey PublicKey::LoadECFromComponents(CurveTypeView curve_view, CoordinateVi
     }
 
     if (!EVP_PKEY_set1_EC_KEY(pubkey.get(), ec.get())) {
-        throw KeyParseError{FormatSslError("Cannot set RSA key to EVP_PKEY")};
+        throw KeyParseError{FormatSslError("Cannot set EC key to EVP_PKEY")};
     }
 
     return PublicKey{std::move(pubkey)};

--- a/universal/src/crypto/public_key.cpp
+++ b/universal/src/crypto/public_key.cpp
@@ -69,7 +69,7 @@ constexpr utils::TrivialBiMap kCurveToNid = [](auto selector) {
 int CurveStringToNid(const std::string_view& curve_str) {
     auto opt_value = kCurveToNid.TryFindICaseByFirst(curve_str);
     if (!opt_value) {
-        throw KeyParseError{FormatSslError(fmt::format("Unsupported curve type {}", curve_str))};
+        throw KeyParseError{fmt::format("Unsupported curve type {}", curve_str)};
     }
     return *opt_value;
 }
@@ -119,7 +119,7 @@ PublicKey PublicKey::LoadFromPrivateKey(const PrivateKey& private_key) {
     Openssl::Init();
 
     if (!private_key) {
-        throw KeyParseError(FormatSslError("Failed to load public key from private key: private key is empty"));
+        throw KeyParseError("Failed to load public key from private key: private key is empty");
     }
 
     auto pubkey_bio = MakeBioMemoryBuffer();

--- a/universal/src/crypto/ssl_ctx.cpp
+++ b/universal/src/crypto/ssl_ctx.cpp
@@ -112,7 +112,7 @@ void SslCtx::SetCertificate(const crypto::Certificate& cert) {
 
 void SslCtx::SetCertificates(const crypto::CertificatesChain& cert_chain) {
     if (cert_chain.empty()) {
-        throw CryptoException(crypto::FormatSslError("Empty certificate chain provided"));
+        throw CryptoException("Empty certificate chain provided");
     }
 
     SetCertificate(*cert_chain.begin());
@@ -143,7 +143,7 @@ void SslCtx::SetPrivateKey(const crypto::PrivateKey& key) {
     LOG_INFO() << "Loaded server private key";
 
     if (1 != SSL_CTX_check_private_key(impl_->Get())) {
-        throw CryptoException("Private key does not match the certificate public key");
+        throw CryptoException(crypto::FormatSslError("Private key does not match the certificate public key"));
     }
 }
 


### PR DESCRIPTION
51163a4a607aabd93e293e4b08fea3b1a404b961: some sites call to the FormatSslError() helper that drains current thread's error queue. But these happen without calling any OSSL API beforehand.
Next calls to functions that do drain can misattribute errors.
c7900ed91d04a08d33801906594a318a02d8ef86: LoadCertificatesChainFromString thinks malformed chain is an invariant violation


