### PR TITLE
Code style: don't patch expressions/statements with preprocessor

### DIFF
--- a/core/libc_include_fixes/errno.h
+++ b/core/libc_include_fixes/errno.h
@@ -15,11 +15,15 @@
 extern "C" {
 #endif
 
-extern int* __errno_location(void)
 #ifdef __THROW
-    __THROW
+#define USERVER_IMPL_LIBC_INCLUDE_FIXES_THROW __THROW
+#else
+#define USERVER_IMPL_LIBC_INCLUDE_FIXES_THROW
 #endif
-    ;
+
+extern int* __errno_location(void) USERVER_IMPL_LIBC_INCLUDE_FIXES_THROW;
+
+#undef USERVER_IMPL_LIBC_INCLUDE_FIXES_THROW
 
 #ifdef __cplusplus
 }

--- a/core/libc_include_fixes/pthread.h
+++ b/core/libc_include_fixes/pthread.h
@@ -15,11 +15,15 @@
 extern "C" {
 #endif
 
-extern pthread_t pthread_self(void)
 #ifdef __THROW
-    __THROW
+#define USERVER_IMPL_LIBC_INCLUDE_FIXES_THROW __THROW
+#else
+#define USERVER_IMPL_LIBC_INCLUDE_FIXES_THROW
 #endif
-    ;
+
+extern pthread_t pthread_self(void) USERVER_IMPL_LIBC_INCLUDE_FIXES_THROW;
+
+#undef USERVER_IMPL_LIBC_INCLUDE_FIXES_THROW
 
 #ifdef __cplusplus
 }

--- a/core/src/clients/dns/net_resolver.cpp
+++ b/core/src/clients/dns/net_resolver.cpp
@@ -236,11 +236,14 @@ public:
     }
 
     void InitChannel() {
-        constexpr int kOptmask =
-            ARES_OPT_FLAGS | ARES_OPT_TIMEOUTMS | ARES_OPT_TRIES | ARES_OPT_DOMAINS |
+        constexpr int kSockStateCbOptmask =
 #if ARES_VERSION < 0x011400
-            ARES_OPT_SOCK_STATE_CB |
+            ARES_OPT_SOCK_STATE_CB;
+#else
+            0;
 #endif
+        constexpr int kOptmask =
+            ARES_OPT_FLAGS | ARES_OPT_TIMEOUTMS | ARES_OPT_TRIES | ARES_OPT_DOMAINS | kSockStateCbOptmask |
             ARES_OPT_LOOKUPS;
         struct ares_options options {};
         options.flags =

--- a/core/src/engine/ev/watcher/io_watcher_test.cpp
+++ b/core/src/engine/ev/watcher/io_watcher_test.cpp
@@ -10,10 +10,12 @@
 USERVER_NAMESPACE_BEGIN
 
 #if defined(BSD) && !defined(__APPLE__)
-UTEST(IoWatcher, DISABLED_DevNull) {
+#define USERVER_IMPL_IO_WATCHER_DEV_NULL DISABLED_DevNull
 #else
-UTEST(IoWatcher, DevNull) {
+#define USERVER_IMPL_IO_WATCHER_DEV_NULL DevNull
 #endif
+
+UTEST(IoWatcher, USERVER_IMPL_IO_WATCHER_DEV_NULL) {
     LOG_DEBUG() << "Opening /dev/null";
     engine::ev::Thread thread{"test_thread"};
     engine::ev::ThreadControl thread_control(thread);

--- a/core/src/engine/io/fd_control.hpp
+++ b/core/src/engine/io/fd_control.hpp
@@ -45,6 +45,14 @@ enum class ErrorMode {
     kFatal,      ///< break execute operation
 };
 
+constexpr bool IsRetryableIoError(int error_code) noexcept {
+#if EWOULDBLOCK != EAGAIN
+    return error_code == EWOULDBLOCK || error_code == EAGAIN;
+#else
+    return error_code == EWOULDBLOCK;
+#endif
+}
+
 class FdControl;
 
 class Direction final {
@@ -323,12 +331,7 @@ ErrorMode Direction::TryHandleError(
 ) {
     if (error_code == EINTR) {
         return ErrorMode::kProcessed;
-    } else if (error_code == EWOULDBLOCK
-#if EWOULDBLOCK != EAGAIN
-               || error_code == EAGAIN
-#endif
-    )
-    {
+    } else if (IsRetryableIoError(error_code)) {
         if (processed_bytes != 0 && mode != TransferMode::kWhole) {
             return ErrorMode::kFatal;
         }

--- a/core/src/engine/io/socket.cpp
+++ b/core/src/engine/io/socket.cpp
@@ -26,17 +26,41 @@ namespace {
 constexpr size_t kMaxStackSizeVector = 32;
 
 // MAC_COMPAT: does not accept flags in type
+constexpr int kSockNonblockFlag =
+#ifdef SOCK_NONBLOCK
+    SOCK_NONBLOCK;
+#else
+    0;
+#endif
+
+constexpr int kSockCloexecFlag =
+#ifdef SOCK_CLOEXEC
+    SOCK_CLOEXEC;
+#else
+    0;
+#endif
+
+// MAC_COMPAT: does not support MSG_NOSIGNAL
+constexpr int kMsgNosignalFlag =
+#ifdef MSG_NOSIGNAL
+    MSG_NOSIGNAL;
+#else
+    0;
+#endif
+
+bool IsWouldBlock() noexcept {
+#if EAGAIN != EWOULDBLOCK
+    return errno == EAGAIN || errno == EWOULDBLOCK;
+#else
+    return errno == EAGAIN;
+#endif
+}
+
 impl::FdControlHolder MakeSocket(AddrDomain domain, SocketType type) {
     return impl::FdControl::Adopt(utils::CheckSyscallCustomException<IoSystemError>(
         ::socket(
             static_cast<int>(domain),
-#ifdef SOCK_NONBLOCK
-            SOCK_NONBLOCK |
-#endif
-#ifdef SOCK_CLOEXEC
-                SOCK_CLOEXEC |
-#endif
-                static_cast<int>(type),
+            kSockNonblockFlag | kSockCloexecFlag | static_cast<int>(type),
             /* protocol=*/0
         ),
         "creating socket"
@@ -68,11 +92,7 @@ Sockaddr& MemoizeAddr(
         fd,
         buf,
         len,
-// MAC_COMPAT: does not support MSG_NOSIGNAL
-#ifdef MSG_NOSIGNAL
-        MSG_NOSIGNAL |
-#endif
-            0
+        kMsgNosignalFlag
     );
 }
 
@@ -106,11 +126,7 @@ public:
             fd,
             buf,
             len,
-// MAC_COMPAT: does not support MSG_NOSIGNAL
-#ifdef MSG_NOSIGNAL
-            MSG_NOSIGNAL |
-#endif
-                0,
+            kMsgNosignalFlag,
             dest_addr_.Data(),
             dest_addr_.Size()
         );
@@ -275,14 +291,9 @@ std::optional<size_t> Socket::RecvNoblock(void* buf, size_t len) {
     const auto bytes_read = RecvWrapper(fd_control_->Fd(), buf, len);
     if (bytes_read >= 0) {
         return {bytes_read};
-    } else if (
-#if EAGAIN != EWOULDBLOCK
-        EWOULDBLOCK == errno
-#else
-        EAGAIN == errno
-#endif
-    )
+    } else if (IsWouldBlock()) {
         return {};
+    }
 
     throw IoException("Attempt to RecvNoblock from closed socket");
 }

--- a/core/src/server/http/http_response_cookie_test.cpp
+++ b/core/src/server/http/http_response_cookie_test.cpp
@@ -9,6 +9,12 @@
 
 USERVER_NAMESPACE_BEGIN
 
+#if defined(BSD) && !defined(__APPLE__)
+#define USERVER_IMPL_HTTP_COOKIE_TIMEZONE "UTC; "
+#else
+#define USERVER_IMPL_HTTP_COOKIE_TIMEZONE "GMT; "
+#endif
+
 TEST(HttpCookie, Simple) {
     server::http::Cookie cookie{"name1", "value1"};
     EXPECT_EQ(cookie.ToString(), "name1=value1");
@@ -29,11 +35,7 @@ TEST(HttpCookie, Simple) {
     const auto* const expected =
         "name1=value1; Domain=domain.com; Path=/; Expires=Wed, 12 Jun 2019 "
         "16:51:45 "
-#if defined(BSD) && !defined(__APPLE__)
-        "UTC; "
-#else
-        "GMT; "
-#endif
+        USERVER_IMPL_HTTP_COOKIE_TIMEZONE
         "Max-Age=3600; Secure; HttpOnly";
     EXPECT_EQ(cookie.ToString(), expected);
 
@@ -41,11 +43,7 @@ TEST(HttpCookie, Simple) {
     const auto* const expected2 =
         "name1=value1; Domain=domain.com; Path=/; Expires=Wed, 12 Jun 2019 "
         "16:51:45 "
-#if defined(BSD) && !defined(__APPLE__)
-        "UTC; "
-#else
-        "GMT; "
-#endif
+        USERVER_IMPL_HTTP_COOKIE_TIMEZONE
         "Max-Age=3600; Secure; SameSite=None; HttpOnly";
     EXPECT_EQ(cookie.ToString(), expected2);
 

--- a/libraries/grpc-reflection/src/grpc-reflection/proto_server_reflection.cpp
+++ b/libraries/grpc-reflection/src/grpc-reflection/proto_server_reflection.cpp
@@ -22,6 +22,7 @@
 #include <grpc-reflection/proto_server_reflection.hpp>
 
 #include <stdexcept>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -35,6 +36,18 @@ namespace proto_reflection = grpc::reflection::v1alpha;
 USERVER_NAMESPACE_BEGIN
 
 namespace grpc_reflection {
+
+namespace {
+
+auto ToDescriptorLookupName(std::string_view name) {
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+    return name;
+#else
+    return std::string{name};
+#endif
+}
+
+}  // namespace
 
 ProtoServerReflection::ProtoServerReflection() : descriptor_pool_(grpc::protobuf::DescriptorPool::generated_pool()) {}
 
@@ -115,12 +128,9 @@ ProtoServerReflection::GetFileByName(std::string_view file_name, proto_reflectio
         return ::grpc::Status::CANCELLED;
     }
 
-    const grpc::protobuf::FileDescriptor* file_desc =
-#if GOOGLE_PROTOBUF_VERSION >= 4022000
-        descriptor_pool_->FindFileByName(file_name);
-#else
-        descriptor_pool_->FindFileByName(std::string{file_name});
-#endif
+    const grpc::protobuf::FileDescriptor* file_desc = descriptor_pool_->FindFileByName(
+        ToDescriptorLookupName(file_name)
+    );
     if (file_desc == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::NOT_FOUND, "File not found.");
     }
@@ -137,11 +147,9 @@ ProtoServerReflection::GetFileByName(std::string_view file_name, proto_reflectio
         return ::grpc::Status::CANCELLED;
     }
 
-#if GOOGLE_PROTOBUF_VERSION >= 4022000
-    const grpc::protobuf::FileDescriptor* file_desc = descriptor_pool_->FindFileContainingSymbol(symbol);
-#else
-    const grpc::protobuf::FileDescriptor* file_desc = descriptor_pool_->FindFileContainingSymbol(std::string{symbol});
-#endif
+    const grpc::protobuf::FileDescriptor* file_desc = descriptor_pool_->FindFileContainingSymbol(
+        ToDescriptorLookupName(symbol)
+    );
     if (file_desc == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::NOT_FOUND, "Symbol not found.");
     }
@@ -181,11 +189,7 @@ ProtoServerReflection::GetFileByName(std::string_view file_name, proto_reflectio
         return ::grpc::Status::CANCELLED;
     }
 
-#if GOOGLE_PROTOBUF_VERSION >= 4022000
-    const grpc::protobuf::Descriptor* desc = descriptor_pool_->FindMessageTypeByName(type);
-#else
-    const grpc::protobuf::Descriptor* desc = descriptor_pool_->FindMessageTypeByName(std::string{type});
-#endif
+    const grpc::protobuf::Descriptor* desc = descriptor_pool_->FindMessageTypeByName(ToDescriptorLookupName(type));
     if (desc == nullptr) {
         return ::grpc::Status(::grpc::StatusCode::NOT_FOUND, "Type not found.");
     }

--- a/mongo/src/storages/mongo/cdriver/pool_impl.cpp
+++ b/mongo/src/storages/mongo/cdriver/pool_impl.cpp
@@ -215,6 +215,22 @@ void HeartbeatFailed(const mongoc_apm_server_heartbeat_failed_t* event) {
     HeartbeatFinished(stats);
 }
 
+bool HasReadableServer(const mongoc_topology_description_t* td, mongoc_read_prefs_t* prefs) {
+#if MONGOC_CHECK_VERSION(1, 17, 0)
+    return mongoc_topology_description_has_readable_server(td, prefs);
+#else
+    return mongoc_topology_description_has_readable_server(const_cast<mongoc_topology_description_t*>(td), prefs);
+#endif
+}
+
+bool HasWritableServer(const mongoc_topology_description_t* td) {
+#if MONGOC_CHECK_VERSION(1, 17, 0)
+    return mongoc_topology_description_has_writable_server(td);
+#else
+    return mongoc_topology_description_has_writable_server(const_cast<mongoc_topology_description_t*>(td));
+#endif
+}
+
 std::string CreateTopologyChangeMessage(const mongoc_apm_topology_changed_t* event) {
     const mongoc_topology_description_t* prev_td = mongoc_apm_topology_changed_get_previous_description(event);
     const mongoc_topology_description_t* new_td = mongoc_apm_topology_changed_get_new_description(event);
@@ -261,21 +277,13 @@ std::string CreateTopologyChangeMessage(const mongoc_apm_topology_changed_t* eve
     mongoc_read_prefs_t* prefs = mongoc_read_prefs_new(MONGOC_READ_SECONDARY);
     const utils::FastScopeGuard prefs_guard{[&prefs]() noexcept { mongoc_read_prefs_destroy(prefs); }};
 
-#if MONGOC_CHECK_VERSION(1, 17, 0)
-    if (mongoc_topology_description_has_readable_server(new_td, prefs)) {
-#else
-    if (mongoc_topology_description_has_readable_server(const_cast<mongoc_topology_description_t*>(new_td), prefs)) {
-#endif
+    if (HasReadableServer(new_td, prefs)) {
         topology_msg.append("\nSecondary AVAILABLE\n");
     } else {
         topology_msg.append("\nSecondary UNAVAILABLE\n");
     }
 
-#if MONGOC_CHECK_VERSION(1, 17, 0)
-    if (mongoc_topology_description_has_writable_server(new_td)) {
-#else
-    if (mongoc_topology_description_has_writable_server(const_cast<mongoc_topology_description_t*>(new_td))) {
-#endif
+    if (HasWritableServer(new_td)) {
         topology_msg.append("Primary AVAILABLE");
     } else {
         topology_msg.append("Primary UNAVAILABLE");

--- a/postgresql/pq-extra/pq_workaround.c
+++ b/postgresql/pq-extra/pq_workaround.c
@@ -120,6 +120,30 @@ static int getParameterStatus(PGconn* conn) {
   return 0;
 }
 
+static int PqxShouldReturnOnIdlePipeline(PGconn* conn) {
+#if PG_VERSION_NUM >= 140000 && PG_VERSION_NUM < 140005
+  return conn->pipelineStatus != PQ_PIPELINE_OFF &&
+         conn->cmd_queue_head != NULL;
+#else
+  (void)conn;
+  return 0;
+#endif
+}
+
+static void PqxMaybeHandleBindComplete(PGconn* conn) {
+  if (conn->cmd_queue_head &&
+      conn->cmd_queue_head->queryclass == PGXQUERY_BIND) {
+    pqCommandQueueAdvanceGlue(conn, false, false);
+    if (conn->pipelineStatus != PQ_PIPELINE_OFF) {
+#if PG_VERSION_NUM >= 140005
+      conn->asyncStatus = PGASYNC_PIPELINE_IDLE;
+#else
+      conn->asyncStatus = PGASYNC_IDLE;
+#endif
+    }
+  }
+}
+
 /*
  * This is copy-paste of pqParseInput3 from fe-protocol3.c, with added
  * handling of `portal suspended` server message
@@ -210,7 +234,6 @@ static void pqxParseInput3(PGconn* conn, const PGresult* description) {
       /* If not IDLE state, just wait ... */
       if (conn->asyncStatus != PGASYNC_IDLE) return;
 
-#if PG_VERSION_NUM >= 140000 && PG_VERSION_NUM < 140005
       /*
        * We're also notionally not-IDLE when in pipeline mode the state
        * says "idle" (so we have completed receiving the results of one
@@ -219,10 +242,8 @@ static void pqxParseInput3(PGconn* conn, const PGresult* description) {
        * that they can initiate processing of the next query in the
        * queue.
        */
-      if (conn->pipelineStatus != PQ_PIPELINE_OFF &&
-          conn->cmd_queue_head != NULL)
+      if (PqxShouldReturnOnIdlePipeline(conn))
         return;
-#endif
 
       /*
        * Unexpected message in IDLE state; need to recover somehow.
@@ -323,20 +344,7 @@ static void pqxParseInput3(PGconn* conn, const PGresult* description) {
           }
           break;
         case '2': /* Bind Complete */
-          if (conn->cmd_queue_head &&
-              conn->cmd_queue_head->queryclass == PGXQUERY_BIND) {
-            pqCommandQueueAdvanceGlue(conn, false, false);
-            /*
-              In case of portal bind, only in pipeline mode
-              the query ends here without a result
-            */
-            if (conn->pipelineStatus != PQ_PIPELINE_OFF)
-#if PG_VERSION_NUM >= 140005
-              conn->asyncStatus = PGASYNC_PIPELINE_IDLE;
-#else
-              conn->asyncStatus = PGASYNC_IDLE;
-#endif
-          }
+          PqxMaybeHandleBindComplete(conn);
           break;
         case '3': /* Close Complete */
 #if PG_VERSION_NUM >= 140005
@@ -1694,4 +1702,3 @@ sendFailed:
   /* error message should be set up already */
   return 0;
 }
-

--- a/universal/include/userver/compiler/select.hpp
+++ b/universal/include/userver/compiler/select.hpp
@@ -65,11 +65,10 @@ private:
         constexpr auto kBits = (sizeof(void*) == 8 ? Bits::k64 : Bits::k32);
         constexpr auto kLib =
 #if defined(_LIBCPP_VERSION)
-            StdLibs::kCpp
+            StdLibs::kCpp;
 #else
-            StdLibs::kStdCpp
+            StdLibs::kStdCpp;
 #endif
-            ;
 
         if (bits == kBits) {
             if (lib == kLib) {

--- a/universal/include/userver/utils/from_string.hpp
+++ b/universal/include/userver/utils/from_string.hpp
@@ -69,15 +69,18 @@ private:
 namespace impl {
 
 template <typename T>
-concept IsFromCharsConvertible =
-    requires(T& v) { std::from_chars(std::declval<const char*>(), std::declval<const char*>(), v); } &&
+concept IsFromCharsCorrectlySupported =
 #if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 13
     // libstdc++ before 13.1 parse long double incorrectly
-    !std::same_as<T, long double>
+    !std::same_as<T, long double>;
 #else
-    true
+    true;
 #endif
-    ;
+
+template <typename T>
+concept IsFromCharsConvertible =
+    requires(T& v) { std::from_chars(std::declval<const char*>(), std::declval<const char*>(), v); } &&
+    IsFromCharsCorrectlySupported<T>;
 
 [[noreturn]] void ThrowFromStringException(
     FromStringErrorCode code,

--- a/universal/src/crypto/ssl_ctx.cpp
+++ b/universal/src/crypto/ssl_ctx.cpp
@@ -45,12 +45,15 @@ std::unique_ptr<SslCtx::Impl> SslCtx::Impl::MakeSslCtx() {
     }
 #endif
 
-    constexpr auto options =
-        SSL_OP_ALL | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION
+    constexpr auto kSslOpNoRenegotiation =
 #if OPENSSL_VERSION_NUMBER >= 0x010100000L
-        | SSL_OP_NO_RENEGOTIATION
+        SSL_OP_NO_RENEGOTIATION;
+#else
+        0;
 #endif
-        ;
+
+    constexpr auto options =
+        SSL_OP_ALL | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION | kSslOpNoRenegotiation;
     SSL_CTX_set_options(ssl_ctx, options);
     SSL_CTX_set_mode(ssl_ctx, SSL_MODE_ENABLE_PARTIAL_WRITE);
     SSL_CTX_clear_mode(ssl_ctx, SSL_MODE_AUTO_RETRY);

--- a/universal/utest/src/utest/current_process_open_files_test.cpp
+++ b/universal/utest/src/utest/current_process_open_files_test.cpp
@@ -21,10 +21,12 @@ constexpr std::string_view kTestFilePart = "test_files_listing_of_current_proc";
 // non-closed file descriptors.
 #if defined(BSD)
 // /dev/fd/* are not symlinks
-TEST(DISABLED_CurrentProcessOpenFiles, Basic) {
+#define USERVER_IMPL_CURRENT_PROCESS_OPEN_FILES DISABLED_CurrentProcessOpenFiles
 #else
-TEST(CurrentProcessOpenFiles, Basic) {
+#define USERVER_IMPL_CURRENT_PROCESS_OPEN_FILES CurrentProcessOpenFiles
 #endif
+
+TEST(USERVER_IMPL_CURRENT_PROCESS_OPEN_FILES, Basic) {
     const auto file_guard = fs::blocking::TempFile::Create("/tmp", kTestFilePart);
     const auto& path = file_guard.GetPath();
 

--- a/ydb/src/ydb/response.cpp
+++ b/ydb/src/ydb/response.cpp
@@ -27,14 +27,22 @@ ParseState::ParseState(const NYdb::TResultSet& result_set)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Row::Row(impl::ParseState& parse_state)
-    : parse_state_(parse_state)
+namespace {
+
+std::vector<bool> MakeConsumedColumns(impl::ParseState& parse_state) {
 #ifndef NDEBUG
-      ,
-      consumed_columns_(parse_state_.parser.ColumnsCount(), false)
+    return std::vector<bool>(parse_state.parser.ColumnsCount(), false);
+#else
+    (void)parse_state;
+    return {};
 #endif
-{
 }
+
+}  // namespace
+
+Row::Row(impl::ParseState& parse_state)
+    : parse_state_(parse_state),
+      consumed_columns_(MakeConsumedColumns(parse_state_)) {}
 
 NYdb::TValueParser& Row::GetColumn(std::size_t index) { return parse_state_.parser.ColumnParser(index); }
 


### PR DESCRIPTION
This pull request establishes the following code style discipline: conditional directives are not allowed below the supported item boundary, such as inside an expression, declaration, or statement header. 

Conditional compilation is allowed:
- When each branch contributes complete grammar items at the surrounding level: complete declarations, complete statements, field or method declarations, enum entries, macro definitions, or includes.
- For complete items in comma-separated lists, such as function arguments, braced initializer items, subscript items, declaration parameters, template arguments, template parameters, and enum entries. 
- For conditional right-hand sides after `=` in assignment statements, alias declarations, and concept definitions.
- For conditional declaration-prefix modifiers.

This discipline keeps the code easier to read for humans and easier to parse, highlight, and format with tools. Code-analysis tools do not need to reason about partial expressions or statement headers across all conditional-compilation branches.

P.S. There's an ongoing work in https://github.com/elizarov/strictfmt to implement a rule-based source code formatter that correctly parses and formats all the source code when these restrictions are met.