### PR TITLE
fix universal: fix random generator initialization in C++23

### DIFF
--- a/universal/src/utils/rand.cpp
+++ b/universal/src/utils/rand.cpp
@@ -8,11 +8,6 @@ namespace utils {
 
 namespace {
 
-template <typename T>
-auto& AsLvalue(T&& rvalue) noexcept {
-    return rvalue;
-}
-
 compiler::ThreadLocal local_random_impl = [] { return impl::RandomImpl{}; };
 
 }  // namespace
@@ -34,8 +29,10 @@ std::seed_seq MakeSeedSeq() {
 }
 
 RandomImpl::RandomImpl()
-    : gen_(AsLvalue(impl::MakeSeedSeq()))
-{}
+    : gen_([] {
+          auto seed_seq = MakeSeedSeq();
+          return decltype(gen_){seed_seq};
+      }()) {}
 
 compiler::ThreadLocalScope<RandomImpl> UseLocalRandomImpl() { return local_random_impl.Use(); }
 


### PR DESCRIPTION
`utils::impl::RandomImpl` initialized `std::mt19937` via `AsLvalue(impl::MakeSeedSeq())`.

This fails to compile in C++23, because returning the rvalue-reference parameter from `AsLvalue` is affected by the C++23 implicit move rules from P2266R3. As a result, the returned expression may no longer be treated as a non-const lvalue reference, while the seed-sequence constructor of the generator expects a non-const lvalue seed sequence.

The error is (gcc 15.2.0):

```text
error: cannot bind non-const lvalue reference of type ‘std::seed_seq&’ to an rvalue of type ‘std::seed_seq’
```

This change removes the `AsLvalue` helper and initializes the generator from a local `std::seed_seq` object instead. The local object stays alive for the duration of the generator construction, and no reference to a temporary is returned.

Testing:

* Built a userver-based project with `CMAKE_CXX_STANDARD=23`.
* Built and ran `userver-universal-unittest`.
* Full `userver-universal-unittest` run: 1671/1672 tests passed. The only failure was `LogFilepath.UserverCroppedCorrectly`, which appears to be path-layout-sensitive when userver is built as a CPM dependency under `_deps/userver-src`.
