### PR TITLE
fix universal: fix ForwardLike in C++23 to behave same as std::forwad_like

### DIFF
--- a/universal/include/userver/utils/forward_like.hpp
+++ b/universal/include/userver/utils/forward_like.hpp
@@ -4,7 +4,6 @@
 /// @brief @copybrief utils::ForwardLike
 
 #include <type_traits>
-#include <utility>
 
 #include <userver/compiler/impl/nodebug.hpp>
 
@@ -14,23 +13,18 @@ namespace utils {
 
 /// Analogue of std::forward_like from C++23.
 template <typename T, typename U>
-USERVER_IMPL_NODEBUG_INLINE_FUNC inline auto&& ForwardLike(U&& x) noexcept {
+USERVER_IMPL_NODEBUG_INLINE_FUNC inline constexpr auto&& ForwardLike(U&& x) noexcept {
     constexpr bool is_adding_const = std::is_const_v<std::remove_reference_t<T>>;
+
+    using URef = std::remove_reference_t<U>;
+    using V = std::conditional_t<is_adding_const, std::add_const_t<URef>, URef>;
+
     if constexpr (std::is_lvalue_reference_v<T&&>) {
-        if constexpr (is_adding_const) {
-            return std::as_const(x);
-        } else {
-            return x;
-        }
+        return static_cast<V&>(x);
     } else {
-        if constexpr (is_adding_const) {
-            return std::move(std::as_const(x));
-        } else {
-            return std::move(x);  // NOLINT(bugprone-move-forwarding-reference)
-        }
+        return static_cast<V&&>(x);
     }
 }
 
 }  // namespace utils
-
 USERVER_NAMESPACE_END


### PR DESCRIPTION
`utils::ForwardLike` used `return x;` for the non-const lvalue-like case.

This no longer matches `std::forward_like` in C++23. Since P2266R3 ("Simpler implicit move"), the C++23 return statement rules treat a move-eligible returned expression as an xvalue. In standard wording this is the return statement wording in `[stmt.return]`: if the returned expression is move-eligible, it is treated as an xvalue. `std::forward_like<T>` still has to preserve the reference category requested by `T&&`, so `ForwardLike<int&>(...)` must produce an lvalue reference.

The existing `forward_like_test.cpp` fails with gcc 15.2.0:

```text
/home/egoncharov/bcore/cmake-build-debug/_deps/userver-src/universal/src/utils/forward_like_test.cpp:55:27:   required from here
   55 |     TestsTwoForwards<int&>(char{});
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
/home/egoncharov/bcore/cmake-build-debug/_deps/userver-src/universal/src/utils/forward_like_test.cpp:36:24: error: static assertion failed
   36 |     static_assert(std::is_same_v<
      |                   ~~~~~^~~~~~~~~~
   37 |                   decltype(std::forward_like<T>(std::forward<U>(x))),
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   38 |                   decltype(utils::ForwardLike<T>(std::forward<U>(x)))>);
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/egoncharov/bcore/cmake-build-debug/_deps/userver-src/universal/src/utils/forward_like_test.cpp:36:24: note: 'std::is_same_v<char&, char&&>' evaluates to false
```

This change implements `ForwardLike` via explicit casts to the expected reference type instead of relying on `return x`, `std::move`, or `std::as_const`.

Here is minimal demonsration of difference between original ForwardLike and std::forward_like in C++23:
https://godbolt.org/z/s7WdxYaWe

The implementation now:

* propagates `const` from `T` to the returned reference type;
* uses `T&&` to decide whether the result should be an lvalue reference or an rvalue reference;
* avoids dependence on C++23 return statement implicit move rules;
* matches `std::forward_like` semantics.

Testing:

* Built a userver-based project with `CMAKE_CXX_STANDARD=23`.
* Built and ran `userver-universal-unittest`.
* Full `userver-universal-unittest` run: 1671/1672 tests passed. The only failure was `LogFilepath.UserverCroppedCorrectly`, which appears to be path-layout-sensitive when userver is built as a CPM dependency under `_deps/userver-src`.



