### PR TITLE
fix websocket: avoid size_t overflow in frame length check

### DIFF
--- a/core/src/websocket/impl/protocol.cpp
+++ b/core/src/websocket/impl/protocol.cpp
@@ -204,7 +204,9 @@ CloseStatus ReadWSFrameImpl(
         return CloseStatus::kProtocolError;
     }
 
-    if (payload_len + frame.payload->size() > max_payload_size) {
+    // payload_len comes straight from the 64-bit extended length, so check it
+    // separately to avoid size_t wraparound in the sum below.
+    if (payload_len > max_payload_size || frame.payload->size() > max_payload_size - payload_len) {
         return CloseStatus::kTooBigData;
     }
 


### PR DESCRIPTION
1. payload_len is read straight from the 64-bit extended length field, so a client fully controls it.
2. the check `payload_len + frame.payload->size() > max_payload_size` wraps in size_t when payload_len is near SIZE_MAX, so after a 1-byte fragmented frame a continuation frame with extended length 0xFFFFFFFFFFFFFFFF passes the limit, the payload is resized to the wrapped near-zero size, and RecvExactly then writes payload_len bytes past the buffer.

Bound payload_len against max_payload_size before adding, then compare the current size against the remaining budget. max-remote-payload defaults to 65536 and the frame reader runs server-side on every client message.