### PR TITLE
use unsigned char for ctype calls in request header parsers

### DIFF
--- a/core/src/server/handlers/auth/digest/directives_parser.cpp
+++ b/core/src/server/handlers/auth/digest/directives_parser.cpp
@@ -79,7 +79,10 @@ ContextFromClient Parser::ParseAuthInfo(std::string_view auth_header_value) {
         fmt::format("Result is: '{}'", auth_header_value.substr(0, kDigestWord.size()))
     );
     auto directives_str = auth_header_value.substr(kDigestWord.size() + 1);
-    for (const char delimiter : directives_str) {
+    // delimiter must be unsigned: std::isalnum/std::isspace have undefined
+    // behavior when passed a negative value, and directives_str is attacker
+    // controlled, so a byte >= 0x80 would otherwise reach them as a negative int.
+    for (const unsigned char delimiter : directives_str) {
         switch (state) {
             case State::kStateSpace:
                 if (std::isalnum(delimiter) || delimiter == '_' || delimiter == '-') {

--- a/core/src/server/handlers/auth/digest/directives_parser_test.cpp
+++ b/core/src/server/handlers/auth/digest/directives_parser_test.cpp
@@ -147,6 +147,15 @@ response="6629fae49393a05397450978507c4ef1"
     EXPECT_THROW(parser.ParseAuthInfo(directives_str), ParseException);
 }
 
+TEST(DirectivesParser, HighBitByteInToken) {
+    // A byte >= 0x80 is negative when char is signed. It reaches std::isalnum
+    // as a negative int (undefined behavior) unless treated as unsigned char.
+    // Such a byte is not a valid token character, so parsing must be rejected.
+    std::string directives_str = "Digest \xC3username=\"Mufasa\"";
+    Parser parser;
+    EXPECT_THROW(parser.ParseAuthInfo(directives_str), ParseException);
+}
+
 TEST(DirectivesParser, UnknownDirective) {
     const std::string_view directives_str = R"(Digest
 username="Mufasa",

--- a/core/src/server/http/http_request_builder.cpp
+++ b/core/src/server/http/http_request_builder.cpp
@@ -11,10 +11,10 @@ namespace server::http {
 namespace {
 
 inline void Strip(const char*& begin, const char*& end) {
-    while (begin < end && isspace(*begin)) {
+    while (begin < end && isspace(static_cast<unsigned char>(*begin))) {
         ++begin;
     }
-    while (begin < end && isspace(end[-1])) {
+    while (begin < end && isspace(static_cast<unsigned char>(end[-1]))) {
         --end;
     }
 }


### PR DESCRIPTION
Repro: send a request whose `Authorization: Digest ...` or `Cookie` header contains a byte >= 0x80 (for example `Digest \xC3username=...`).
Cause: `ParseAuthInfo` and the cookie `Strip` helper walk the header with a signed `char` and hand each byte to `std::isalnum`/`std::isspace`. A byte >= 0x80 becomes a negative `int`, and passing a negative value other than `EOF` to the ctype functions is undefined behavior; on libc builds whose classification table is not defined below zero this is an out-of-bounds read.
Fix: classify the bytes as `unsigned char`, the same convention already used in `universal/src/http/url.cpp`.

Both headers are parsed before authentication, so any client can reach the call. Added a regression test that feeds a high-bit byte through the digest parser.