### PR TITLE
fix build: add lost Debian boost dependencies

### DIFF
--- a/scripts/docs/en/deps/debian-12.md
+++ b/scripts/docs/en/deps/debian-12.md
@@ -4,6 +4,8 @@ cmake
 gdb
 git
 libbenchmark-dev
+libboost-context1.81-dev
+libboost-coroutine1.81-dev 
 libboost1.81-dev
 libboost-filesystem1.81-dev
 libboost-iostreams1.81-dev

--- a/scripts/docs/en/deps/debian-13.md
+++ b/scripts/docs/en/deps/debian-13.md
@@ -4,6 +4,8 @@ cmake
 gdb
 git
 libbenchmark-dev
+libboost-context1.83-dev
+libboost-coroutine1.83-dev 
 libboost1.83-dev
 libboost-filesystem1.83-dev
 libboost-iostreams1.83-dev


### PR DESCRIPTION

Problem:
CMake fails to find the `boost_context` component when building userver on Debian 13 (trixie):
CMake Error at sr/lib/x86_64-linux-gnu/cmake/Boost-1.83.0/BoostConfig.cmake:141 (find_package):
Could not find a package configuration file provided by "boost_context"
(requested version 1.83.0) with any of the following names:

boost_contextConfig.cmake
boost_context-config.cmake

The base package `libboost1.83-dev` does not include the `context` component; it is provided by a separate development package.

Solution:
Add needed build dependencies for Debian OS.