### PR TITLE
fix http parser: avoid out-of-bounds read in upgrade detection

### DIFF
--- a/core/src/server/http/http_request_parser.cpp
+++ b/core/src/server/http/http_request_parser.cpp
@@ -30,11 +30,10 @@ bool IsWebSocketUpgradeRequest(std::string_view req) {
     if (it == req.end()) {
         return false;
     }
-    while (*it == ' ' && it != req.end()) {
+    while (it != req.end() && *it == ' ') {
         ++it;
     }
-    const auto end = it + kWebsocketUpgradeHeaderValue.size();
-    if (end >= req.end()) {
+    if (static_cast<size_t>(req.end() - it) <= kWebsocketUpgradeHeaderValue.size()) {
         return false;
     }
     return utils::StrIcaseEqual{

--- a/core/src/server/http/http_request_parser_test.cpp
+++ b/core/src/server/http/http_request_parser_test.cpp
@@ -1,5 +1,8 @@
 #include <server/http/http_request_parser.hpp>
 
+#include <string_view>
+#include <vector>
+
 #include <server/http/create_parser_test.hpp>
 #include <userver/utest/utest.hpp>
 
@@ -253,6 +256,22 @@ UTEST(HttpRequestParserParser, BodyContentLengthTooLong) {
 
     parser->Parse(kHttpRequestBodyContentLengthTooLong);
     EXPECT_EQ(parsed, false);
+}
+
+UTEST(HttpRequestParserParser, UpgradeProbeTrailingSpaces) {
+    bool parsed = false;
+    auto parser = server::CreateTestParser([&parsed](std::shared_ptr<server::http::HttpRequest>&&) { parsed = true; });
+
+    // CONNECT carries no Upgrade header, so the only "Upgrade:" token while
+    // probing for a WebSocket upgrade is the trailing bytes, and those end with
+    // spaces that run to the exact end of the buffer. Backed by a sized vector
+    // (no terminating '\0') so a read past the end is observable under
+    // sanitizers.
+    constexpr std::string_view request =
+        "CONNECT example.org:443 HTTP/1.1\r\nHost: example.org\r\n\r\nUpgrade:    ";
+    const std::vector<char> buffer{request.begin(), request.end()};
+    EXPECT_NO_THROW(parser->Parse(std::string_view{buffer.data(), buffer.size()}));
+    EXPECT_EQ(parsed, true);
 }
 
 USERVER_NAMESPACE_END


### PR DESCRIPTION
1. IsWebSocketUpgradeRequest scans the whole peeked socket buffer for "Upgrade:" and then skips trailing spaces with `while (*it == ' ' && it != req.end())`, dereferencing the iterator before testing it against the end.
2. When the buffer ends with "Upgrade:" followed by spaces that run to the exact end, the loop walks to req.end() and reads one byte past the buffer; the next line then forms `it + kWebsocketUpgradeHeaderValue.size()`, a pointer past one-past-the-end. This is reachable before auth: a CONNECT request carries no Upgrade header, so llhttp returns HPE_PAUSED_UPGRADE and Parse() runs this probe over a buffer whose only "Upgrade:" is attacker-appended trailing bytes.

Reordered the loop to check the end iterator first and replaced the pointer walk with a remaining-length comparison, which keeps the existing accept/reject behavior. Verified under AddressSanitizer by feeding the bundled llhttp a CONNECT request ending in "Upgrade:" plus spaces (heap-buffer-overflow read of size 1 before the patch, clean after).