### PR TITLE
feat build: update fmtlib include directives

### DIFF
--- a/core/include/userver/server/http/http_status.hpp
+++ b/core/include/userver/server/http/http_status.hpp
@@ -3,8 +3,6 @@
 /// @file userver/server/http/http_status.hpp
 /// @brief @copybrief server::http::HttpStatus
 
-#include <fmt/core.h>
-
 #include <userver/http/status_code.hpp>
 
 USERVER_NAMESPACE_BEGIN

--- a/core/src/clients/http/response.cpp
+++ b/core/src/clients/http/response.cpp
@@ -1,6 +1,6 @@
 #include <userver/clients/http/response.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <userver/clients/http/response_future.hpp>
 #include <userver/utils/assert.hpp>

--- a/core/src/components/manager.cpp
+++ b/core/src/components/manager.cpp
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <thread>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <components/component_context_impl.hpp>

--- a/core/src/server/handlers/auth/digest/auth_checker_base.cpp
+++ b/core/src/server/handlers/auth/digest/auth_checker_base.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 

--- a/core/src/server/handlers/http_handler_base.cpp
+++ b/core/src/server/handlers/http_handler_base.cpp
@@ -1,6 +1,6 @@
 #include <userver/server/handlers/http_handler_base.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/container/small_vector.hpp>
 

--- a/core/src/testsuite/tasks.cpp
+++ b/core/src/testsuite/tasks.cpp
@@ -2,7 +2,7 @@
 
 #include <atomic>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <userver/components/component_context.hpp>
 #include <userver/engine/task/task_with_result.hpp>

--- a/libraries/grpc-protovalidate/src/grpc-protovalidate/validate.cpp
+++ b/libraries/grpc-protovalidate/src/grpc-protovalidate/validate.cpp
@@ -7,7 +7,7 @@
 
 #include <algorithm>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <google/protobuf/arena.h>
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_ptr_field.h>

--- a/sqlite/src/storages/sqlite/tests/common_result_set_test.cpp
+++ b/sqlite/src/storages/sqlite/tests/common_result_set_test.cpp
@@ -1,6 +1,5 @@
 #include <userver/utest/utest.hpp>
 
-#include <fmt/core.h>
 #include <gtest/gtest.h>
 
 #include <userver/utest/assert_macros.hpp>

--- a/sqlite/src/storages/sqlite/tests/common_test.cpp
+++ b/sqlite/src/storages/sqlite/tests/common_test.cpp
@@ -1,6 +1,5 @@
 #include <userver/utest/utest.hpp>
 
-#include <fmt/core.h>
 #include <gtest/gtest.h>
 
 #include <userver/utest/assert_macros.hpp>

--- a/sqlite/src/storages/sqlite/tests/connection_test.cpp
+++ b/sqlite/src/storages/sqlite/tests/connection_test.cpp
@@ -1,6 +1,5 @@
 #include <userver/utest/utest.hpp>
 
-#include <fmt/core.h>
 #include <gtest/gtest.h>
 
 #include <userver/engine/async.hpp>

--- a/sqlite/src/storages/sqlite/tests/cursor_test.cpp
+++ b/sqlite/src/storages/sqlite/tests/cursor_test.cpp
@@ -1,6 +1,5 @@
 #include <userver/utest/utest.hpp>
 
-#include <fmt/core.h>
 #include <gtest/gtest.h>
 
 #include <userver/utest/assert_macros.hpp>

--- a/sqlite/src/storages/sqlite/tests/journals_test.cpp
+++ b/sqlite/src/storages/sqlite/tests/journals_test.cpp
@@ -1,6 +1,6 @@
 #include <userver/utest/utest.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include <userver/engine/async.hpp>

--- a/sqlite/src/storages/sqlite/tests/metrics_test.cpp
+++ b/sqlite/src/storages/sqlite/tests/metrics_test.cpp
@@ -2,7 +2,6 @@
 
 #include <vector>
 
-#include <fmt/core.h>
 #include <gtest/gtest.h>
 
 #include <userver/engine/async.hpp>

--- a/sqlite/src/storages/sqlite/tests/supported_types_test.cpp
+++ b/sqlite/src/storages/sqlite/tests/supported_types_test.cpp
@@ -2,7 +2,6 @@
 
 #include <vector>
 
-#include <fmt/core.h>
 #include <gtest/gtest.h>
 #include <boost/uuid/uuid.hpp>
 

--- a/universal/src/crypto/ssl_ctx.cpp
+++ b/universal/src/crypto/ssl_ctx.cpp
@@ -1,6 +1,5 @@
 #include <userver/crypto/ssl_ctx.hpp>
 
-#include <fmt/core.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 

--- a/universal/src/utils/debugging.cpp
+++ b/universal/src/utils/debugging.cpp
@@ -18,7 +18,7 @@
 #include <fstream>
 #include <string>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #endif
 
 #ifdef USERVER_DEBUGGING_USE_APPLE

--- a/universal/src/utils/from_string_test.cpp
+++ b/universal/src/utils/from_string_test.cpp
@@ -5,7 +5,6 @@
 #include <random>
 #include <type_traits>
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Using fmt::format via fmt/core.h has been deprecated since version 11 https://github.com/fmtlib/fmt/commit/0007426c2d8d22df6e56d3b4d109415242e683e0








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

