### PR TITLE
fix chaotic: integration tests with boost >=1.91

### DIFF
--- a/chaotic/integration_tests/tests/render/container_format.cpp
+++ b/chaotic/integration_tests/tests/render/container_format.cpp
@@ -1,6 +1,8 @@
 #include <userver/formats/json/inline.hpp>
 #include <userver/utest/assert_macros.hpp>
 
+#include <boost/version.hpp>
+
 #include <userver/chaotic/exception.hpp>
 
 #include <schemas/container_format.hpp>
@@ -26,11 +28,19 @@ TEST(ContainerFormat, UuidValidSax) {
 
 TEST(ContainerFormat, UuidInvalid) {
     auto json = formats::json::MakeObject("my_field", formats::json::MakeArray("not-a-uuid"));
+#if BOOST_VERSION >= 109100
+    UEXPECT_THROW_MSG(
+        json.As<ns::ContainerWithFormatItem>(),
+        chaotic::Error<formats::json::Value>,
+        "Error at path 'my_field[0]': Invalid UUID string at position 0: hex digit expected"
+    );
+#else
     UEXPECT_THROW_MSG(
         json.As<ns::ContainerWithFormatItem>(),
         chaotic::Error<formats::json::Value>,
         "Error at path 'my_field[0]': invalid uuid string"
     );
+#endif
 }
 
 USERVER_NAMESPACE_END

--- a/chaotic/integration_tests/tests/render/uuid.cpp
+++ b/chaotic/integration_tests/tests/render/uuid.cpp
@@ -1,6 +1,7 @@
 #include <userver/formats/json/inline.hpp>
 #include <userver/utest/assert_macros.hpp>
 
+#include <boost/version.hpp>
 #include <boost/uuid/string_generator.hpp>
 
 #include <userver/formats/json/serialize.hpp>
@@ -45,11 +46,19 @@ TEST(Simple, UuidSax) {
 
 TEST(Simple, UuidInvalid) {
     auto json = formats::json::MakeObject("uuid", "not-a-valid-uuid");
+#if BOOST_VERSION >= 109100
+    UEXPECT_THROW_MSG(
+        json.As<ns::ObjectUuid>(),
+        chaotic::Error<formats::json::Value>,
+        "Error at path 'uuid': Invalid UUID string at position 0: hex digit expected"
+    );
+#else
     UEXPECT_THROW_MSG(
         json.As<ns::ObjectUuid>(),
         chaotic::Error<formats::json::Value>,
         "Error at path 'uuid': invalid uuid string"
     );
+#endif
 }
 
 USERVER_NAMESPACE_END


### PR DESCRIPTION
Since 1.91 introduced boost::uuid::invalid_uuid exception class with changed error message

https://github.com/boostorg/uuid/commit/884c050576cfec045d0db3bcd022f2ba4fdcfeab#diff-a5cb0ec62ead01a1b3ac972eeaa51b7f23c88736007dafd41ce07a218211ffeeR48








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

