### PR TITLE
fix postgres: bound-check buffer in inet/cidr/macaddr parsers

### DIFF
--- a/postgresql/include/userver/storages/postgres/io/ip.hpp
+++ b/postgresql/include/userver/storages/postgres/io/ip.hpp
@@ -140,6 +140,14 @@ protected:
 
     template <typename Bytes>
     IpParserInfo<Bytes> Parse(FieldBuffer buffer) {
+        static constexpr std::size_t kHeaderSize = 4;
+        // The buffer comes straight from the server, so validate its length
+        // before reading the fixed header and the address bytes below.
+        if (buffer.length < kHeaderSize) {
+            throw storages::postgres::InvalidInputBufferSize(
+                fmt::format("Buffer size {} is too small to parse an IP address", buffer.length)
+            );
+        }
         IpParserInfo<Bytes> result;
         const uint8_t* byte_cptr = buffer.buffer;
         result.family = *byte_cptr;
@@ -150,6 +158,11 @@ protected:
         ++byte_cptr;
         result.bytes_number = *byte_cptr;
         ++byte_cptr;
+        if (buffer.length - kHeaderSize < result.bytes_number) {
+            throw storages::postgres::InvalidInputBufferSize(fmt::format(
+                "Buffer size {} is too small for an IP address of {} bytes", buffer.length, result.bytes_number
+            ));
+        }
         this->ParseIpBytes(byte_cptr, result.bytes, result.bytes_number, result.family);
         return result;
     }

--- a/postgresql/include/userver/storages/postgres/io/macaddr.hpp
+++ b/postgresql/include/userver/storages/postgres/io/macaddr.hpp
@@ -4,6 +4,7 @@
 /// @brief utils::Macaddr and utils::Macaddr8 I/O support
 /// @ingroup userver_postgres_parse_and_format
 
+#include <userver/storages/postgres/exceptions.hpp>
 #include <userver/storages/postgres/io/buffer_io.hpp>
 #include <userver/storages/postgres/io/buffer_io_base.hpp>
 #include <userver/utils/macaddr.hpp>
@@ -38,6 +39,13 @@ struct MacaddrBufferParser : BufferParserBase<T> {
     using BaseType::BaseType;
     void operator()(FieldBuffer buffer) {
         typename T::OctetsType octets;
+        // The buffer is server-supplied; reject a short one before reading the
+        // fixed number of octets straight from it.
+        if (buffer.length < octets.size()) {
+            throw storages::postgres::InvalidInputBufferSize(fmt::format(
+                "Buffer size {} is too small for a MAC address of {} bytes", buffer.length, octets.size()
+            ));
+        }
         const uint8_t* byte_cptr = buffer.buffer;
         for (auto& val : octets) {
             val = *byte_cptr;

--- a/postgresql/src/storages/postgres/tests/ip_address_buffer_test.cpp
+++ b/postgresql/src/storages/postgres/tests/ip_address_buffer_test.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include <initializer_list>
+
+#include <storages/postgres/tests/test_buffers.hpp>
+#include <storages/postgres/tests/util_pgtest.hpp>
+
+#include <userver/storages/postgres/exceptions.hpp>
+#include <userver/storages/postgres/io/ip.hpp>
+#include <userver/storages/postgres/io/macaddr.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace pg = storages::postgres;
+namespace io = pg::io;
+namespace ip = utils::ip;
+
+namespace {
+
+const pg::UserTypes types;
+
+pg::test::Buffer MakeBuffer(std::initializer_list<unsigned char> bytes) {
+    pg::test::Buffer buffer;
+    for (const auto b : bytes) {
+        buffer.push_back(static_cast<char>(b));
+    }
+    return buffer;
+}
+
+// A server-sent inet/cidr field shorter than the fixed 4-byte header must be
+// rejected instead of reading past the field buffer.
+TEST(PostgreIOIpAddressBuffer, ShortInetHeader) {
+    const auto buffer = MakeBuffer({0x02, 0x20});  // 2 bytes, header needs 4
+    auto fb = pg::test::MakeFieldBuffer(buffer);
+    pg::AddressV4 tgt;
+    UEXPECT_THROW(io::ReadBuffer(fb, tgt), pg::InvalidInputBufferSize);
+}
+
+// A 4-byte header that declares a 16-byte address but carries no address bytes
+// must be rejected before the memcpy (std::array parser path, AddressV6).
+TEST(PostgreIOIpAddressBuffer, TruncatedInet6Address) {
+    const auto buffer = MakeBuffer({0x03, 0x80, 0x01, 0x10});  // declared size = 16
+    auto fb = pg::test::MakeFieldBuffer(buffer);
+    pg::AddressV6 tgt;
+    UEXPECT_THROW(io::ReadBuffer(fb, tgt), pg::InvalidInputBufferSize);
+}
+
+// Same defect through the std::vector parser path (InetNetwork).
+TEST(PostgreIOIpAddressBuffer, TruncatedInetNetwork) {
+    const auto buffer = MakeBuffer({0x03, 0x80, 0x00, 0x10});  // declared size = 16
+    auto fb = pg::test::MakeFieldBuffer(buffer);
+    pg::InetNetwork tgt;
+    UEXPECT_THROW(io::ReadBuffer(fb, tgt), pg::InvalidInputBufferSize);
+}
+
+// A valid address still round-trips after the bounds check.
+TEST(PostgreIOIpAddressBuffer, ValidAddressRoundtrip) {
+    const auto address = ip::AddressV4FromString("127.0.0.1");
+    pg::test::Buffer buffer;
+    UEXPECT_NO_THROW(io::WriteBuffer(types, buffer, address));
+    auto fb = pg::test::MakeFieldBuffer(buffer);
+    pg::AddressV4 tgt;
+    UEXPECT_NO_THROW(io::ReadBuffer(fb, tgt));
+    EXPECT_EQ(address, tgt);
+}
+
+// A macaddr field shorter than the fixed octet count must be rejected.
+TEST(PostgreIOIpAddressBuffer, ShortMacaddr) {
+    const auto buffer = MakeBuffer({0xaa, 0xbb, 0xcc});  // 3 of 6 octets
+    auto fb = pg::test::MakeFieldBuffer(buffer);
+    pg::Macaddr tgt;
+    UEXPECT_THROW(io::ReadBuffer(fb, tgt), pg::InvalidInputBufferSize);
+}
+
+TEST(PostgreIOIpAddressBuffer, ShortMacaddr8) {
+    const auto buffer = MakeBuffer({0xaa, 0xbb, 0xcc, 0xdd, 0xee});  // 5 of 8 octets
+    auto fb = pg::test::MakeFieldBuffer(buffer);
+    pg::Macaddr8 tgt;
+    UEXPECT_THROW(io::ReadBuffer(fb, tgt), pg::InvalidInputBufferSize);
+}
+
+}  // namespace
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
Repro: a Postgres server returns an inet/cidr field shorter than its 4-byte header (or a 4-byte header that declares a 16-byte address with no address bytes present), or a macaddr field shorter than its 6/8 octets.
Cause: the inet/cidr parser in ip.hpp and the macaddr parser in macaddr.hpp read the fixed header and then memcpy the address bytes straight from FieldBuffer::buffer without checking FieldBuffer::length, so a short field reads past the end of the buffer (ASan reports a 16-byte heap read one byte past a 4-byte region).
Fix: validate buffer.length against the header size and the declared address length before reading, throwing InvalidInputBufferSize the same way the rest of the io layer does for short buffers. Added a unit test covering the short inet/cidr/macaddr cases.