### PR TITLE
fix build: fix debian parallel builds

### DIFF
--- a/libraries/protobuf/CMakeLists.txt
+++ b/libraries/protobuf/CMakeLists.txt
@@ -34,4 +34,8 @@ if(USERVER_BUILD_TESTS)
         $<BUILD_INTERFACE:${_PROTO_GEN}>
     )
     target_link_libraries(userver-protobuf-unittest-proto PUBLIC protobuf::libprotobuf)
+    
+    if(TARGET userver-protobuf-unittest)
+        add_dependencies(userver-protobuf-unittest userver-protobuf-unittest-proto)
+    endif()
 endif()


### PR DESCRIPTION
Ensure generated protobuf headers exist before unittest sources compile. target_link_libraries only guarantees the dependency for linking, not for header generation in parallel builds (e.g. Ninja on macOS CI).








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

