### PR TITLE
fix build: fix debian protobuf build

### DIFF
--- a/libraries/protobuf/CMakeLists.txt
+++ b/libraries/protobuf/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(userver-protobuf CXX)
 
+add_subdirectory(tests)
+
 userver_module(
     protobuf
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -10,28 +12,3 @@ userver_module(
         "${CMAKE_CURRENT_SOURCE_DIR}/tests/json/*.cpp"
     UTEST_LINK_LIBRARIES userver-protobuf-unittest-proto
 )
-
-if(USERVER_BUILD_TESTS)
-    set(_PROTO_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/tests/proto/proto_json/messages.proto")
-    set(_PROTO_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/tests/proto")
-    set(_PROTO_GEN  "${CMAKE_CURRENT_BINARY_DIR}/proto")
-
-    # protoc requires its output directory to already exist.
-    file(MAKE_DIRECTORY "${_PROTO_GEN}")
-
-    add_library(userver-protobuf-unittest-proto STATIC "${_PROTO_SRC}")
-    protobuf_generate(
-        TARGET userver-protobuf-unittest-proto
-        LANGUAGE cpp
-        IMPORT_DIRS
-            "${_PROTO_ROOT}"
-            "${Protobuf_INCLUDE_DIR}"
-        PROTOC_OUT_DIR "${_PROTO_GEN}"
-    )
-
-    target_compile_options(userver-protobuf-unittest-proto PUBLIC -Wno-unused-parameter)
-    target_include_directories(userver-protobuf-unittest-proto SYSTEM PUBLIC
-        $<BUILD_INTERFACE:${_PROTO_GEN}>
-    )
-    target_link_libraries(userver-protobuf-unittest-proto PUBLIC protobuf::libprotobuf)
-endif()

--- a/libraries/protobuf/tests/CMakeLists.txt
+++ b/libraries/protobuf/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+if(USERVER_BUILD_TESTS)
+    set(_PROTO_SRC  "${CMAKE_CURRENT_SOURCE_DIR}/proto/proto_json/messages.proto")
+    set(_PROTO_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/proto")
+    set(_PROTO_GEN  "${CMAKE_CURRENT_BINARY_DIR}/proto")
+
+    # protoc requires its output directory to already exist.
+    file(MAKE_DIRECTORY "${_PROTO_GEN}")
+
+    add_library(userver-protobuf-unittest-proto STATIC "${_PROTO_SRC}")
+    protobuf_generate(
+        TARGET userver-protobuf-unittest-proto
+        LANGUAGE cpp
+        IMPORT_DIRS
+            "${_PROTO_ROOT}"
+            "${Protobuf_INCLUDE_DIR}"
+        PROTOC_OUT_DIR "${_PROTO_GEN}"
+    )
+
+    target_compile_options(userver-protobuf-unittest-proto PUBLIC -Wno-unused-parameter)
+    target_include_directories(userver-protobuf-unittest-proto SYSTEM PUBLIC
+        $<BUILD_INTERFACE:${_PROTO_GEN}>
+    )
+    target_link_libraries(userver-protobuf-unittest-proto PUBLIC protobuf::libprotobuf)
+endif()


### PR DESCRIPTION
userver-protobuf-unittest-proto was defined after userver_module() called target_link_libraries with its name. Since the target didn't exist yet, CMake treated it as a plain linker flag and skipped transitive include-directory propagation. The compiler never received -I for the generated protobuf headers directory, causing "proto_json/messages.pb.h: No such file or directory" in parallel builds.

Move proto target setup into tests/CMakeLists.txt and add_subdirectory before userver_module() so the target exists when linked against.








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

