### PR TITLE
fix core: convert SystemStatisticsCollector to PIMPL

### DIFF
--- a/core/include/userver/utils/statistics/system_statistics_collector.hpp
+++ b/core/include/userver/utils/statistics/system_statistics_collector.hpp
@@ -3,14 +3,18 @@
 /// @file userver/utils/statistics/system_statistics_collector.hpp
 /// @brief @copybrief components::SystemStatisticsCollector
 
+#include <memory>
+
 #include <userver/components/component_base.hpp>
 #include <userver/components/component_fwd.hpp>
-#include <userver/concurrent/variable.hpp>
-#include <userver/engine/task/task_processor_fwd.hpp>
-#include <userver/utils/periodic_task.hpp>
-#include <utils/statistics/system_statistics.hpp>
 
 USERVER_NAMESPACE_BEGIN
+
+namespace utils::statistics {
+
+class Writer;
+
+}  // namespace utils::statistics
 
 namespace components {
 
@@ -36,6 +40,7 @@ public:
     static constexpr std::string_view kName = "system-statistics-collector";
 
     SystemStatisticsCollector(const ComponentConfig&, const ComponentContext&);
+    ~SystemStatisticsCollector() override;
 
     static yaml_config::Schema GetStaticConfigSchema();
 
@@ -44,15 +49,8 @@ private:
 
     void ProcessTimer();
 
-    struct Data {
-        utils::statistics::impl::SystemStats last_stats{};
-        utils::statistics::impl::SystemStats last_nginx_stats{};
-    };
-
-    const bool with_nginx_;
-    engine::TaskProcessor& fs_task_processor_;
-    concurrent::Variable<Data> data_;
-    utils::PeriodicTask periodic_;
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
 };
 
 template <>

--- a/core/src/utils/statistics/system_statistics_collector.cpp
+++ b/core/src/utils/statistics/system_statistics_collector.cpp
@@ -1,9 +1,15 @@
 #include <userver/utils/statistics/system_statistics_collector.hpp>
 
+#include <memory>
+
 #include <userver/components/component.hpp>
 #include <userver/components/statistics_storage.hpp>
+#include <userver/concurrent/variable.hpp>
 #include <userver/engine/async.hpp>
+#include <userver/utils/periodic_task.hpp>
 #include <userver/yaml_config/merge_schemas.hpp>
+
+#include <utils/statistics/system_statistics.hpp>
 
 #ifndef ARCADIA_ROOT
 #include "generated/src/utils/statistics/system_statistics_collector.yaml.hpp"  // Y_IGNORE
@@ -13,40 +19,58 @@ USERVER_NAMESPACE_BEGIN
 
 namespace components {
 
+struct SystemStatisticsCollector::Impl {
+    struct Data {
+        utils::statistics::impl::SystemStats last_stats{};
+        utils::statistics::impl::SystemStats last_nginx_stats{};
+    };
+
+    Impl(SystemStatisticsCollector& owner, const ComponentConfig& config, const ComponentContext& context)
+        : with_nginx(config["with-nginx"].As<bool>(false)),
+          fs_task_processor(GetFsTaskProcessor(config, context)),
+          periodic(
+              "system_statistics_collector",
+              {std::chrono::seconds(10), {utils::PeriodicTask::Flags::kNow}},
+              [&owner] { owner.ProcessTimer(); }
+          )
+    {}
+
+    const bool with_nginx;
+    engine::TaskProcessor& fs_task_processor;
+    concurrent::Variable<Data> data;
+    utils::PeriodicTask periodic;
+};
+
 SystemStatisticsCollector::SystemStatisticsCollector(const ComponentConfig& config, const ComponentContext& context)
     : ComponentBase(config, context),
-      with_nginx_(config["with-nginx"].As<bool>(false)),
-      fs_task_processor_(GetFsTaskProcessor(config, context)),
-      periodic_(
-          "system_statistics_collector",
-          {std::chrono::seconds(10), {utils::PeriodicTask::Flags::kNow}},
-          [this] { ProcessTimer(); }
-      )
+      impl_(std::make_unique<Impl>(*this, config, context))
 {
     utils::statistics::RegisterWriterScope(context, "", [this](utils::statistics::Writer& writer) {
         ExtendStatistics(writer);
     });
 }
 
+SystemStatisticsCollector::~SystemStatisticsCollector() = default;
+
 void SystemStatisticsCollector::ProcessTimer() {
-    engine::CriticalAsyncNoTracing(fs_task_processor_, [&] {
+    engine::CriticalAsyncNoTracing(impl_->fs_task_processor, [&] {
         auto self = utils::statistics::impl::GetSelfSystemStatistics();
         utils::statistics::impl::SystemStats nginx;
-        if (with_nginx_) {
+        if (impl_->with_nginx) {
             nginx = utils::statistics::impl::GetSystemStatisticsByExeName("nginx");
         }
 
-        auto data = data_.UniqueLock();
+        auto data = impl_->data.UniqueLock();
         data->last_stats = self;
         data->last_nginx_stats = nginx;
     }).Get();
 }
 
 void SystemStatisticsCollector::ExtendStatistics(utils::statistics::Writer& writer) {
-    auto data = data_.Lock();
+    auto data = impl_->data.Lock();
 
     DumpMetric(writer, data->last_stats);
-    if (with_nginx_) {
+    if (impl_->with_nginx) {
         writer.ValueWithLabels(data->last_nginx_stats, {"application", "nginx"});
     }
 }


### PR DESCRIPTION
Issue: current SystemStatisticsCollector header includes an internal header and therefore isn't really usable in every case. I believe this class should match TaskProcessorsLoadMonitor.

