### PR TITLE
fix mongo: avoid deprecated bson_append_array_begin

### DIFF
--- a/mongo/src/formats/bson/wrappers.hpp
+++ b/mongo/src/formats/bson/wrappers.hpp
@@ -131,7 +131,11 @@ public:
     SubarrayBson(bson_t* parent, const char* key, size_t key_len)
         : parent_(parent)
     {
-        bson_append_array_begin(parent_, key, key_len, &bson_);
+#if BSON_CHECK_VERSION(2, 3, 0)
+        bson_append_array_unsafe_begin(parent_, key, static_cast<int>(key_len), &bson_);
+#else
+        bson_append_array_begin(parent_, key, static_cast<int>(key_len), &bson_);
+#endif
     }
 
     ~SubarrayBson() {


### PR DESCRIPTION
Related to #1225.

## Summary

Fixes usage of `bson_append_array_begin`, which is deprecated in libbson / mongo-c-driver `2.3.0`.

For libbson `2.3.0+`, use `bson_append_array_unsafe_begin` instead. Older supported libbson versions keep using `bson_append_array_begin`, because `bson_append_array_unsafe_begin` is not available there.

The replacement preserves the existing `bson_t*` subarray-building flow and remains compatible with the current manual array key generation via `ArrayIndexer`.

