### PR TITLE
fix redis: guard empty array reply in OnPsubscribeReply

### DIFF
--- a/redis/src/storages/redis/impl/sentinel.cpp
+++ b/redis/src/storages/redis/impl/sentinel.cpp
@@ -355,7 +355,7 @@ void Sentinel::OnPsubscribeReply(
         return;
     }
     const auto& reply_array = reply->data.GetArray();
-    if (!reply_array[0].IsString()) {
+    if (reply_array.empty() || !reply_array[0].IsString()) {
         return;
     }
     if (!strcasecmp(reply_array[0].GetString().c_str(), "PSUBSCRIBE")) {

--- a/redis/src/storages/redis/impl/sentinel_test.cpp
+++ b/redis/src/storages/redis/impl/sentinel_test.cpp
@@ -1,7 +1,11 @@
 #include <storages/redis/impl/keyshard_impl.hpp>
 #include <storages/redis/impl/sentinel.hpp>
 
+#include <memory>
+
 #include <gtest/gtest.h>
+
+#include <userver/storages/redis/reply.hpp>
 
 USERVER_NAMESPACE_BEGIN
 
@@ -12,6 +16,27 @@ TEST(Sentinel, CreateTmpKey) {
         EXPECT_STRNE(key, tmpkey.c_str()) << key << " vs " << tmpkey;
         EXPECT_EQ(key_shard.ShardByKey(key), key_shard.ShardByKey(tmpkey)) << key << " vs " << tmpkey;
     }
+}
+
+TEST(Sentinel, OnPsubscribeReplyEmptyArray) {
+    using storages::redis::Reply;
+    using storages::redis::ReplyData;
+    using storages::redis::impl::Sentinel;
+
+    auto reply = std::make_shared<Reply>("PSUBSCRIBE", ReplyData{ReplyData::Array{}});
+    ASSERT_TRUE(reply->data.IsArray());
+    ASSERT_TRUE(reply->data.GetArray().empty());
+
+    const auto fail_pmessage = [](storages::redis::ServerId, const std::string&, const std::string&,
+                                  const std::string&) { FAIL() << "pmessage callback must not fire on empty array"; };
+    const auto fail_subscribe = [](storages::redis::ServerId, const std::string&, size_t) {
+        FAIL() << "subscribe callback must not fire on empty array";
+    };
+    const auto fail_unsubscribe = [](storages::redis::ServerId, const std::string&, size_t) {
+        FAIL() << "unsubscribe callback must not fire on empty array";
+    };
+
+    Sentinel::OnPsubscribeReply(fail_pmessage, fail_subscribe, fail_unsubscribe, reply);
 }
 
 USERVER_NAMESPACE_END

--- a/redis/src/storages/redis/impl/sentinel_test.cpp
+++ b/redis/src/storages/redis/impl/sentinel_test.cpp
@@ -2,6 +2,9 @@
 #include <storages/redis/impl/sentinel.hpp>
 
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -37,6 +40,42 @@ TEST(Sentinel, OnPsubscribeReplyEmptyArray) {
     };
 
     Sentinel::OnPsubscribeReply(fail_pmessage, fail_subscribe, fail_unsubscribe, reply);
+}
+
+TEST(Sentinel, OnPsubscribeReplyTooShortArray) {
+    using storages::redis::Reply;
+    using storages::redis::ReplyData;
+    using storages::redis::impl::Sentinel;
+
+    const auto fail_pmessage = [](storages::redis::ServerId, const std::string&, const std::string&,
+                                  const std::string&) { FAIL() << "pmessage callback must not fire on malformed array"; };
+    const auto fail_subscribe = [](storages::redis::ServerId, const std::string&, size_t) {
+        FAIL() << "subscribe callback must not fire on malformed array";
+    };
+    const auto fail_unsubscribe = [](storages::redis::ServerId, const std::string&, size_t) {
+        FAIL() << "unsubscribe callback must not fire on malformed array";
+    };
+
+    // A server/proxy may answer with a well-formed array that is missing the
+    // channel/count fields. Each of these must be ignored, not indexed OOB.
+    const auto make_array = [](std::vector<std::string> parts) {
+        ReplyData::Array array;
+        for (auto& part : parts) array.emplace_back(std::move(part));
+        return array;
+    };
+
+    for (auto& parts : std::vector<std::vector<std::string>>{
+             {"PSUBSCRIBE"},                       // command only, no channel/count
+             {"PSUBSCRIBE", "news.*"},             // missing count
+             {"PUNSUBSCRIBE"},                     // command only
+             {"PUNSUBSCRIBE", "news.*"},           // missing count
+             {"PMESSAGE"},                         // command only
+             {"PMESSAGE", "news.*"},               // missing channel/payload
+             {"PMESSAGE", "news.*", "news.tech"},  // missing payload
+         }) {
+        auto reply = std::make_shared<Reply>("PSUBSCRIBE", ReplyData{make_array(std::move(parts))});
+        Sentinel::OnPsubscribeReply(fail_pmessage, fail_subscribe, fail_unsubscribe, reply);
+    }
 }
 
 USERVER_NAMESPACE_END


### PR DESCRIPTION
Repro: psubscribe to a pattern and have the server answer the psubscribe with an empty array (RESP `*0\r\n`).
Cause: OnPsubscribeReply checks reply->data.IsArray() but then reads reply_array[0] before any size check, so an empty array is indexed out of bounds on the vector returned by GetArray(). The dispatch in subscription_storage.cpp only checks IsOk/non-nil/IsArray, so an empty array reaches this handler.
Fix: return early when the array is empty, matching the guard the sibling OnSubscribeImpl already applies before touching element 0. Added a regression test that feeds an empty-array PSUBSCRIBE reply and checks no callback fires and no out-of-bounds access happens under the addr;ub sanitizer build.