### PR TITLE
testsuite: add typing-extensions requirement

### DIFF
--- a/testsuite/requirements.txt
+++ b/testsuite/requirements.txt
@@ -13,4 +13,5 @@ websockets >= 16.0, < 17.0
 # pytest 8.4 contains fix required for uservice_oneshot:
 # https://github.com/pytest-dev/pytest/issues/13248
 pytest >= 8.4
+typing-extensions >= 4.4.0
 zstd >= 1.5.5.0


### PR DESCRIPTION
Related to #1270.

## Summary

- Add `typing-extensions >= 4.4.0` to the base testsuite requirements.
- `pytest_userver` plugins import `typing_extensions.override`, so clean test virtualenvs must install it explicitly.