### PR TITLE
fix build: make parse constexpr for new fmt

### DIFF
--- a/libraries/protobuf/tests/json/utils.hpp
+++ b/libraries/protobuf/tests/json/utils.hpp
@@ -54,13 +54,7 @@ inline const /*deliberately non-constexpr*/ bool
 
 template <>
 struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::PrintOptions> {
-    auto parse(fmt::format_parse_context& ctx) {
-        auto it = ctx.begin();
-        if (it != ctx.end() && *it != '}') {
-            throw fmt::format_error("invalid format");
-        }
-        return it;
-    }
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
 
     template <typename FormatContext>
     auto format(const USERVER_NAMESPACE::protobuf::json::PrintOptions& options, FormatContext& ctx) const
@@ -79,13 +73,7 @@ struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::PrintOptions> {
 
 template <>
 struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::ParseOptions> {
-    auto parse(fmt::format_parse_context& ctx) {
-        auto it = ctx.begin();
-        if (it != ctx.end() && *it != '}') {
-            throw fmt::format_error("invalid format");
-        }
-        return it;
-    }
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
 
     template <typename FormatContext>
     auto format(const USERVER_NAMESPACE::protobuf::json::ParseOptions& options, FormatContext& ctx) const
@@ -101,13 +89,7 @@ struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::ParseOptions> {
 
 template <>
 struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::PrintErrorCode> {
-    auto parse(fmt::format_parse_context& ctx) {
-        auto it = ctx.begin();
-        if (it != ctx.end() && *it != '}') {
-            throw fmt::format_error("invalid format");
-        }
-        return it;
-    }
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
 
     template <typename FormatContext>
     auto format(const USERVER_NAMESPACE::protobuf::json::PrintErrorCode& code, FormatContext& ctx) const
@@ -123,13 +105,7 @@ struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::PrintErrorCode> {
 
 template <>
 struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::ParseErrorCode> {
-    auto parse(fmt::format_parse_context& ctx) {
-        auto it = ctx.begin();
-        if (it != ctx.end() && *it != '}') {
-            throw fmt::format_error("invalid format");
-        }
-        return it;
-    }
+    constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
 
     template <typename FormatContext>
     auto format(const USERVER_NAMESPACE::protobuf::json::ParseErrorCode& code, FormatContext& ctx) const


### PR DESCRIPTION
fmt v11+ uses consteval format string validation (fstring) which requires fmt::formatter::parse() to be a constant expression. The non-constexpr parse() methods in protobuf test utils caused compile errors like:

  error: call to consteval function 'fmt::fstring<...>' is not a constant expression
  note: non-constexpr function 'parse' cannot be used in a constant expression

Make all 4 parse() methods constexpr and simplify them to return ctx.begin(), matching the existing pattern in http_method.hpp and sockaddr.hpp. The removed runtime throw guard is no longer needed — fmt's compile-time checker now catches invalid format specs at compile time with "unknown format specifier" error.
