### PR TITLE
fix redis: check geo reply member is a string before GetString

### DIFF
--- a/redis/src/storages/redis/parse_reply.cpp
+++ b/redis/src/storages/redis/parse_reply.cpp
@@ -198,6 +198,14 @@ std::vector<GeoPoint> ParseReplyDataArray(ReplyData&& array_data, [[maybe_unused
                     "Can't parse value from reply to '" + request_description + ", additional_info item is empty array"
                 );
             }
+            if (!additional_infos[0].IsString()) {
+                throw ParseReplyException(
+                    "Can't parse value from reply to '" + request_description + "', expected " +
+                    ReplyData::TypeToString(ReplyData::Type::kString) +
+                    " as the first additional_info element, got type: " + additional_infos[0].GetTypeString() +
+                    " elem=" + additional_infos[0].ToDebugString()
+                );
+            }
             geo_point.member = std::move(additional_infos[0].GetString());
 
             for (size_t i = 1; i < additional_infos.size(); ++i) {

--- a/redis/src/storages/redis/parse_reply_test.cpp
+++ b/redis/src/storages/redis/parse_reply_test.cpp
@@ -1,0 +1,59 @@
+#include <userver/storages/redis/parse_reply.hpp>
+
+#include <gtest/gtest.h>
+
+#include <userver/storages/redis/exception.hpp>
+#include <userver/storages/redis/reply.hpp>
+#include <userver/storages/redis/reply_types.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+// A GEORADIUS/GEOSEARCH reply with WITHDIST/WITHCOORD/WITHHASH is an array of
+// per-member arrays whose first element is the member name (a bulk string). A
+// malicious, compromised or MITM'd Redis server can return a non-string there.
+// The first element used to be read with GetString() without a type check, so
+// the parser dereferenced the null returned by std::get_if in a release build.
+TEST(ParseReply, GeoPointFirstElementNotString) {
+    using storages::redis::ReplyData;
+
+    ReplyData::Array member_info;
+    member_info.emplace_back(ReplyData(42));                  // member name, but an int
+    member_info.emplace_back(ReplyData(std::string{"1.5"}));  // distance
+
+    ReplyData::Array top;
+    top.emplace_back(ReplyData(std::move(member_info)));
+
+    ReplyData reply{std::move(top)};
+
+    EXPECT_THROW(
+        storages::redis::ParseReplyDataArray(
+            std::move(reply),
+            "GEORADIUS",
+            storages::redis::To<std::vector<storages::redis::GeoPoint>>{}
+        ),
+        storages::redis::ParseReplyException
+    );
+}
+
+TEST(ParseReply, GeoPointFirstElementString) {
+    using storages::redis::ReplyData;
+
+    ReplyData::Array member_info;
+    member_info.emplace_back(ReplyData(std::string{"Palermo"}));
+    member_info.emplace_back(ReplyData(std::string{"190.4424"}));
+
+    ReplyData::Array top;
+    top.emplace_back(ReplyData(std::move(member_info)));
+
+    ReplyData reply{std::move(top)};
+
+    auto result = storages::redis::ParseReplyDataArray(
+        std::move(reply),
+        "GEORADIUS",
+        storages::redis::To<std::vector<storages::redis::GeoPoint>>{}
+    );
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].member, "Palermo");
+}
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
ParseReplyDataArray for GeoPoint in redis/src/storages/redis/parse_reply.cpp reads the first element of each per-member sub-array of a GEORADIUS/GEOSEARCH reply with GetString(), but only checks that the sub-array is non-empty rather than that the element is a string. ReplyData::GetString() resolves through std::get_if, which returns nullptr for a non-string element, so a compromised or MITM'd Redis server that returns an integer or nested array there makes the parser dereference that null pointer while move-constructing member (a UASSERT abort under the sanitizer CI, a null-pointer dereference of a std::string in release). I added an IsString check before the read that throws ParseReplyException, matching the type checks the sibling branches already perform, and covered both the rejected and accepted reply shapes with a test.
