### PR TITLE
feat protobuf: mark fmt::formatter<>::parse as constexpr

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -131,7 +131,6 @@ jobs:
                   TransactionDeathTest.AccessAfterCommit
                   TransactionDeathTest.AccessAfterRollback
                   PostgreCluster.TransactionTimeouts
-                  '*ViaChaosProxy'
                   HttpClient.HttpsWithCrl
                   HttpClient.HttpsWithNoClientCa
                   HttpClient.StatsOnTimeout

--- a/libraries/protobuf/tests/json/custom_name_test.cpp
+++ b/libraries/protobuf/tests/json/custom_name_test.cpp
@@ -25,7 +25,14 @@ struct CustomNameFromJsonTestParam {
 };
 
 void PrintTo(const CustomNameToJsonTestParam& param, std::ostream* os) {
-    *os << fmt::format("{{ options = {} }}", param.options);
+    *os << fmt::format(
+        "{{ options = {{ always_print_fields_with_no_presence = {}, always_print_enums_as_ints = {}, "
+        "preserve_proto_field_names = {}, nonportable_raw_any = {} }} }}",
+        param.options.always_print_fields_with_no_presence,
+        param.options.always_print_enums_as_ints,
+        param.options.preserve_proto_field_names,
+        param.options.nonportable_raw_any
+    );
 }
 
 void PrintTo(const CustomNameFromJsonTestParam& param, std::ostream* os) {

--- a/libraries/protobuf/tests/json/custom_name_test.cpp
+++ b/libraries/protobuf/tests/json/custom_name_test.cpp
@@ -25,14 +25,7 @@ struct CustomNameFromJsonTestParam {
 };
 
 void PrintTo(const CustomNameToJsonTestParam& param, std::ostream* os) {
-    *os << fmt::format(
-        "{{ options = {{ always_print_fields_with_no_presence = {}, always_print_enums_as_ints = {}, "
-        "preserve_proto_field_names = {}, nonportable_raw_any = {} }} }}",
-        param.options.always_print_fields_with_no_presence,
-        param.options.always_print_enums_as_ints,
-        param.options.preserve_proto_field_names,
-        param.options.nonportable_raw_any
-    );
+    *os << fmt::format("{{ options = {} }}", param.options);
 }
 
 void PrintTo(const CustomNameFromJsonTestParam& param, std::ostream* os) {

--- a/libraries/protobuf/tests/json/utils.hpp
+++ b/libraries/protobuf/tests/json/utils.hpp
@@ -54,7 +54,7 @@ inline const /*deliberately non-constexpr*/ bool
 
 template <>
 struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::PrintOptions> {
-    auto parse(fmt::format_parse_context& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}') {
             throw fmt::format_error("invalid format");
@@ -79,7 +79,7 @@ struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::PrintOptions> {
 
 template <>
 struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::ParseOptions> {
-    auto parse(fmt::format_parse_context& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}') {
             throw fmt::format_error("invalid format");
@@ -101,7 +101,7 @@ struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::ParseOptions> {
 
 template <>
 struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::PrintErrorCode> {
-    auto parse(fmt::format_parse_context& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}') {
             throw fmt::format_error("invalid format");
@@ -123,7 +123,7 @@ struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::PrintErrorCode> {
 
 template <>
 struct fmt::formatter<USERVER_NAMESPACE::protobuf::json::ParseErrorCode> {
-    auto parse(fmt::format_parse_context& ctx) {
+    constexpr auto parse(fmt::format_parse_context& ctx) {
         auto it = ctx.begin();
         if (it != ctx.end() && *it != '}') {
             throw fmt::format_error("invalid format");


### PR DESCRIPTION
Mark fmt::formatter<>::parse as constexpr and drop '*ViaChaosProxy' from the test exclusion list