### PR TITLE
feat rabbitmq: Support for queue optional args and queue.declare-ok response

### DIFF
--- a/rabbitmq/include/userver/urabbitmq/admin_channel.hpp
+++ b/rabbitmq/include/userver/urabbitmq/admin_channel.hpp
@@ -45,7 +45,16 @@ public:
         DeclareExchange(exchange, Exchange::Type::kFanOut, {}, deadline);
     }
 
-    void DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) override;
+    void DeclareQueue(
+        const Queue& queue, 
+        utils::Flags<Queue::Flags> flags, 
+        const std::unordered_map<std::string, HeaderValue>& headers, 
+        engine::Deadline deadline
+    ) override;
+
+    void DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) override {
+        DeclareQueue(queue, flags, {}, deadline);
+    }
 
     void DeclareQueue(const Queue& queue, engine::Deadline deadline) override { DeclareQueue(queue, {}, deadline); }
 

--- a/rabbitmq/include/userver/urabbitmq/admin_channel.hpp
+++ b/rabbitmq/include/userver/urabbitmq/admin_channel.hpp
@@ -45,18 +45,21 @@ public:
         DeclareExchange(exchange, Exchange::Type::kFanOut, {}, deadline);
     }
 
-    void DeclareQueue(
-        const Queue& queue, 
-        utils::Flags<Queue::Flags> flags, 
-        const std::unordered_map<std::string, HeaderValue>& headers, 
+    QueueDeclareResponse DeclareQueue(
+        const Queue& queue,
+        utils::Flags<Queue::Flags> flags,
+        const std::unordered_map<std::string, HeaderValue>& headers,
         engine::Deadline deadline
     ) override;
 
-    void DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) override {
-        DeclareQueue(queue, flags, {}, deadline);
+    QueueDeclareResponse
+    DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) override {
+        return DeclareQueue(queue, flags, {}, deadline);
     }
 
-    void DeclareQueue(const Queue& queue, engine::Deadline deadline) override { DeclareQueue(queue, {}, deadline); }
+    QueueDeclareResponse DeclareQueue(const Queue& queue, engine::Deadline deadline) override {
+        return DeclareQueue(queue, {}, deadline);
+    }
 
     void BindQueue(
         const Exchange& exchange,

--- a/rabbitmq/include/userver/urabbitmq/broker_interface.hpp
+++ b/rabbitmq/include/userver/urabbitmq/broker_interface.hpp
@@ -44,17 +44,20 @@ public:
     /// @param flags queue flags
     /// @param headers metadata table of the queue
     /// @param deadline execution deadline
-    virtual void DeclareQueue(
-        const Queue& queue, 
-        utils::Flags<Queue::Flags> flags, 
-        const std::unordered_map<std::string, HeaderValue>& headers, 
+    /// @returns the broker's `queue.declare-ok` reply (queue name, message and
+    /// consumer counts)
+    virtual QueueDeclareResponse DeclareQueue(
+        const Queue& queue,
+        utils::Flags<Queue::Flags> flags,
+        const std::unordered_map<std::string, HeaderValue>& headers,
         engine::Deadline deadline) = 0;
 
     /// @brief overload of DeclareQueue
-    virtual void DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) = 0;
+    virtual QueueDeclareResponse
+    DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) = 0;
 
     /// @brief overload of DeclareQueue
-    virtual void DeclareQueue(const Queue& queue, engine::Deadline deadline) = 0;
+    virtual QueueDeclareResponse DeclareQueue(const Queue& queue, engine::Deadline deadline) = 0;
 
     /// @brief Bind a queue to an exchange.
     ///

--- a/rabbitmq/include/userver/urabbitmq/broker_interface.hpp
+++ b/rabbitmq/include/userver/urabbitmq/broker_interface.hpp
@@ -42,7 +42,15 @@ public:
     ///
     /// @param queue name of the queue
     /// @param flags queue flags
+    /// @param headers metadata table of the queue
     /// @param deadline execution deadline
+    virtual void DeclareQueue(
+        const Queue& queue, 
+        utils::Flags<Queue::Flags> flags, 
+        const std::unordered_map<std::string, HeaderValue>& headers, 
+        engine::Deadline deadline) = 0;
+
+    /// @brief overload of DeclareQueue
     virtual void DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) = 0;
 
     /// @brief overload of DeclareQueue

--- a/rabbitmq/include/userver/urabbitmq/client.hpp
+++ b/rabbitmq/include/userver/urabbitmq/client.hpp
@@ -53,9 +53,18 @@ public:
         DeclareExchange(exchange, Exchange::Type::kFanOut, {}, deadline);
     }
 
-    void DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) override;
+    void DeclareQueue(
+        const Queue& queue, 
+        utils::Flags<Queue::Flags> flags, 
+        const std::unordered_map<std::string, HeaderValue>& headers, 
+        engine::Deadline deadline
+    ) override;
 
-    void DeclareQueue(const Queue& queue, engine::Deadline deadline) override { DeclareQueue(queue, {}, deadline); }
+    void DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) override {
+        DeclareQueue(queue, flags, {}, deadline);
+    }
+
+    void DeclareQueue(const Queue& queue, engine::Deadline deadline) override { DeclareQueue(queue, {}, {}, deadline); }
 
     void BindQueue(
         const Exchange& exchange,

--- a/rabbitmq/include/userver/urabbitmq/client.hpp
+++ b/rabbitmq/include/userver/urabbitmq/client.hpp
@@ -53,18 +53,21 @@ public:
         DeclareExchange(exchange, Exchange::Type::kFanOut, {}, deadline);
     }
 
-    void DeclareQueue(
-        const Queue& queue, 
-        utils::Flags<Queue::Flags> flags, 
-        const std::unordered_map<std::string, HeaderValue>& headers, 
+    QueueDeclareResponse DeclareQueue(
+        const Queue& queue,
+        utils::Flags<Queue::Flags> flags,
+        const std::unordered_map<std::string, HeaderValue>& headers,
         engine::Deadline deadline
     ) override;
 
-    void DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) override {
-        DeclareQueue(queue, flags, {}, deadline);
+    QueueDeclareResponse
+    DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) override {
+        return DeclareQueue(queue, flags, {}, deadline);
     }
 
-    void DeclareQueue(const Queue& queue, engine::Deadline deadline) override { DeclareQueue(queue, {}, {}, deadline); }
+    QueueDeclareResponse DeclareQueue(const Queue& queue, engine::Deadline deadline) override {
+        return DeclareQueue(queue, {}, {}, deadline);
+    }
 
     void BindQueue(
         const Exchange& exchange,

--- a/rabbitmq/include/userver/urabbitmq/typedefs.hpp
+++ b/rabbitmq/include/userver/urabbitmq/typedefs.hpp
@@ -72,6 +72,17 @@ enum class MessageType {
 /// This is not JSON, but a convenient tree representation for AMQP field values.
 using HeaderValue = formats::json::Value;
 
+/// @brief Result of a `DeclareQueue` call, mirroring the broker's
+/// `queue.declare-ok` response.
+struct QueueDeclareResponse {
+    /// name of the declared queue (useful for server-named queues)
+    std::string name;
+    /// number of messages ready for delivery in the queue at the time of the reply
+    std::uint32_t message_count{0};
+    /// number of consumers subscribed to the queue at the time of the reply
+    std::uint32_t consumer_count{0};
+};
+
 /// @brief Structure holding an AMQP message body along with some of its
 /// metadata fields. This struct is used to pass messages to the end user,
 /// hiding the actual AMQP message object implementation.

--- a/rabbitmq/src/tests/admin_rmqtest.cpp
+++ b/rabbitmq/src/tests/admin_rmqtest.cpp
@@ -1,5 +1,10 @@
 #include "utils_rmqtest.hpp"
 
+#include <string>
+#include <unordered_map>
+
+#include <userver/formats/json/value_builder.hpp>
+
 USERVER_NAMESPACE_BEGIN
 
 UTEST(AdminChannel, DeclareRemoveExchange) {
@@ -44,6 +49,62 @@ UTEST(AdminChannel, DeclareRemoveQueue) {
     new_channel.RemoveQueue(queue, client.GetDeadline());
     declare_queue(new_channel, urabbitmq::Queue::Flags::kNone);
     new_channel.RemoveQueue(queue, client.GetDeadline());
+}
+
+UTEST(AdminChannel, DeclareQueueWithMaxLengthArgument) {
+    // This test checks, whether optional args for queue are working
+    ClientWrapper client{};
+    auto channel = client->GetAdminChannel(client.GetDeadline());
+
+    constexpr std::int64_t kMaxLength = 3;
+    const std::unordered_map<std::string, urabbitmq::HeaderValue> arguments{
+        {"x-max-length", urabbitmq::HeaderValue::Builder{std::int64_t{kMaxLength}}.ExtractValue()},
+    };
+
+    channel.DeclareExchange(client.GetExchange(), urabbitmq::Exchange::Type::kFanOut, {}, client.GetDeadline());
+    channel.DeclareQueue(client.GetQueue(), {}, arguments, client.GetDeadline());
+    channel.BindQueue(client.GetExchange(), client.GetQueue(), client.GetRoutingKey(), client.GetDeadline());
+
+    constexpr int kPublishCount = kMaxLength + 10;
+    for (int i = 0; i < kPublishCount; ++i) {
+        client->PublishReliable(
+            client.GetExchange(), client.GetRoutingKey(), "message-" + std::to_string(i), client.GetDeadline()
+        );
+    }
+    const auto response = channel.DeclareQueue(client.GetQueue(), {}, arguments, client.GetDeadline());
+    EXPECT_EQ(response.message_count, kMaxLength);
+
+    // The default (drop-head) overflow drops the oldest messages, so the queue
+    // keeps only the newest kMaxLength ones. Reading them back in FIFO order must
+    // yield that tail: message-10, message-11, message-12.
+    for (int i = 0; i < kMaxLength; ++i) {
+        const auto message = client->Get(client.GetQueue(), urabbitmq::Queue::Flags::kNoAck, client.GetDeadline());
+        EXPECT_EQ(message, "message-" + std::to_string(kPublishCount - kMaxLength + i));
+    }
+}
+
+UTEST(AdminChannel, DeclareQueueArgumentMismatchFails) {
+    // Here we are testing the same queue with different optional args
+    ClientWrapper client{};
+
+    const auto declare_with_max_length = [&client](std::int64_t max_length) {
+        // A fresh channel per attempt: a PRECONDITION_FAILED breaks the channel
+        // it happens on, so reusing one would mask the cause of later failures.
+        auto channel = client->GetAdminChannel(client.GetDeadline());
+        const std::unordered_map<std::string, urabbitmq::HeaderValue> arguments{
+            {"x-max-length", urabbitmq::HeaderValue::Builder{std::int64_t{max_length}}.ExtractValue()},
+        };
+        channel.DeclareQueue(client.GetQueue(), {}, arguments, client.GetDeadline());
+    };
+
+    // First declaration creates the queue with x-max-length == 3.
+    declare_with_max_length(3);
+
+    // Re-declaring the same queue with a different argument value is a conflict.
+    EXPECT_ANY_THROW(declare_with_max_length(5));
+
+    // Re-declaring with the very same value is idempotent and must not throw.
+    EXPECT_NO_THROW(declare_with_max_length(3));
 }
 
 USERVER_NAMESPACE_END

--- a/rabbitmq/src/urabbitmq/admin_channel.cpp
+++ b/rabbitmq/src/urabbitmq/admin_channel.cpp
@@ -24,9 +24,11 @@ void AdminChannel::DeclareExchange(
     ConnectionHelper::DeclareExchange(*impl_, exchange, type, flags, deadline).Wait(deadline);
 }
 
-void AdminChannel::DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, 
+QueueDeclareResponse AdminChannel::DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags,
     const std::unordered_map<std::string, HeaderValue>& headers, engine::Deadline deadline) {
-    ConnectionHelper::DeclareQueue(*impl_, queue, flags, headers, deadline).Wait(deadline);
+    QueueDeclareResponse response;
+    ConnectionHelper::DeclareQueue(*impl_, queue, flags, headers, response, deadline).Wait(deadline);
+    return response;
 }
 
 void AdminChannel::BindQueue(

--- a/rabbitmq/src/urabbitmq/admin_channel.cpp
+++ b/rabbitmq/src/urabbitmq/admin_channel.cpp
@@ -24,8 +24,9 @@ void AdminChannel::DeclareExchange(
     ConnectionHelper::DeclareExchange(*impl_, exchange, type, flags, deadline).Wait(deadline);
 }
 
-void AdminChannel::DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) {
-    ConnectionHelper::DeclareQueue(*impl_, queue, flags, deadline).Wait(deadline);
+void AdminChannel::DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, 
+    const std::unordered_map<std::string, HeaderValue>& headers, engine::Deadline deadline) {
+    ConnectionHelper::DeclareQueue(*impl_, queue, flags, headers, deadline).Wait(deadline);
 }
 
 void AdminChannel::BindQueue(

--- a/rabbitmq/src/urabbitmq/client.cpp
+++ b/rabbitmq/src/urabbitmq/client.cpp
@@ -34,10 +34,13 @@ void Client::DeclareExchange(
     awaiter.Wait(deadline);
 }
 
-void Client::DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, 
+QueueDeclareResponse Client::DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags,
     const std::unordered_map<std::string, HeaderValue>& headers, engine::Deadline deadline) {
-    auto awaiter = ConnectionHelper::DeclareQueue(impl_->GetConnection(deadline), queue, flags, headers, deadline);
+    QueueDeclareResponse response;
+    auto awaiter =
+        ConnectionHelper::DeclareQueue(impl_->GetConnection(deadline), queue, flags, headers, response, deadline);
     awaiter.Wait(deadline);
+    return response;
 }
 
 void Client::BindQueue(

--- a/rabbitmq/src/urabbitmq/client.cpp
+++ b/rabbitmq/src/urabbitmq/client.cpp
@@ -34,8 +34,9 @@ void Client::DeclareExchange(
     awaiter.Wait(deadline);
 }
 
-void Client::DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline) {
-    auto awaiter = ConnectionHelper::DeclareQueue(impl_->GetConnection(deadline), queue, flags, deadline);
+void Client::DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, 
+    const std::unordered_map<std::string, HeaderValue>& headers, engine::Deadline deadline) {
+    auto awaiter = ConnectionHelper::DeclareQueue(impl_->GetConnection(deadline), queue, flags, headers, deadline);
     awaiter.Wait(deadline);
 }
 

--- a/rabbitmq/src/urabbitmq/connection_helper.cpp
+++ b/rabbitmq/src/urabbitmq/connection_helper.cpp
@@ -23,9 +23,10 @@ impl::ResponseAwaiter ConnectionHelper::DeclareQueue(
     const ConnectionPtr& connection,
     const Queue& queue,
     utils::Flags<Queue::Flags> flags,
+    const std::unordered_map<std::string, HeaderValue>& headers,
     engine::Deadline deadline
 ) {
-    return WithSpan("declare_queue", [&] { return connection->GetChannel().DeclareQueue(queue, flags, deadline); });
+    return WithSpan("declare_queue", [&] { return connection->GetChannel().DeclareQueue(queue, flags, headers, deadline); });
 }
 
 impl::ResponseAwaiter ConnectionHelper::BindQueue(

--- a/rabbitmq/src/urabbitmq/connection_helper.cpp
+++ b/rabbitmq/src/urabbitmq/connection_helper.cpp
@@ -24,9 +24,12 @@ impl::ResponseAwaiter ConnectionHelper::DeclareQueue(
     const Queue& queue,
     utils::Flags<Queue::Flags> flags,
     const std::unordered_map<std::string, HeaderValue>& headers,
+    QueueDeclareResponse& response,
     engine::Deadline deadline
 ) {
-    return WithSpan("declare_queue", [&] { return connection->GetChannel().DeclareQueue(queue, flags, headers, deadline); });
+    return WithSpan("declare_queue", [&] {
+        return connection->GetChannel().DeclareQueue(queue, flags, headers, response, deadline);
+    });
 }
 
 impl::ResponseAwaiter ConnectionHelper::BindQueue(

--- a/rabbitmq/src/urabbitmq/connection_helper.hpp
+++ b/rabbitmq/src/urabbitmq/connection_helper.hpp
@@ -33,6 +33,7 @@ public:
         const Queue& queue,
         utils::Flags<Queue::Flags> flags,
         const std::unordered_map<std::string, HeaderValue>& headers,
+        QueueDeclareResponse& response,
         engine::Deadline deadline
     );
 

--- a/rabbitmq/src/urabbitmq/connection_helper.hpp
+++ b/rabbitmq/src/urabbitmq/connection_helper.hpp
@@ -32,6 +32,7 @@ public:
         const ConnectionPtr& connection,
         const Queue& queue,
         utils::Flags<Queue::Flags> flags,
+        const std::unordered_map<std::string, HeaderValue>& headers,
         engine::Deadline deadline
     );
 

--- a/rabbitmq/src/urabbitmq/impl/amqp_channel.cpp
+++ b/rabbitmq/src/urabbitmq/impl/amqp_channel.cpp
@@ -133,6 +133,7 @@ ResponseAwaiter AmqpChannel::DeclareQueue(
     const Queue& queue,
     utils::Flags<Queue::Flags> flags,
     const std::unordered_map<std::string, HeaderValue>& headers,
+    QueueDeclareResponse& response,
     engine::Deadline deadline
 ) {
     auto awaiter = conn_.GetAwaiter(deadline);
@@ -141,7 +142,9 @@ ResponseAwaiter AmqpChannel::DeclareQueue(
         auto channel = conn_.GetChannel(deadline);
         AMQP::Table table;
         AddHeadersToTable(table, headers);
-        awaiter.GetWrapper()->Wrap(channel->declareQueue(queue.GetUnderlying(), Convert(flags), table));
+        awaiter.GetWrapper()->WrapDeclareQueue(
+            channel->declareQueue(queue.GetUnderlying(), Convert(flags), table), response
+        );
     }
 
     return awaiter;

--- a/rabbitmq/src/urabbitmq/impl/amqp_channel.cpp
+++ b/rabbitmq/src/urabbitmq/impl/amqp_channel.cpp
@@ -132,13 +132,16 @@ ResponseAwaiter AmqpChannel::DeclareExchange(
 ResponseAwaiter AmqpChannel::DeclareQueue(
     const Queue& queue,
     utils::Flags<Queue::Flags> flags,
+    const std::unordered_map<std::string, HeaderValue>& headers,
     engine::Deadline deadline
 ) {
     auto awaiter = conn_.GetAwaiter(deadline);
 
     {
         auto channel = conn_.GetChannel(deadline);
-        awaiter.GetWrapper()->Wrap(channel->declareQueue(queue.GetUnderlying(), Convert(flags)));
+        AMQP::Table table;
+        AddHeadersToTable(table, headers);
+        awaiter.GetWrapper()->Wrap(channel->declareQueue(queue.GetUnderlying(), Convert(flags), table));
     }
 
     return awaiter;

--- a/rabbitmq/src/urabbitmq/impl/amqp_channel.hpp
+++ b/rabbitmq/src/urabbitmq/impl/amqp_channel.hpp
@@ -40,7 +40,12 @@ public:
         engine::Deadline deadline
     );
 
-    ResponseAwaiter DeclareQueue(const Queue& queue, utils::Flags<Queue::Flags> flags, engine::Deadline deadline);
+    ResponseAwaiter DeclareQueue(
+        const Queue& queue, 
+        utils::Flags<Queue::Flags> flags, 
+        const std::unordered_map<std::string, HeaderValue>& headers,
+        engine::Deadline deadline
+    );
 
     ResponseAwaiter BindQueue(
         const Exchange& exchange,

--- a/rabbitmq/src/urabbitmq/impl/amqp_channel.hpp
+++ b/rabbitmq/src/urabbitmq/impl/amqp_channel.hpp
@@ -41,9 +41,10 @@ public:
     );
 
     ResponseAwaiter DeclareQueue(
-        const Queue& queue, 
-        utils::Flags<Queue::Flags> flags, 
+        const Queue& queue,
+        utils::Flags<Queue::Flags> flags,
         const std::unordered_map<std::string, HeaderValue>& headers,
+        QueueDeclareResponse& response,
         engine::Deadline deadline
     );
 

--- a/rabbitmq/src/urabbitmq/impl/deferred_wrapper.cpp
+++ b/rabbitmq/src/urabbitmq/impl/deferred_wrapper.cpp
@@ -4,6 +4,7 @@
 
 #include <urabbitmq/make_shared_enabler.hpp>
 
+#include <userver/urabbitmq/typedefs.hpp>
 #include <userver/utils/assert.hpp>
 
 USERVER_NAMESPACE_BEGIN
@@ -55,6 +56,16 @@ void DeferredWrapper::WrapGet(AMQP::DeferredGet& deferred, std::string& message)
     deferred
         .onSuccess([wrap = shared_from_this(), &message](const AMQP::Message& message_rec, uint64_t, bool) {
             message = std::string(message_rec.body(), message_rec.bodySize());
+            wrap->Ok();
+        })
+        .onError([wrap = shared_from_this()](const char* error) { wrap->Fail(error); });
+}
+
+void DeferredWrapper::WrapDeclareQueue(AMQP::DeferredQueue& deferred, QueueDeclareResponse& response) {
+    deferred
+        .onSuccess([wrap = shared_from_this(),
+                    &response](const std::string& name, uint32_t message_count, uint32_t consumer_count) {
+            response = QueueDeclareResponse{name, message_count, consumer_count};
             wrap->Ok();
         })
         .onError([wrap = shared_from_this()](const char* error) { wrap->Fail(error); });

--- a/rabbitmq/src/urabbitmq/impl/deferred_wrapper.hpp
+++ b/rabbitmq/src/urabbitmq/impl/deferred_wrapper.hpp
@@ -11,9 +11,14 @@
 namespace AMQP {
 class Deferred;
 class DeferredGet;
+class DeferredQueue;
 }  // namespace AMQP
 
 USERVER_NAMESPACE_BEGIN
+
+namespace urabbitmq {
+struct QueueDeclareResponse;
+}  // namespace urabbitmq
 
 namespace urabbitmq::impl {
 
@@ -30,6 +35,8 @@ public:
     void Wrap(AMQP::Deferred& deferred);
 
     void WrapGet(AMQP::DeferredGet& deferred, std::string& message);
+
+    void WrapDeclareQueue(AMQP::DeferredQueue& deferred, QueueDeclareResponse& response);
 
     static std::shared_ptr<DeferredWrapper> Create();
 


### PR DESCRIPTION
There are cases, when we need to use so called queue's optional args like maximal message count per queue etc. Out the box userver does not provide such feature. I have added this via already implemented HeaderValue class (to wrap amqp's Table) + have added response from DeclareQueue in order to carefully check optional args in unit tests





------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

