### PR TITLE
fix redis: use FromString for double reply values

### DIFF
--- a/redis/src/storages/redis/parse_reply.cpp
+++ b/redis/src/storages/redis/parse_reply.cpp
@@ -263,7 +263,7 @@ std::string Parse(ReplyData&& reply_data, const std::string& request_description
 double Parse(ReplyData&& reply_data, const std::string& request_description, To<double>) {
     reply_data.ExpectString(request_description);
     try {
-        return std::stod(reply_data.GetString());
+        return utils::FromString<double>(reply_data.GetString());
     } catch (const std::exception& ex) {
         throw ParseReplyException(
             "Can't parse value from reply to '" + request_description + "' request (" + reply_data.ToDebugString() +

--- a/redis/src/storages/redis/parse_reply_test.cpp
+++ b/redis/src/storages/redis/parse_reply_test.cpp
@@ -1,0 +1,43 @@
+#include <userver/storages/redis/parse_reply.hpp>
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include <userver/storages/redis/exception.hpp>
+#include <userver/storages/redis/reply.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace {
+
+double ParseDouble(std::string value) {
+    return storages::redis::Parse(
+        storages::redis::ReplyData{std::move(value)}, "test_request", storages::redis::To<double>{}
+    );
+}
+
+}  // namespace
+
+TEST(ParseReply, DoubleValid) {
+    EXPECT_DOUBLE_EQ(ParseDouble("3.14"), 3.14);
+    EXPECT_DOUBLE_EQ(ParseDouble("-2.5"), -2.5);
+    EXPECT_DOUBLE_EQ(ParseDouble("1e3"), 1000.0);
+}
+
+TEST(ParseReply, DoubleInfinity) {
+    // ZSCORE and friends report infinite scores as "inf"/"-inf".
+    EXPECT_TRUE(std::isinf(ParseDouble("inf")));
+    EXPECT_TRUE(std::isinf(ParseDouble("-inf")));
+}
+
+TEST(ParseReply, DoubleTrailingJunk) {
+    // A compromised, misbehaving, or MITM'd server can return a bulk string with
+    // a valid numeric prefix followed by junk. std::stod silently accepted the
+    // prefix and dropped the rest; the strict parser rejects the whole reply.
+    EXPECT_THROW(ParseDouble("3.14garbage"), storages::redis::ParseReplyException);
+    EXPECT_THROW(ParseDouble("nonsense"), storages::redis::ParseReplyException);
+    EXPECT_THROW(ParseDouble(""), storages::redis::ParseReplyException);
+}
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
1. `Parse(..., To<double>)` converts floating-point reply values (`ZSCORE`, `HINCRBYFLOAT`, `ZADD ... INCR`) with `std::stod`, which respects the process `LC_NUMERIC` and keeps only the valid numeric prefix of the string.
2. under a comma-decimal locale `"3.14"` parses as `3.0`, and a reply like `"3.14x"` parses as `3.14` with the trailing bytes silently dropped, so a compromised or MITM'd server can return a corrupted value.

Switched to `utils::FromString<double>`, matching the geo parser at line 58 and the score parser at line 166 in this file: it is locale-independent and rejects trailing junk, while numbers, scientific notation, and `inf`/`-inf` still parse the same. Added a regression test for the trailing-junk case along with valid and infinite values.