### PR TITLE
fix chaotic: indirect in oneOf now uses proper WriteToStream

### DIFF
--- a/chaotic/include/userver/chaotic/ref.hpp
+++ b/chaotic/include/userver/chaotic/ref.hpp
@@ -30,6 +30,16 @@ void WriteToStream(const Ref<T>& ps, formats::json::StringBuilder& sw) {
     WriteToStream(T{*ps.value}, sw);
 }
 
+template <typename T>
+void WriteToStream(
+    const Ref<T>& ps,
+    formats::json::StringBuilder& sw,
+    bool hide_brackets,
+    std::string_view hide_field_name
+) {
+    WriteToStream(T{*ps.value}, sw, hide_brackets, hide_field_name);
+}
+
 }  // namespace chaotic
 
 USERVER_NAMESPACE_END

--- a/chaotic/include/userver/chaotic/sax_parser.hpp
+++ b/chaotic/include/userver/chaotic/sax_parser.hpp
@@ -104,8 +104,10 @@ private:
 template <typename T, typename ResultType = TypeOfDescriptor<T>>
 class RefParser final : private formats::json::parser::Subscriber<ResultType> {
 public:
+    using Subparser = chaotic::sax::Parser<T>;
+
     RefParser()
-        : parser_(std::make_unique<chaotic::sax::Parser<T>>())
+        : parser_(std::make_unique<Subparser>())
     {
         parser_->Subscribe(*this);
     }
@@ -114,12 +116,12 @@ public:
 
     void Subscribe(formats::json::parser::Subscriber<utils::Box<ResultType>>& subscriber) { subscriber_ = &subscriber; }
 
-    formats::json::parser::BaseParser& GetParser() { return *parser_; }
+    formats::json::parser::BaseParser& GetParser() { return parser_->GetParser(); }
 
+    void OnSend(ResultType&& value) override { subscriber_->OnSend(utils::Box<ResultType>(std::move(value))); }
 private:
-    void OnSend(ResultType&& value) { subscriber_->OnSend(utils::Box<ResultType>(std::move(value))); }
 
-    std::unique_ptr<formats::json::parser::TypedParser<ResultType>> parser_;
+    std::unique_ptr<Subparser> parser_;
     formats::json::parser::Subscriber<utils::Box<ResultType>>* subscriber_{nullptr};
 };
 

--- a/chaotic/integration_tests/schemas/oneof_discriminator_indirect.yaml
+++ b/chaotic/integration_tests/schemas/oneof_discriminator_indirect.yaml
@@ -1,0 +1,43 @@
+definitions:
+    Tree:
+        type: object
+        additionalProperties: false
+        required:
+            - root
+        properties:
+            root:
+                $ref: '#/definitions/Node'
+                x-usrv-cpp-indirect: true
+
+    Node:
+        oneOf:
+            - $ref: '#/definitions/TypeA'
+              x-usrv-cpp-indirect: true
+            - $ref: '#/definitions/TypeB'
+              x-usrv-cpp-indirect: true
+        discriminator:
+            propertyName: kind
+            mapping:
+                1: '#/definitions/TypeA'
+                2: '#/definitions/TypeB'
+
+    TypeA:
+        type: object
+        required:
+            - kind
+        properties:
+            kind:
+                type: integer
+            value:
+                type: integer
+
+    TypeB:
+        type: object
+        required:
+            - kind
+        properties:
+            kind:
+                type: integer
+            nested:
+                $ref: '#/definitions/Node'
+                x-usrv-cpp-indirect: true

--- a/chaotic/integration_tests/tests/render/oneof_discriminator_indirect.cpp
+++ b/chaotic/integration_tests/tests/render/oneof_discriminator_indirect.cpp
@@ -1,0 +1,51 @@
+#include <gmock/gmock.h>
+
+#include <userver/formats/json/inline.hpp>
+#include <userver/formats/parse/variant.hpp>
+#include <userver/utils/box.hpp>
+
+#include <schemas/oneof_discriminator_indirect.hpp>
+
+#include "helper.hpp"
+
+USERVER_NAMESPACE_BEGIN
+
+TEST(OneOfDiscriminatorIndirect, ParseSimpleVariant) {
+    const auto json = formats::json::MakeObject(
+        "root",
+        formats::json::MakeObject("kind", 1, "value", 42)
+    );
+    auto tree = json.As<ns::Tree>();
+
+    EXPECT_TRUE(std::holds_alternative<utils::Box<ns::TypeA>>(*tree.root));
+    EXPECT_EQ(std::get<utils::Box<ns::TypeA>>(*tree.root)->value, 42);
+
+    EXPECT_EQ(TestDomSerializer(tree), json);
+    EXPECT_EQ(TestWriteToStream(tree), json);
+}
+
+TEST(OneOfDiscriminatorIndirect, ParseVariantWithIndirectNested) {
+    const auto json = formats::json::MakeObject(
+        "root",
+        formats::json::MakeObject(
+            "kind", 2,
+            "nested", formats::json::MakeObject(
+                "kind", 1,
+                "value", 100
+            )
+        )
+    );
+    auto tree = json.As<ns::Tree>();
+    EXPECT_TRUE(std::holds_alternative<utils::Box<ns::TypeB>>(*tree.root));
+
+    auto& type_b = std::get<utils::Box<ns::TypeB>>(*tree.root);
+    EXPECT_TRUE(type_b->nested.has_value());
+    EXPECT_TRUE(std::holds_alternative<utils::Box<ns::TypeA>>(*type_b->nested.value()));
+    EXPECT_EQ(std::get<utils::Box<ns::TypeA>>(*type_b->nested.value())->value, 100);
+
+
+    EXPECT_EQ(TestDomSerializer(tree), json);
+    EXPECT_EQ(TestWriteToStream(tree), json);
+}
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
**Bug**: Compilation fails when using `oneOf` with discriminator and `x-usrv-cpp-indirect: true` on variant references

**Error**:
`error: no matching function for call to 'WriteToStream'`

**Root cause**: `OneOfWithDiscriminator` serializes variants with `hide_brackets` and `hide_field_name` parameters, but `Ref<T>` (used for `x-usrv-cpp-indirect`) only has a 2-argument `WriteToStream` overload

**Fix:** Add `WriteToStream` overload for `Ref<T>` that accepts and forwards `hide_brackets` / `hide_field_name` parameters

**Test case**: `oneof_discriminator_indirect.yaml` — recursive Node type with `x-usrv-cpp-indirect: true` on both oneOf variants
