### PR TITLE
fix core: don't depend on HTTP/2.0 pseudo-header field order

### DIFF
--- a/core/functional_tests/http2server/tests/test_low_level.py
+++ b/core/functional_tests/http2server/tests/test_low_level.py
@@ -470,3 +470,69 @@ async def test_streams_with_the_same_id(create_connection, service_client):
         assert 'unexpected non-CONTINUATION frame or stream_id is invalid' in str(
             receive,
         )
+
+
+# RFC 9113 8.3 does not fix an order among the pseudo-header fields, so a
+# request must be routed identically regardless of it. h2load, for example,
+# serializes :path first and :method after :scheme and :authority.
+PSEUDO_HEADER_ORDERS = [
+    pytest.param(order, id=order_id)
+    for order_id, order in [
+        ('method-first', [':method', ':path', ':scheme', ':authority']),
+        ('h2load', [':path', ':scheme', ':authority', ':method']),
+        ('method-last', [':path', ':authority', ':scheme', ':method']),
+        ('path-last', [':authority', ':scheme', ':method', ':path']),
+    ]
+]
+
+
+def _make_headers(order, query, extra):
+    values = {
+        ':method': 'GET',
+        ':path': f'{DEFAULT_PATH}?{query}',
+        ':scheme': 'http',
+        ':authority': 'localhost',
+    }
+    return [(name, values[name]) for name in order] + extra
+
+
+@pytest.mark.parametrize('order', PSEUDO_HEADER_ORDERS)
+async def test_pseudo_header_order_is_irrelevant(
+    create_connection,
+    service_client,
+    order,
+):
+    headers = _make_headers(order, 'type=echo-header', [('echo-header', 'reordered')])
+    async with create_connection() as (sock, conn):
+        stream_id = conn.get_next_available_stream_id()
+        conn.send_headers(stream_id, headers, end_stream=True)
+        await sock.sendall(conn.data_to_send())
+
+        events = await utils.receive_until_stream_ended(sock, conn)
+        response = next(event for event in events if isinstance(event, h2.events.ResponseReceived))
+        assert b'200' == dict(response.headers)[b':status']
+        assert b'reordered' == utils.response_data(events)
+
+
+@pytest.mark.parametrize('order', PSEUDO_HEADER_ORDERS)
+async def test_pseudo_header_order_with_request_body(
+    create_connection,
+    service_client,
+    order,
+):
+    # Handler matching installs the per-handler request limits, which must be
+    # in place before the DATA frames arrive - so it must happen at the end
+    # of the header block whatever the pseudo-header order was.
+    body = b'0123456789abcdef' * 64
+    headers = _make_headers(order, 'type=echo-body', [])
+    headers = [(':method', 'POST') if name == ':method' else (name, value) for name, value in headers]
+    async with create_connection() as (sock, conn):
+        stream_id = conn.get_next_available_stream_id()
+        conn.send_headers(stream_id, headers, end_stream=False)
+        conn.send_data(stream_id, body, end_stream=True)
+        await sock.sendall(conn.data_to_send())
+
+        events = await utils.receive_until_stream_ended(sock, conn)
+        response = next(event for event in events if isinstance(event, h2.events.ResponseReceived))
+        assert b'200' == dict(response.headers)[b':status']
+        assert body == utils.response_data(events)

--- a/core/src/server/http/http2_session.cpp
+++ b/core/src/server/http/http2_session.cpp
@@ -98,6 +98,21 @@ int Http2Session::OnFrameRecv(nghttp2_session* session, const nghttp2_frame* fra
     switch (frame->hd.type) {
         case NGHTTP2_DATA:
         case NGHTTP2_HEADERS: {
+            if (frame->hd.type == NGHTTP2_HEADERS && frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
+                // Safety net for requests that did not reach the handler
+                // matching in OnHeader (normally it fires as soon as both
+                // :method and :path are decoded). The whole header block,
+                // CONTINUATION frames included, is decoded at this point.
+                // Matching cannot happen later, in FinalizeRequest: it
+                // installs the per-handler request limits, which must be in
+                // place before the DATA frames of the request body arrive.
+                // Parse errors are handled in FinalizeRequest.
+                auto* stream =
+                    static_cast<Stream*>(nghttp2_session_get_stream_user_data(session, frame->hd.stream_id));
+                if (stream != nullptr) {
+                    [[maybe_unused]] const bool url_ok = stream->CheckUrlComplete();
+                }
+            }
             if (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
                 auto& stream = parser.GetStreamChecked(Stream::Id{frame->hd.stream_id});
                 try {
@@ -145,12 +160,15 @@ int Http2Session::OnHeader(
     auto& parser = GetParser(user_data);
     auto& stream = parser.GetStreamChecked(Stream::Id{frame->hd.stream_id});
     auto& ctor = stream.RequestConstructor();
-    if (hname == USERVER_NAMESPACE::http::headers::k2::kMethod) {
+    const bool is_method = hname == USERVER_NAMESPACE::http::headers::k2::kMethod;
+    const bool is_path = hname == USERVER_NAMESPACE::http::headers::k2::kPath;
+    if (is_method) {
         ctor.SetMethod(HttpMethodFromString(hvalue));
-    } else if (hname == USERVER_NAMESPACE::http::headers::k2::kPath) {
+        stream.SetMethodParsed();
+    } else if (is_path) {
         try {
             ctor.AppendUrl(hvalue);
-            stream.CheckUrlComplete();
+            stream.SetPathParsed();
         } catch (const std::exception& e) {
             LOG_LIMITED_WARNING() << "can't append url: " << e;
             IncStat(parser.stats_.http2_stats.streams_parse_error);
@@ -163,6 +181,22 @@ int Http2Session::OnHeader(
             LOG_LIMITED_WARNING() << "can't append header field: " << e;
             IncStat(parser.stats_.http2_stats.streams_parse_error);
         }
+    }
+
+    if ((is_method || is_path) && stream.IsRequestTargetComplete()) {
+        // Match the handler at the earliest correct moment: when both
+        // :method and :path are decoded. Neither field alone is enough —
+        // RFC 9113 fixes no order among the pseudo-header fields (h2load,
+        // for example, serializes :path before :method), and matching with
+        // a yet-unknown method used to produce a cached 405 for the whole
+        // request. Since all pseudo-header fields precede the regular ones,
+        // matching here means the per-handler request limits cover the
+        // remaining header fields, and a doomed request (405/404) is known
+        // as early as possible. The rest of the header block still has to
+        // be decoded either way: HPACK is stateful, so a block cannot be
+        // abandoned midway without desyncing the whole connection; the
+        // accumulated data is bounded by max_headers_size.
+        [[maybe_unused]] const bool url_ok = stream.CheckUrlComplete();
     }
     return 0;
 }

--- a/core/src/server/http/http2_stream.hpp
+++ b/core/src/server/http/http2_stream.hpp
@@ -41,6 +41,12 @@ public:
     void SetStreaming(bool streaming);
 
     bool CheckUrlComplete();
+    // RFC 9113 fixes no order among the pseudo-header fields, so :method and
+    // :path may arrive in any relative order; the request target is complete
+    // only when both were decoded.
+    void SetMethodParsed() { method_parsed_ = true; }
+    void SetPathParsed() { path_parsed_ = true; }
+    bool IsRequestTargetComplete() const { return method_parsed_ && path_parsed_; }
     void PushChunk(std::string&& chunk);
     ssize_t GetMaxSize(std::size_t max_len, std::uint32_t* flags);
     void Send(engine::io::RwBase& socket, std::string_view data_frame_header, std::size_t max_len);
@@ -48,6 +54,8 @@ public:
 
 private:
     bool url_complete_{false};
+    bool method_parsed_{false};
+    bool path_parsed_{false};
     HttpRequestConstructor constructor_;
     const Id id_;
     // Body sending


### PR DESCRIPTION
The server matches a request against its handlers as soon as the `:path`
pseudo-header is decoded, using whatever method has been parsed by that point.
RFC 9113 §8.3 doesn't fix an order among pseudo-header fields, and clients
disagree: curl sends `:method` first, h2load sends `:path` first. As a result
every h2load request gets `405 Method Not Allowed` — matching runs with the
default `HttpMethod::kUnknown` and the cached result is never revisited:

```console
$ h2load -n 1 -c 1 -v http://localhost:8080/ping
[stream_id=1] :status: 405
```

This matches the handler once *both* `:method` and `:path` are decoded. Since
pseudo-header fields precede all regular fields, that is the earliest correct
moment in every order: the per-handler request limits then cover the rest of
the header block, and a doomed request (405/404) is known as early as
possible — no resource-usage regression versus the old eager match. The
remainder of the block still has to be decoded either way (HPACK is stateful;
abandoning a block midway would desync the connection) and is bounded by
`max_headers_size`. A call at end-of-header-block (`OnFrameRecv`, fires after
all CONTINUATION frames) remains as a safety net; matching can't be postponed
to `FinalizeRequest` because the per-handler limits must be installed before
the request body's DATA frames arrive.

Tested with two new parametrized tests in the http2server functional suite:
the same request over four pseudo-header orders (h2load's exact order
included), as GET and as POST with a request body — the latter checks that
the per-handler limits are installed before the body arrives. Without the fix
the four `:path`-before-`:method` cases fail with 405; with it all pass. The
rest of the http2server suite (h2spec included) and the http2/connection unit
tests pass unchanged. Also verified with stock h2load under load: 2M
requests, 100% `200`.


closes: #1300