### PR TITLE
fix core: close idle HTTP/2 connections on keepalive_timeout

### DIFF
--- a/core/src/server/net/connection_test.cpp
+++ b/core/src/server/net/connection_test.cpp
@@ -340,6 +340,47 @@ TYPED_UTEST(ServerNetConnection, KeepAlive) {
     EXPECT_EQ(handler.asyncs_finished, 2);
 }
 
+// After a completed keep-alive request the connection goes idle. The server
+// must close it on `keepalive_timeout` by itself (no cancellation) for both
+// HTTP/1.1 and HTTP/2; otherwise an idle HTTP/2 connection would live forever.
+TYPED_UTEST(ServerNetConnection, IdleKeepAliveTimeout) {
+    using ConnectionType = TypeParam;
+    const auto http_ver = HttpVersion<ConnectionType>();
+    net::ListenerConfig config = CreateConfig(http_ver);
+    config.connection_config.keepalive_timeout = std::chrono::seconds{1};
+    auto request_socket = net::CreateSocket(config, config.ports[0]);
+
+    auto http_client_ptr = utest::CreateHttpClient();
+    auto request =
+        CreateRequest(*http_client_ptr, request_socket, kSuccessRequestTimeout, http_ver, ConnectionHeader::kKeepAlive);
+
+    auto peer = request_socket.Accept(Deadline::FromDuration(kAcceptTimeout));
+    ASSERT_TRUE(peer.IsValid());
+    net::Stats stats{};
+    server::request::ResponseDataAccounter data_accounter;
+    TestHttprequestHandler handler;
+
+    auto task = engine::AsyncNoTracing([&] {
+        ConnectionType connection(
+            config.connection_config,
+            config.handler_defaults,
+            std::make_unique<engine::io::Socket>(std::move(peer)),
+            {},
+            handler,
+            stats,
+            data_accounter
+        );
+
+        connection.Process();
+    });
+    EXPECT_EQ(request.Get()->status_code(), 404);
+
+    // The connection is idle now; it must terminate on the keepalive timeout
+    // with nobody cancelling the task.
+    task.WaitFor(utest::kMaxTestWaitTime);
+    EXPECT_TRUE(task.IsFinished());
+}
+
 TYPED_UTEST(ServerNetConnection, CancelMultipleInFlight) {
     using ConnectionType = TypeParam;
     constexpr std::size_t kInFlightRequests = 10;

--- a/core/src/server/net/http2_connection.cpp
+++ b/core/src/server/net/http2_connection.cpp
@@ -100,9 +100,11 @@ void Http2Connection::ListenForRequests() {
             return;
         }
 
-        const auto ready_id = wait_any.Wait();
+        const auto ready_id = wait_any.WaitUntil(engine::Deadline::FromDuration(config_.keepalive_timeout));
         if (!ready_id) {
-            UASSERT(ready_id == utils::unexpected(engine::WaitAnyError::kCancelled));
+            if (ready_id == utils::unexpected(engine::WaitAnyError::kTimeout) && !IsIdle()) {
+                continue;
+            }
             return;
         }
 
@@ -181,6 +183,8 @@ void Http2Connection::SendResponse(http::HttpRequest& request) noexcept {
 
     request.WriteAccessLogs(request_handler_.LoggerAccess(), request_handler_.LoggerAccessTskv(), GetPeerName());
 }
+
+bool Http2Connection::IsIdle() const noexcept { return handler_tasks_.empty(); }
 
 bool Http2Connection::ShouldCloseConnection() const noexcept {
     UASSERT(parser_);

--- a/core/src/server/net/http2_connection.hpp
+++ b/core/src/server/net/http2_connection.hpp
@@ -69,6 +69,7 @@ private:
     void EnsureHttp2();
 
     bool ShouldCloseConnection() const noexcept;
+    bool IsIdle() const noexcept;
 
     const ConnectionConfig& config_;
     const request::HttpRequestConfig& handler_defaults_config_;


### PR DESCRIPTION
An idle or slowly-dripping HTTP/2 connection is never closed by the server, so
a client can hold connections open at near-zero cost and exhaust the server's
`max_connections` slots (default 32768), after which new connections are
refused for every client — a classic Slowloris. HTTP/1.1 closes such a
connection after `keepalive_timeout`; HTTP/2 used to as well, but the
enforcement was dropped in the HttpReader refactor (f75379023) that replaced
the deadline-carrying `WaitOnSocket` with a deadline-less `WaitAnyContext`
loop.

Root cause: `Http2Connection::ListenForRequests()` blocked in
`wait_any.Wait()` with no deadline. `keepalive_timeout` is still applied inside
`SocketBufferedReader::TryRead`, but that runs only *after* `Wait()` reports
the socket readable — a connection that never becomes readable never enters
`TryRead`, so the deadline never applies.

This restores the timeout on the current concurrent connection loop:

* The wait now uses `WaitUntil(Deadline::FromDuration(config_.keepalive_timeout))`
  instead of `Wait()`. On expiry the connection is closed only when it is idle
  (`IsIdle()` — no in-flight handler task); otherwise the loop re-arms and
  keeps waiting. This makes the deadline a purely *inbound idle* timeout: a
  connection actively serving a response is never torn down for lack of
  *incoming* bytes. The close reuses HTTP/1.1's `"Closing idle connection on
  timeout"` log line.
* Cancellation and empty-context expiry keep the existing early return; only
  the new `kTimeout` branch is added.

Reusing `keepalive_timeout` keeps parity with HTTP/1.1. Like HTTP/1.1, the
timeout is a per-idle-period deadline, not a whole-connection cap — a slow
drip of bytes resets it — so a separate longer whole-connection cap could be
added later if desired; it is out of scope here.

Verified end-to-end against `ng200ok` with `keepalive_timeout: 5` over h2c: an
idle connection (preface only, no request) is closed at exactly 5.0s and logs
the idle-close line. The in-flight-request path (a `GET /sql/?delay=8` handler
slower than the keepalive survives the deadline and returns 200 at 8.3s) was
verified on the body-streaming-restore build, since `ng200ok` uses
`response-body-stream: true`, which only works there; the `IsIdle()` gate that
protects it is identical.


closes: #1303 
