### PR TITLE
fix grpc: reject out-of-range day in datetime IsValid

### DIFF
--- a/grpc/src/ugrpc/datetime_utils.cpp
+++ b/grpc/src/ugrpc/datetime_utils.cpp
@@ -38,7 +38,9 @@ bool IsValid(const google::type::Date& grpc_date) {
     return (grpc_date.year() >= 1 && grpc_date.year() < 10'000) &&
            (grpc_date.month() >= 1 && grpc_date.month() <= 12) &&
            (grpc_date.day() >= 1 &&
-            std::chrono::day(grpc_date.day()) <= utils::datetime::DaysInMonth(grpc_date.month(), grpc_date.year()));
+            grpc_date.day() <= static_cast<int>(static_cast<unsigned>(
+                                   utils::datetime::DaysInMonth(grpc_date.month(), grpc_date.year())
+                               )));
 }
 
 #if __cpp_lib_chrono >= 201907L

--- a/grpc/tests/datetime_utils_test.cpp
+++ b/grpc/tests/datetime_utils_test.cpp
@@ -149,6 +149,9 @@ TEST(DatetimeUtilsDateIsValid, BigMonth) { EXPECT_FALSE(ugrpc::IsValid(MakeDate(
 TEST(DatetimeUtilsDateIsValid, NegativeDay) { EXPECT_FALSE(ugrpc::IsValid(MakeDate(2025, 4, -10))); }
 TEST(DatetimeUtilsDateIsValid, BigDay) { EXPECT_FALSE(ugrpc::IsValid(MakeDate(2025, 4, 50))); }
 TEST(DatetimeUtilsDateIsValid, DayDoesNotMatchMonth) { EXPECT_FALSE(ugrpc::IsValid(MakeDate(2025, 4, 31))); }
+// day is a wire-controlled int32; values above 255 must not wrap into the valid range
+TEST(DatetimeUtilsDateIsValid, DayWrapsToZero) { EXPECT_FALSE(ugrpc::IsValid(MakeDate(2025, 4, 256))); }
+TEST(DatetimeUtilsDateIsValid, DayWrapsIntoValidRange) { EXPECT_FALSE(ugrpc::IsValid(MakeDate(2025, 4, 286))); }
 
 #if __cpp_lib_chrono >= 201907L
 


### PR DESCRIPTION
1. IsValid(google::type::Date) reads the wire-controlled day() as an int32 but compares std::chrono::day(day()) against DaysInMonth, and std::chrono::day holds its value in an unsigned char, so day() is taken modulo 256 before the upper-bound check while the day() >= 1 guard still sees the full int.
2. Out-of-range days that reduce to a legal value pass validation: 286 becomes 30, 271 becomes 15, 256 becomes 0, so IsValid returns true for each.
3. ToUtilsDate, ToYearMonthDay and ToTimePoint use IsValid as their only gate before converting a peer-supplied Date, so an out-of-range day is accepted and later silently reinterpreted as a different day.

Compared the raw day() against DaysInMonth as an int so the untrusted value is no longer narrowed before the check.
Added DatetimeUtilsDateIsValid cases for day 256 and 286, which return true on the current code and false after the fix.
