### PR TITLE
fix ip: validate address size in CidrNetworkFromInetNetwork

### DIFF
--- a/universal/src/utils/ip.cpp
+++ b/universal/src/utils/ip.cpp
@@ -93,6 +93,13 @@ template <typename T>
 static T CidrNetworkFromInetNetwork(const InetNetwork& inet_network) {
     typename T::AddressType::BytesType bytes;
     const auto& inet_bytes = inet_network.GetBytes();
+    if (inet_bytes.size() != bytes.size()) {
+        throw std::invalid_argument(fmt::format(
+            "InetNetwork address size {} does not match the target CIDR network size {}",
+            inet_bytes.size(),
+            bytes.size()
+        ));
+    }
     std::ranges::copy(inet_bytes, bytes.begin());
     return T(typename T::AddressType(bytes), inet_network.GetPrefixLength());
 }

--- a/universal/src/utils/ip_test.cpp
+++ b/universal/src/utils/ip_test.cpp
@@ -255,4 +255,18 @@ TEST(InetNetworkTest, FromInetNetworkTests) {
     EXPECT_EQ(NetworkV6FromInetNetwork(inet_v6), net_v6);
 }
 
+TEST(InetNetworkTest, FromInetNetworkFamilyMismatch) {
+    using utils::ip::NetworkV4FromInetNetwork;
+    using utils::ip::NetworkV6FromInetNetwork;
+
+    // An IPv6 InetNetwork carries 16 address bytes; converting it to a 4-byte
+    // NetworkV4 must be rejected instead of copying past the target array.
+    const InetNetwork inet_v6(std::vector<unsigned char>(16, 0), 128, InetNetwork::AddressFamily::kIPv6);
+    EXPECT_THROW(NetworkV4FromInetNetwork(inet_v6), std::invalid_argument);
+
+    // The reverse mismatch (4-byte value into a 16-byte NetworkV6) is rejected too.
+    const InetNetwork inet_v4({127, 0, 0, 1}, 32, InetNetwork::AddressFamily::kIPv4);
+    EXPECT_THROW(NetworkV6FromInetNetwork(inet_v4), std::invalid_argument);
+}
+
 USERVER_NAMESPACE_END


### PR DESCRIPTION
1. CidrNetworkFromInetNetwork copies the InetNetwork byte vector into a fixed-size std::array (4 bytes for NetworkV4, 16 for NetworkV6) with std::ranges::copy and never checks that the source length matches the destination.
2. InetNetwork holds the parsed bytes of a PostgreSQL inet/cidr value, whose 4- or 16-byte length follows the server-supplied family. Converting a 16-byte IPv6 value through NetworkV4FromInetNetwork copies 16 bytes into the 4-byte array (a 12-byte out-of-bounds stack write); the reverse case leaves 12 destination bytes uninitialized.
3. Require inet_bytes.size() == bytes.size() and throw std::invalid_argument on mismatch, mirroring the size and family validation already performed in the InetNetwork constructor.

Verified with a regression in ip_test.cpp: the IPv6-to-NetworkV4 case trips AddressSanitizer (stack-buffer-overflow, 16-byte write into a 4-byte array) on the current tree and throws std::invalid_argument after the change. The valid same-family conversions are unaffected.
