### PR TITLE
fix datetime: size TimestampToString buffer for years past 9999

### DIFF
--- a/core/src/utils/datetime_test.cpp
+++ b/core/src/utils/datetime_test.cpp
@@ -53,6 +53,17 @@ TEST(Datetime, UtcTimestringCTime) {
     /// [UtcTimestring C time example]
 }
 
+TEST(Datetime, TimestampToStringFarFuture) {
+    // Year >= 10000 formats to more than the usual 24 bytes, so the fixed-length
+    // buffer could not hold the result and the returned string was truncated /
+    // read past the written bytes.
+    const std::time_t year_10000 = 253402300800;  // 10000-01-01T00:00:00Z
+    EXPECT_EQ(utils::datetime::TimestampToString(year_10000), "10000-01-01T00:00:00+0000");
+
+    const std::time_t year_2020 = 1577836800;  // 2020-01-01T00:00:00Z
+    EXPECT_EQ(utils::datetime::TimestampToString(year_2020), "2020-01-01T00:00:00+0000");
+}
+
 TEST(Datetime, GuessStringtime) {
     /// [GuessStringtime example]
     const auto tp = utils::datetime::UtcStringtime("2014-03-17T02:47:07+0000");

--- a/universal/src/utils/datetime_light.cpp
+++ b/universal/src/utils/datetime_light.cpp
@@ -196,15 +196,18 @@ std::chrono::system_clock::time_point Epoch() noexcept {
 
 /// Return string with time in ISO8601 format "YYYY-MM-DDTHH:MM:SS+0000".
 std::string TimestampToString(const time_t timestamp) {
-    static constexpr size_t kStringLen = 24;  // "YYYY-MM-DDTHH:MM:SS+0000"
+    // "%Y" is not limited to four digits, so far-future timestamps (year >= 10000)
+    // format to more than the usual 24 bytes. Size the buffer for any 64-bit year
+    // and return exactly the bytes strftime wrote; otherwise strftime reports 0 on
+    // truncation and the fixed-length slice reads the rest of an uninitialized
+    // buffer.
+    static constexpr size_t kBufferSize = 64;
 
     std::tm ptm{};
     gmtime_r(&timestamp, &ptm);
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init): performance
-    std::array<char, kStringLen + 1> buffer;
-    auto ret = strftime(buffer.data(), buffer.size(), "%Y-%m-%dT%H:%M:%S+0000", &ptm);
-    UASSERT(ret == kStringLen);
-    return {buffer.data(), kStringLen};
+    std::array<char, kBufferSize> buffer{};
+    const auto len = strftime(buffer.data(), buffer.size(), "%Y-%m-%dT%H:%M:%S+0000", &ptm);
+    return {buffer.data(), len};
 }
 
 std::int64_t TimePointToTicks(const std::chrono::system_clock::time_point& tp) noexcept {


### PR DESCRIPTION
1. `TimestampToString` formats a `time_t` with `strftime("%Y-%m-%dT%H:%M:%S+0000")` into a fixed 25-byte buffer and always returns the first 24 bytes, guarded only by `UASSERT(ret == 24)` which is compiled out under NDEBUG.
2. For a timestamp in year 10000 or later the `%Y` field is 5 or more digits, so the output does not fit: `strftime` returns 0 and leaves the buffer contents unspecified, yet the function still returns 24 bytes of it. That is an uninitialized-stack read in release builds (and the assertion aborts in debug builds).
3. Sized the buffer for any 64-bit year, value-initialized it, and return the exact number of bytes `strftime` wrote. Output for years up to 9999 is unchanged; added a regression in datetime_test.cpp for a year-10000 timestamp.