### PR TITLE
fix ydb: support released SDK source builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,6 +34,9 @@ jobs:
                         -DCPM_SOURCE_CACHE=/userver/.cpm
                         -DUSERVER_NO_WERROR=0
                         -DUSERVER_BUILD_ALL_COMPONENTS=1
+                        -DUSERVER_DOWNLOAD_PACKAGE_YDBCPPSDK=1
+                        -DUSERVER_YDBCPPSDK_VERSION=3.21.0
+                        -DCMAKE_DISABLE_FIND_PACKAGE_ydb-cpp-sdk=1
                         -DUSERVER_FEATURE_ROCKS=0
                         -DUSERVER_BUILD_SAMPLES=1
                         -DUSERVER_BUILD_TESTS=1

--- a/cmake/SetupYdbCppSDK.cmake
+++ b/cmake/SetupYdbCppSDK.cmake
@@ -1,7 +1,10 @@
 # @ingroup download
 option(USERVER_DOWNLOAD_PACKAGE_YDBCPPSDK "Download and setup ydb-cpp-sdk" ${USERVER_DOWNLOAD_PACKAGES})
 
-set(USERVER_YDBCPPSDK_VERSION 3.21.1)
+set(USERVER_YDBCPPSDK_VERSION
+    3.21.1
+    CACHE STRING "ydb-cpp-sdk version"
+)
 set(USERVER_YDBCPPSDK_COMPONENTS
     Coordination
     Driver
@@ -75,14 +78,45 @@ else()
     set(YDB_SDK_GOOGLE_COMMON_PROTOS_TARGET ${api-common-proto_LIBRARY})
 endif()
 
+set(_userver_ydb_cpp_sdk_options
+    "Brotli_VERSION ${Brotli_VERSION}" "RAPIDJSON_INCLUDE_DIRS ${RAPIDJSON_INCLUDE_DIRS}"
+    "YDB_SDK_GOOGLE_COMMON_PROTOS_TARGET ${YDB_SDK_GOOGLE_COMMON_PROTOS_TARGET}" "YDB_SDK_DEPENDENCY_MODE SYSTEM"
+    "YDB_SDK_EXAMPLES OFF"
+)
+set(_userver_ydb_google_proto_include_dir "${USERVER_GOOGLE_COMMON_PROTOS}")
+if(NOT _userver_ydb_google_proto_include_dir)
+    set(_userver_ydb_google_proto_include_dir "${api-common-protos_SOURCE_DIR}")
+endif()
+if(NOT _userver_ydb_google_proto_include_dir)
+    set(_userver_ydb_google_proto_include_dir "${CPM_PACKAGE_api-common-protos_SOURCE_DIR}")
+endif()
+if(_userver_ydb_google_proto_include_dir)
+    list(APPEND _userver_ydb_cpp_sdk_options
+         "YDB_SDK_GOOGLE_PROTO_INCLUDE_DIR ${_userver_ydb_google_proto_include_dir}"
+    )
+endif()
+
+set(_userver_ydb_grpc_version "${gRPC_VERSION}")
+if(NOT _userver_ydb_grpc_version
+   AND USERVER_FEATURE_GRPC
+   AND EXISTS "${USERVER_ROOT_DIR}/grpc/CMakeLists.txt"
+)
+    # The grpc directory is configured before ydb, but its gRPC_VERSION is directory-scoped.
+    get_directory_property(_userver_ydb_grpc_version DIRECTORY "${USERVER_ROOT_DIR}/grpc" DEFINITION gRPC_VERSION)
+endif()
+
+set(_userver_ydb_saved_cmake_module_path "${CMAKE_MODULE_PATH}")
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ydb")
+
 cpmaddpackage(
     NAME ydb-cpp-sdk
     GIT_TAG v${USERVER_YDBCPPSDK_VERSION}
     GITHUB_REPOSITORY ydb-platform/ydb-cpp-sdk
     GIT_SHALLOW TRUE
-    OPTIONS "Brotli_VERSION ${Brotli_VERSION}" "RAPIDJSON_INCLUDE_DIRS ${RAPIDJSON_INCLUDE_DIRS}"
-            "YDB_SDK_GOOGLE_COMMON_PROTOS_TARGET ${YDB_SDK_GOOGLE_COMMON_PROTOS_TARGET}" "YDB_SDK_EXAMPLES OFF"
+    OPTIONS ${_userver_ydb_cpp_sdk_options}
 )
+
+set(CMAKE_MODULE_PATH "${_userver_ydb_saved_cmake_module_path}")
 
 list(APPEND ydb-cpp-sdk_INCLUDE_DIRS ${ydb-cpp-sdk_SOURCE_DIR} ${ydb-cpp-sdk_SOURCE_DIR}/include
      ${ydb-cpp-sdk_BINARY_DIR}

--- a/cmake/modules/Findlibnghttp2.cmake
+++ b/cmake/modules/Findlibnghttp2.cmake
@@ -1,3 +1,11 @@
+set(_userver_libnghttp2_cpm_options "BUILD_STATIC_LIBS ON" "BUILD_SHARED_LIBS OFF" "ENABLE_APP OFF"
+                                    "ENABLE_EXAMPLES OFF"
+)
+if(USERVER_FEATURE_YDB)
+    # nghttp2 documentation defines a `json` target that clashes with ydb-cpp-sdk.
+    list(APPEND _userver_libnghttp2_cpm_options "ENABLE_DOC OFF")
+endif()
+
 _userver_module_begin(
     NAME libnghttp2
     DEBIAN_NAMES libnghttp2-dev
@@ -7,7 +15,7 @@ _userver_module_begin(
     CPM_GITHUB_REPOSITORY nghttp2/nghttp2
     CPM_VERSION 1.66.0
     CPM_GIT_TAG v1.66.0
-    CPM_OPTIONS "BUILD_STATIC_LIBS ON" "BUILD_SHARED_LIBS OFF" "ENABLE_APP OFF" "ENABLE_EXAMPLES OFF"
+    CPM_OPTIONS ${_userver_libnghttp2_cpm_options}
 )
 
 _userver_module_find_include(NAMES nghttp2/nghttp2.h)

--- a/cmake/ydb/FindgRPC.cmake
+++ b/cmake/ydb/FindgRPC.cmake
@@ -1,0 +1,37 @@
+include(FindPackageHandleStandardArgs)
+
+if(NOT gRPC_VERSION)
+    set(gRPC_VERSION "${_userver_ydb_grpc_version}")
+endif()
+
+if(NOT TARGET gRPC::grpc++ OR NOT gRPC_VERSION)
+    if(gRPC_FIND_VERSION_EXACT)
+        find_package(gRPC ${gRPC_FIND_VERSION} EXACT QUIET CONFIG)
+    elseif(gRPC_FIND_VERSION)
+        find_package(gRPC ${gRPC_FIND_VERSION} QUIET CONFIG)
+    else()
+        find_package(gRPC QUIET CONFIG)
+    endif()
+endif()
+
+set(_userver_grpc_target_found FALSE)
+if(TARGET gRPC::grpc++)
+    set(_userver_grpc_target_found TRUE)
+
+    if(NOT TARGET gRPC::grpc_cpp_plugin)
+        get_property(_userver_grpc_cpp_plugin GLOBAL PROPERTY userver_grpc_cpp_plugin)
+        if(NOT _userver_grpc_cpp_plugin)
+            find_program(_userver_grpc_cpp_plugin grpc_cpp_plugin)
+        endif()
+        if(_userver_grpc_cpp_plugin)
+            add_executable(gRPC::grpc_cpp_plugin IMPORTED GLOBAL)
+            set_target_properties(gRPC::grpc_cpp_plugin PROPERTIES IMPORTED_LOCATION "${_userver_grpc_cpp_plugin}")
+        endif()
+    endif()
+endif()
+
+find_package_handle_standard_args(
+    gRPC
+    REQUIRED_VARS _userver_grpc_target_found
+    VERSION_VAR gRPC_VERSION
+)

--- a/scripts/docs/en/userver/build/options.md
+++ b/scripts/docs/en/userver/build/options.md
@@ -140,6 +140,7 @@ The exact format of setting cmake options varies depending on the method of buil
 | `USERVER_DOWNLOAD_PACKAGE_PROTOBUF`      | Download and setup Protobuf if no Protobuf of matching version was found                | `${USERVER_DOWNLOAD_PACKAGE_GRPC}`   |
 | `USERVER_DOWNLOAD_PACKAGE_KAFKA`         | Download and setup librdkafka if no librdkafka matching version was found               | `${USERVER_DOWNLOAD_PACKAGES}`       |
 | `USERVER_DOWNLOAD_PACKAGE_YDBCPPSDK`     | Download and setup ydb-cpp-sdk if no ydb-cpp-sdk of matching version was found          | `${USERVER_DOWNLOAD_PACKAGES}`       |
+| `USERVER_YDBCPPSDK_VERSION`              | ydb-cpp-sdk version to find or download                                                  | `3.21.1`                             |
 | `USERVER_DOWNLOAD_PACKAGE_C_ARES`        | Download and setup libc-ares if no libc-ares of matching version was found              | `${USERVER_DOWNLOAD_PACKAGES}`       |
 | `USERVER_DOWNLOAD_PACKAGE_LIBEV`         | Download and setup libev if no libev of matching version was found                      | `${USERVER_DOWNLOAD_PACKAGES}`       |
 | `USERVER_DOWNLOAD_PACKAGE_LIBNGHTTP2`    | Download and setup libnghttp2 if no libnghttp2 of matching version was found            | `${USERVER_DOWNLOAD_PACKAGES}`       |

--- a/ydb/CMakeLists.txt
+++ b/ydb/CMakeLists.txt
@@ -34,9 +34,22 @@ _userver_directory_install(
     FILES "${USERVER_ROOT_DIR}/cmake/SetupYdbCppSDK.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/userver"
 )
+_userver_directory_install(
+    COMPONENT ydb
+    FILES "${USERVER_ROOT_DIR}/cmake/ydb/FindgRPC.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/userver/ydb"
+)
 
 add_subdirectory(utest)
 
 if(USERVER_BUILD_TESTS)
+    add_test(
+        NAME userver-cmake-find-ydb-grpc
+        COMMAND
+            ${CMAKE_COMMAND} -S "${CMAKE_CURRENT_SOURCE_DIR}/tests/cmake/find_grpc" -B
+            "${CMAKE_CURRENT_BINARY_DIR}/tests/cmake/find_grpc"
+            "-DUSERVER_YDB_CMAKE_MODULE_DIR=${USERVER_ROOT_DIR}/cmake/ydb"
+    )
+
     add_subdirectory(functional_tests)
 endif()

--- a/ydb/src/ydb/topic.cpp
+++ b/ydb/src/ydb/topic.cpp
@@ -19,6 +19,15 @@ namespace ydb {
 
 namespace {
 
+template <typename Settings>
+void EnableAsyncExecutionMode(Settings& settings) {
+    // AsyncExecutionMode is available in newer SDK revisions, but not in the
+    // released 3.21.0 and 3.21.1 tags.
+    if constexpr (requires { settings.AsyncExecutionMode(true); }) {
+        settings.AsyncExecutionMode(true);
+    }
+}
+
 void ResetSimpleWriteSessionHandlers(NYdb::NTopic::TWriteSessionSettings::TEventHandlers& handlers) {
     // Keep this decomposition exhaustive so that adding a field in the YDB SDK
     // requires an explicit decision here.
@@ -290,7 +299,7 @@ TopicProducer TopicClient::CreateProducer(const TopicProducerSettings& settings,
     auto native_settings = static_cast<const NYdb::NTopic::TProducerSettings&>(settings);
     native_settings.MaxMemoryUsage(max_memory_usage_bytes);
     native_settings.MaxBlockTimeout(TDuration::Zero());
-    native_settings.AsyncExecutionMode(true);
+    EnableAsyncExecutionMode(native_settings);
     return TopicProducer{topic_client_->CreateProducer(native_settings)};
 }
 

--- a/ydb/tests/cmake/find_grpc/CMakeLists.txt
+++ b/ydb/tests/cmake/find_grpc/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.14)
+project(userver-find-ydb-grpc-test NONE)
+
+if(NOT USERVER_YDB_CMAKE_MODULE_DIR)
+    message(FATAL_ERROR "USERVER_YDB_CMAKE_MODULE_DIR is required")
+endif()
+
+list(PREPEND CMAKE_MODULE_PATH "${USERVER_YDB_CMAKE_MODULE_DIR}")
+
+add_library(gRPC::grpc++ INTERFACE IMPORTED GLOBAL)
+set_property(GLOBAL PROPERTY userver_grpc_cpp_plugin "${CMAKE_COMMAND}")
+set(_userver_ydb_grpc_version "1.59.1")
+
+find_package(gRPC 1.41 REQUIRED)
+
+if(NOT TARGET gRPC::grpc_cpp_plugin)
+    message(FATAL_ERROR "FindgRPC did not create gRPC::grpc_cpp_plugin")
+endif()
+if(NOT "${gRPC_VERSION}" STREQUAL "1.59.1")
+    message(FATAL_ERROR "FindgRPC returned unexpected version: ${gRPC_VERSION}")
+endif()
+
+get_target_property(grpc_cpp_plugin gRPC::grpc_cpp_plugin IMPORTED_LOCATION)
+if(NOT "${grpc_cpp_plugin}" STREQUAL "${CMAKE_COMMAND}")
+    message(FATAL_ERROR "FindgRPC returned unexpected grpc_cpp_plugin: ${grpc_cpp_plugin}")
+endif()


### PR DESCRIPTION
Support released ydb-cpp-sdk source tags while reusing userver's configured dependencies.

- provide a private, YDB-only gRPC discovery adapter during SDK setup
- pass the SDK system-dependency and Google proto settings explicitly
- tolerate the topic producer option absent from SDK 3.21.0 and 3.21.1
- disable the colliding nghttp2 documentation target only when YDB is enabled
- exercise the 3.21.0 source build in Docker CI and add a focused registered CMake test

There are no non-YDB runtime behavior changes, and generic userver gRPC discovery remains unchanged.