### PR TITLE
fix chaotic-openapi: inproper serialization for single body requests

### DIFF
--- a/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.application.multipart.formdata.jinja
+++ b/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.application.multipart.formdata.jinja
@@ -2,7 +2,7 @@
   const auto &data = {{ request }};
   USERVER_NAMESPACE::clients::http::Form form;
 
-  {% for field_name, field in body.schema.fields.items() %}
+  {% for field_name, field in body.fields().items() %}
       {% if field.required %}
         form.AddContent("{{ field_name }}", USERVER_NAMESPACE::chaotic::openapi::PrimitiveToString(data.{{ field_name }}));
       {% else %}

--- a/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.application.octet.stream.jinja
+++ b/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.application.octet.stream.jinja
@@ -1,7 +1,7 @@
 {# An operation with a single content type stores the body as a bare std::string,
    while multiple content types are wrapped into distinct structs (see define_body_cpp_name)
    to make the std::variant alternatives unambiguous. #}
-{% macro serialize(request, http_request, wrapped=True) %}
+{% macro serialize(request, http_request, wrapped) %}
   {{ http_request }}.data({{ request }}{% if wrapped %}.data{% endif %});
 {% endmacro %}
 

--- a/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.application.octet.stream.jinja
+++ b/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.application.octet.stream.jinja
@@ -1,5 +1,8 @@
-{% macro serialize(request, http_request) %}
-  {{ http_request }}.data({{ request }}.data);
+{# An operation with a single content type stores the body as a bare std::string,
+   while multiple content types are wrapped into distinct structs (see define_body_cpp_name)
+   to make the std::variant alternatives unambiguous. #}
+{% macro serialize(request, http_request, wrapped=True) %}
+  {{ http_request }}.data({{ request }}{% if wrapped %}.data{% endif %});
 {% endmacro %}
 
 

--- a/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.application.xwwwformurlencoded.jinja
+++ b/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.application.xwwwformurlencoded.jinja
@@ -2,7 +2,7 @@
   const auto &data = {{ request }};
   std::unordered_map<std::string, std::string> map;
 
-  {% for field_name, field in body.schema.fields.items() %}
+  {% for field_name, field in body.fields().items() %}
       {% if field.required %}
         map["{{ field_name }}"] = USERVER_NAMESPACE::chaotic::openapi::PrimitiveToString(data.{{ field_name }});
       {% else %}

--- a/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.cpp.jinja
+++ b/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.cpp.jinja
@@ -66,7 +66,20 @@ void SerializeRequest(const Request& request, const std::string& base_url, USERV
 
   {# body #}
   {% if len(op.request_bodies) == 1 %}
-    http_request.data(ToString(USERVER_NAMESPACE::formats::json::ValueBuilder(request.body).ExtractValue()));
+    {% set body = op.request_bodies[0] %}
+    {% if body.content_type != 'multipart/form-data' %}
+        sink.SetHeader(USERVER_NAMESPACE::http::headers::kContentType, "{{ body.content_type }}");
+    {% endif %}
+
+    {% if body.content_type == 'application/json' %}
+        {{ application_json.serialize("request.body", "http_request") }}
+    {% elif body.content_type == 'multipart/form-data' %}
+        {{ application_multipartformdata.serialize(body, "request.body", "http_request") }}
+    {% elif body.content_type == 'application/x-www-form-urlencoded' %}
+        {{ application_xwwwformurlencoded.serialize(body, "request.body", "http_request") }}
+    {% else %}
+        {{ application_octetstream.serialize("request.body", "http_request", wrapped=False) }}
+    {% endif %}
   {% elif len(op.request_bodies) > 1 %}
     switch (request.body.index()) {
     {%- for num, body in enumerate(op.request_bodies) -%}

--- a/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.cpp.jinja
+++ b/chaotic-openapi/chaotic_openapi/back/cpp/client/templates/requests.cpp.jinja
@@ -17,6 +17,21 @@ namespace {{ namespace }} {
 
 namespace openapi = USERVER_NAMESPACE::chaotic::openapi;
 
+{% macro serialize_request_single_body(body, body_obj, http_request, wrapped) %}
+    {% if body.content_type != 'multipart/form-data' %}
+    sink.SetHeader(USERVER_NAMESPACE::http::headers::kContentType, "{{ body.content_type }}");
+    {% endif %}
+    {% if body.content_type == 'application/json' %}
+        {{ application_json.serialize(body_obj, http_request) }}
+    {% elif body.content_type == 'multipart/form-data' %}
+        {{ application_multipartformdata.serialize(body, body_obj, http_request) }}
+    {% elif body.content_type == 'application/x-www-form-urlencoded' %}
+        {{ application_xwwwformurlencoded.serialize(body, body_obj, http_request) }}
+    {% else %}
+        {{ application_octetstream.serialize(body_obj, http_request, wrapped=wrapped) }}
+    {% endif %}
+{% endmacro %}
+
 {% for op in operations %}
   {% if op.client_generate %}
       namespace {{ op.cpp_namespace() }} {
@@ -66,39 +81,13 @@ void SerializeRequest(const Request& request, const std::string& base_url, USERV
 
   {# body #}
   {% if len(op.request_bodies) == 1 %}
-    {% set body = op.request_bodies[0] %}
-    {% if body.content_type != 'multipart/form-data' %}
-        sink.SetHeader(USERVER_NAMESPACE::http::headers::kContentType, "{{ body.content_type }}");
-    {% endif %}
-
-    {% if body.content_type == 'application/json' %}
-        {{ application_json.serialize("request.body", "http_request") }}
-    {% elif body.content_type == 'multipart/form-data' %}
-        {{ application_multipartformdata.serialize(body, "request.body", "http_request") }}
-    {% elif body.content_type == 'application/x-www-form-urlencoded' %}
-        {{ application_xwwwformurlencoded.serialize(body, "request.body", "http_request") }}
-    {% else %}
-        {{ application_octetstream.serialize("request.body", "http_request", wrapped=False) }}
-    {% endif %}
+    {{ serialize_request_single_body(op.request_bodies[0], "request.body", "http_request", wrapped=False) }}
   {% elif len(op.request_bodies) > 1 %}
     switch (request.body.index()) {
     {%- for num, body in enumerate(op.request_bodies) -%}
       case {{ num }}: {
-        {% if body.content_type != 'multipart/form-data' %}
-            http_request.headers(USERVER_NAMESPACE::clients::http::Headers{ {USERVER_NAMESPACE::http::headers::kContentType, "{{ body.content_type }}"} });
-        {% endif %}
-
         {% set body_obj = "std::get<" + str(num) + ">(request.body)" %}
-        {% if body.content_type == 'application/json' %}
-            {{ application_json.serialize(body_obj, "http_request") }}
-        {% elif body.content_type == 'multipart/form-data' %}
-            {{ application_multipartformdata.serialize(body, body_obj, "http_request") }}
-        {% elif body.content_type == 'application/x-www-form-urlencoded' %}
-            {{ application_xwwwformurlencoded.serialize(body, body_obj, "http_request") }}
-        {% else %}
-            {{ application_octetstream.serialize(body_obj, "http_request") }}
-        {% endif %}
-
+        {{ serialize_request_single_body(body, body_obj, "http_request", wrapped=True) }}
         break;
       }
     {% endfor %}

--- a/chaotic-openapi/chaotic_openapi/back/cpp/common/translator.py
+++ b/chaotic-openapi/chaotic_openapi/back/cpp/common/translator.py
@@ -389,6 +389,7 @@ class BaseTranslator(abc.ABC):
         assert schema.json_schema
         source_location = schema.json_schema.source_location()
 
+        schema = common_types.resolve_ref(schema)
         if not isinstance(schema, cpp_types.CppStruct):
             raise chaotic_error.BaseError(
                 full_filepath=source_location.filepath,
@@ -397,7 +398,7 @@ class BaseTranslator(abc.ABC):
                 msg='"application/x-www-form-urlencoded" body allows only "type: object"',
             )
         for field in schema.fields.values():
-            if not isinstance(field.schema, cpp_types.CppPrimitiveType):
+            if not isinstance(common_types.resolve_ref(field.schema), cpp_types.CppPrimitiveType):
                 raise chaotic_error.BaseError(
                     full_filepath=source_location.filepath,
                     infile_path=source_location.location,

--- a/chaotic-openapi/chaotic_openapi/back/cpp/common/types.py
+++ b/chaotic-openapi/chaotic_openapi/back/cpp/common/types.py
@@ -8,6 +8,13 @@ from chaotic.back.cpp import types as cpp_types
 from chaotic_openapi.back.cpp.client import middleware
 
 
+def resolve_ref(schema: cpp_types.CppType) -> cpp_types.CppType:
+    """Follow the `$ref` chain down to the referenced type."""
+    while isinstance(schema, cpp_types.CppRef):
+        schema = schema.orig_cpp_type
+    return schema
+
+
 @dataclasses.dataclass
 class Security:
     auth_type: str
@@ -133,6 +140,13 @@ class Body:
             return self.cpp_name()
         assert self.schema is not None
         return self.schema.cpp_user_name()
+
+    def fields(self) -> dict[str, cpp_types.CppStructField]:
+        """Fields of a form body, with `$ref` resolved."""
+        assert self.schema is not None
+        schema = resolve_ref(self.schema)
+        assert isinstance(schema, cpp_types.CppStruct), schema
+        return schema.fields
 
 
 @dataclasses.dataclass

--- a/chaotic-openapi/chaotic_openapi/back/cpp/handler/templates/requests.cpp.jinja
+++ b/chaotic-openapi/chaotic_openapi/back/cpp/handler/templates/requests.cpp.jinja
@@ -24,7 +24,7 @@ namespace {{ spec.cpp_namespace }}::{{ op.cpp_namespace() }} {
 {% endmacro %}
 
 {% macro _parse_urlencoded(body, prefix) %}
-    {% for field_name, field in body.schema.fields.items() %}
+    {% for field_name, field in body.fields().items() %}
         {% if field.required %}
             if (!http_request.HasArg("{{ field_name }}")) {
                 throw {{ userver }}::server::handlers::ClientError(
@@ -49,7 +49,7 @@ namespace {{ spec.cpp_namespace }}::{{ op.cpp_namespace() }} {
 {% endmacro %}
 
 {% macro _parse_multipart(body, prefix) %}
-    {% for field_name, field in body.schema.fields.items() %}
+    {% for field_name, field in body.fields().items() %}
         {% if field.required %}
             if (!http_request.HasFormDataArg("{{ field_name }}")) {
                 throw {{ userver }}::server::handlers::ClientError(

--- a/chaotic-openapi/chaotic_openapi/front/parser.py
+++ b/chaotic-openapi/chaotic_openapi/front/parser.py
@@ -182,15 +182,20 @@ class Parser:
                     msg='"consumes" must be either "multipart/form-data" or "application/x-www-form-urlencoded" for "type: file"',
                 )
 
-        schema = self._parse_schema(
-            request_body.model_dump(
-                by_alias=True,
-                exclude={'name', 'in_', 'description', 'required', 'allowEmptyValue', 'collectionFormat'},
-                exclude_unset=True,
-            ),
-            infile_path,
-            allow_file=True,
+        field_schema = request_body.model_dump(
+            by_alias=True,
+            exclude={'name', 'in_', 'description', 'required', 'allowEmptyValue', 'collectionFormat'},
+            exclude_unset=True,
         )
+        object_schema: dict[str, Any] = {
+            'type': 'object',
+            'properties': {request_body.name: field_schema},
+            'additionalProperties': False,
+        }
+        if request_body.required:
+            object_schema['required'] = [request_body.name]
+
+        schema = self._parse_schema(object_schema, infile_path, allow_file=True)
         return [
             model.RequestBody(
                 content_type=mime,

--- a/chaotic-openapi/golden_tests/output/client/src/clients/test/requests.cpp
+++ b/chaotic-openapi/golden_tests/output/client/src/clients/test/requests.cpp
@@ -27,7 +27,9 @@ base_url + "/testme"
 openapi::WriteParameter<openapi::TrivialParameter<openapi::In::kQuery, knumber, std::string, std::string>>(request.number, sink);
 openapi::WriteParameter<openapi::ArrayParameter<openapi::In::kQuery, karray, ',', std::string, std::string>>(request.array, sink);
 
-http_request.data(ToString(USERVER_NAMESPACE::formats::json::ValueBuilder(request.body).ExtractValue()));
+sink.SetHeader(USERVER_NAMESPACE::http::headers::kContentType, "application/json");
+
+  http_request.data(ToString(USERVER_NAMESPACE::formats::json::ValueBuilder(request.body).ExtractValue()));
 
 sink.Flush();
 

--- a/chaotic-openapi/integration_tests/clients/multiple-content-types/openapi.yaml
+++ b/chaotic-openapi/integration_tests/clients/multiple-content-types/openapi.yaml
@@ -10,80 +10,40 @@ paths:
                 content:
                     application/json:
                         schema:
-                            type: object
-                            properties:
-                                foo:
-                                    type: string
-                            additionalProperties: false
+                            $ref: '#/components/schemas/single-json'
                     multipart/form-data:
                         schema:
-                            type: object
-                            required:
-                              - filename
-                            properties:
-                                filename:
-                                    type: string
-                                content:
-                                    type: string
-                            additionalProperties: false
+                            $ref: '#/components/schemas/single-form-data'
                     application/x-www-form-urlencoded:
                         schema:
-                            type: object
-                            required:
-                              - name
-                              - age
-                            properties:
-                                name:
-                                    type: string
-                                password:
-                                    type: string
-                                age:
-                                    type: integer
-                                salary:
-                                    type: number
-                                is_smoking:
-                                    type: boolean
-                            additionalProperties: false
+                            $ref: '#/components/schemas/single-form-urlen'
                     application/octet-stream:
                         schema:
-                            type: string
+                            $ref: '#/components/schemas/single-octet'
             responses:
                 '200':
                     description: OK
                     content:
                         application/json:
                             schema:
-                                type: object
-                                properties:
-                                    bar:
-                                        type: string
-                                additionalProperties: false
+                                $ref: '#/components/schemas/common-response'
                         application/octet-stream:
                             schema:
                                 type: string
-#   TODO: declare common components per content type in order to reuse in /test1
     /test-single-json:
         post:
             requestBody:
                 content:
                     application/json:
                         schema:
-                            type: object
-                            properties:
-                                foo:
-                                    type: string
-                            additionalProperties: false
+                            $ref: '#/components/schemas/single-json'
             responses:
                 '200':
                     description: OK
                     content:
                         application/json:
                             schema:
-                                type: object
-                                properties:
-                                    bar:
-                                        type: string
-                                additionalProperties: false
+                                $ref: '#/components/schemas/common-response'
 
     /test-single-form-data:
         post:
@@ -91,26 +51,14 @@ paths:
                 content:
                     multipart/form-data:
                         schema:
-                            type: object
-                            required:
-                              - filename
-                            properties:
-                                filename:
-                                    type: string
-                                content:
-                                    type: string
-                            additionalProperties: false
+                            $ref: '#/components/schemas/single-form-data'
             responses:
                 '200':
                     description: OK
                     content:
                         application/json:
                             schema:
-                                type: object
-                                properties:
-                                    bar:
-                                        type: string
-                                additionalProperties: false
+                                $ref: '#/components/schemas/common-response'
 
     /test-single-form-urlen:
         post:
@@ -118,33 +66,14 @@ paths:
                 content:
                     application/x-www-form-urlencoded:
                         schema:
-                            type: object
-                            required:
-                              - name
-                              - age
-                            properties:
-                                name:
-                                    type: string
-                                password:
-                                    type: string
-                                age:
-                                    type: integer
-                                salary:
-                                    type: number
-                                is_smoking:
-                                    type: boolean
-                            additionalProperties: false
+                            $ref: '#/components/schemas/single-form-urlen'
             responses:
                 '200':
                     description: OK
                     content:
                         application/json:
                             schema:
-                                type: object
-                                properties:
-                                    bar:
-                                        type: string
-                                additionalProperties: false
+                                $ref: '#/components/schemas/common-response'
 
     /test-single-octet:
         post:
@@ -152,7 +81,7 @@ paths:
                 content:
                     application/octet-stream:
                         schema:
-                            type: string
+                            $ref: '#/components/schemas/single-octet'
             responses:
                 '200':
                     description: OK
@@ -160,3 +89,46 @@ paths:
                         application/octet-stream:
                             schema:
                                 type: string                                
+components:
+    schemas:
+        single-json:
+            type: object
+            properties:
+                foo:
+                    type: string
+            additionalProperties: false
+        single-form-data:
+            type: object
+            required:
+                - filename
+            properties:
+                filename:
+                    type: string
+                content:
+                    type: string
+            additionalProperties: false
+        single-form-urlen:
+            type: object
+            required:
+                - name
+                - age
+            properties:
+                name:
+                    type: string
+                password:
+                    type: string
+                age:
+                    type: integer
+                salary:
+                    type: number
+                is_smoking:
+                    type: boolean
+            additionalProperties: false
+        single-octet:
+            type: string
+        common-response:
+            type: object
+            properties:
+                bar:
+                    type: string
+            additionalProperties: false

--- a/chaotic-openapi/integration_tests/clients/multiple-content-types/openapi.yaml
+++ b/chaotic-openapi/integration_tests/clients/multiple-content-types/openapi.yaml
@@ -61,3 +61,102 @@ paths:
                         application/octet-stream:
                             schema:
                                 type: string
+#   TODO: declare common components per content type in order to reuse in /test1
+    /test-single-json:
+        post:
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                foo:
+                                    type: string
+                            additionalProperties: false
+            responses:
+                '200':
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    bar:
+                                        type: string
+                                additionalProperties: false
+
+    /test-single-form-data:
+        post:
+            requestBody:
+                content:
+                    multipart/form-data:
+                        schema:
+                            type: object
+                            required:
+                              - filename
+                            properties:
+                                filename:
+                                    type: string
+                                content:
+                                    type: string
+                            additionalProperties: false
+            responses:
+                '200':
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    bar:
+                                        type: string
+                                additionalProperties: false
+
+    /test-single-form-urlen:
+        post:
+            requestBody:
+                content:
+                    application/x-www-form-urlencoded:
+                        schema:
+                            type: object
+                            required:
+                              - name
+                              - age
+                            properties:
+                                name:
+                                    type: string
+                                password:
+                                    type: string
+                                age:
+                                    type: integer
+                                salary:
+                                    type: number
+                                is_smoking:
+                                    type: boolean
+                            additionalProperties: false
+            responses:
+                '200':
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    bar:
+                                        type: string
+                                additionalProperties: false
+
+    /test-single-octet:
+        post:
+            requestBody:
+                content:
+                    application/octet-stream:
+                        schema:
+                            type: string
+            responses:
+                '200':
+                    description: OK
+                    content:
+                        application/octet-stream:
+                            schema:
+                                type: string                                

--- a/chaotic-openapi/integration_tests/clients/swagger-form-data/swagger.yaml
+++ b/chaotic-openapi/integration_tests/clients/swagger-form-data/swagger.yaml
@@ -1,0 +1,22 @@
+swagger: '2.0'
+description: |
+    Swagger "in: formData" request body.
+
+    Such a parameter describes a single form field, not the whole body, so it is
+    wrapped into a one-property object schema (see
+    Parser._convert_swagger_request_body). Only one "in: formData" parameter per
+    operation is supported for now, the rest are silently dropped by the parser.
+
+paths:
+    /form-urlencoded:
+        post:
+            consumes:
+              - application/x-www-form-urlencoded
+            parameters:
+              - in: formData
+                name: name
+                required: true
+                type: string
+            responses:
+                '200':
+                    description: OK

--- a/chaotic-openapi/integration_tests/src/requests_test.cpp
+++ b/chaotic-openapi/integration_tests/src/requests_test.cpp
@@ -61,111 +61,127 @@ UTEST(Requests, RegexDestinationName) {
 }
 
 UTEST(RequestsMultipleContentTypes, Json) {
-    const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
-        EXPECT_EQ(request.body, R"({"foo":"a"})");
-        EXPECT_EQ(request.headers.at(std::string{"Content-Type"}), "application/json");
-        utest::HttpServerMock::HttpResponse response{};
-        response.response_status = 200;
-        return response;
-    });
+    auto test = []<typename Request, typename Body>() {
+        const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
+            EXPECT_EQ(request.body, R"({"foo":"a"})");
+            EXPECT_EQ(request.headers.at(std::string{"Content-Type"}), "application/json");
+            utest::HttpServerMock::HttpResponse response{};
+            response.response_status = 200;
+            return response;
+        });
 
-    auto http_client_ptr = utest::CreateHttpClient();
-    auto request = http_client_ptr->CreateRequest();
+        auto http_client_ptr = utest::CreateHttpClient();
+        auto request = http_client_ptr->CreateRequest();
 
-    client::SerializeRequest({client::RequestBodyApplicationJson{"a"}}, http_server.GetBaseUrl(), request);
+        SerializeRequest(Request{Body{"a"}}, http_server.GetBaseUrl(), request);
 
-    auto response = request.perform();
-    EXPECT_EQ(response->status_code(), 200);
+        auto response = request.perform();
+        EXPECT_EQ(response->status_code(), 200);
+    };
+
+    namespace single = ::clients::multiple_content_types::test_single_json::post;
+    test.operator()<client::Request, client::RequestBodyApplicationJson>();
+    test.operator()<single::Request, single::Body>();
 }
 
 UTEST(RequestsMultipleContentTypes, XWwwFormUrlencoded) {
-    const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
-        // x-www-form-urlencoded field order is unspecified (serialized from a
-        // std::unordered_map), so compare the '&'-separated parts order-independently.
-        const auto parts = utils::text::Split(request.body, "&");
-        EXPECT_THAT(
-            parts,
-            ::testing::UnorderedElementsAre(
-                "name=abc",
-                "password=123%20456",
-                "age=30",
-                "salary=1000.500000",
-                "is_smoking=true"
-            )
-        );
-        EXPECT_EQ(request.headers.at(std::string{"Content-Type"}), "application/x-www-form-urlencoded");
-        utest::HttpServerMock::HttpResponse response{};
-        response.response_status = 200;
-        return response;
-    });
+    auto test = []<typename Request, typename Body>() {
+        const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
+            // x-www-form-urlencoded field order is unspecified (serialized from a
+            // std::unordered_map), so compare the '&'-separated parts order-independently.
+            const auto parts = utils::text::Split(request.body, "&");
+            EXPECT_THAT(
+                parts,
+                ::testing::UnorderedElementsAre(
+                    "name=abc",
+                    "password=123%20456",
+                    "age=30",
+                    "salary=1000.500000",
+                    "is_smoking=true"
+                )
+            );
+            EXPECT_EQ(request.headers.at(std::string{"Content-Type"}), "application/x-www-form-urlencoded");
+            utest::HttpServerMock::HttpResponse response{};
+            response.response_status = 200;
+            return response;
+        });
 
-    auto http_client_ptr = utest::CreateHttpClient();
-    auto request = http_client_ptr->CreateRequest();
+        auto http_client_ptr = utest::CreateHttpClient();
+        auto request = http_client_ptr->CreateRequest();
 
-    client::SerializeRequest(
-        {client::RequestBodyApplicationXWwwFormUrlencoded{"abc", "123 456", 30, 1000.5, true}},
-        http_server.GetBaseUrl(),
-        request
-    );
+        SerializeRequest(Request{Body{"abc", "123 456", 30, 1000.5, true}}, http_server.GetBaseUrl(), request);
 
-    auto response = request.perform();
-    EXPECT_EQ(response->status_code(), 200);
+        auto response = request.perform();
+        EXPECT_EQ(response->status_code(), 200);
+    };
+
+    namespace single = ::clients::multiple_content_types::test_single_form_urlen::post;
+    test.operator()<client::Request, client::RequestBodyApplicationXWwwFormUrlencoded>();
+    test.operator()<single::Request, single::Body>();
 }
 
 UTEST(RequestsMultipleContentTypes, MultipartFormData) {
-    const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
-        const auto& raw_content_type = request.headers.at(std::string{"Content-Type"});
-        const http::ContentType content_type(raw_content_type);
-        EXPECT_EQ(content_type.MediaType(), "multipart/form-data");
-        const auto& boundary = content_type.Boundary();
-        EXPECT_THAT(raw_content_type, ::testing::HasSubstr("boundary="));
-        EXPECT_FALSE(boundary.empty());
-        EXPECT_EQ(
-            request.body,
-            "--" + boundary +
-                "\r\n"
-                "Content-Disposition: form-data; name=\"filename\"\r\n"
-                "\r\nfilename\r\n" +
+    auto test = []<typename Request, typename Body>() {
+        const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
+            const auto& raw_content_type = request.headers.at(std::string{"Content-Type"});
+            const http::ContentType content_type(raw_content_type);
+            EXPECT_EQ(content_type.MediaType(), "multipart/form-data");
+            const auto& boundary = content_type.Boundary();
+            EXPECT_THAT(raw_content_type, ::testing::HasSubstr("boundary="));
+            EXPECT_FALSE(boundary.empty());
+            EXPECT_EQ(
+                request.body,
                 "--" + boundary +
-                "\r\n"
-                "Content-Disposition: form-data; name=\"content\"\r\n"
-                "\r\nfile\ncontent\r\n" +
-                "--" + boundary + "--\r\n"
-        );
-        utest::HttpServerMock::HttpResponse response{};
-        response.response_status = 200;
-        return response;
-    });
+                    "\r\n"
+                    "Content-Disposition: form-data; name=\"filename\"\r\n"
+                    "\r\nfilename\r\n" +
+                    "--" + boundary +
+                    "\r\n"
+                    "Content-Disposition: form-data; name=\"content\"\r\n"
+                    "\r\nfile\ncontent\r\n" +
+                    "--" + boundary + "--\r\n"
+            );
+            utest::HttpServerMock::HttpResponse response{};
+            response.response_status = 200;
+            return response;
+        });
 
-    auto http_client_ptr = utest::CreateHttpClient();
-    auto request = http_client_ptr->CreateRequest();
+        auto http_client_ptr = utest::CreateHttpClient();
+        auto request = http_client_ptr->CreateRequest();
 
-    client::SerializeRequest(
-        {client::RequestBodyMultipartFormData{"filename", "file\ncontent"}},
-        http_server.GetBaseUrl(),
-        request
-    );
+        SerializeRequest(Request{Body{"filename", "file\ncontent"}}, http_server.GetBaseUrl(), request);
 
-    auto response = request.perform();
-    EXPECT_EQ(response->status_code(), 200);
+        auto response = request.perform();
+        EXPECT_EQ(response->status_code(), 200);
+    };
+
+    namespace single = ::clients::multiple_content_types::test_single_form_data::post;
+    test.operator()<client::Request, client::RequestBodyMultipartFormData>();
+    test.operator()<single::Request, single::Body>();
 }
 
 UTEST(RequestsMultipleContentTypes, OctetStream) {
-    const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
-        EXPECT_EQ(request.body, "blabla");
-        EXPECT_EQ(request.headers.at(std::string{"Content-Type"}), "application/octet-stream");
-        utest::HttpServerMock::HttpResponse response{};
-        response.response_status = 200;
-        return response;
-    });
+    auto test = []<typename Request, typename Body>() {
+        const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
+            EXPECT_EQ(request.body, "blabla");
+            EXPECT_EQ(request.headers.at(std::string{"Content-Type"}), "application/octet-stream");
+            utest::HttpServerMock::HttpResponse response{};
+            response.response_status = 200;
+            return response;
+        });
 
-    auto http_client_ptr = utest::CreateHttpClient();
-    auto request = http_client_ptr->CreateRequest();
+        auto http_client_ptr = utest::CreateHttpClient();
+        auto request = http_client_ptr->CreateRequest();
 
-    client::SerializeRequest({client::RequestBodyApplicationOctetStream{"blabla"}}, http_server.GetBaseUrl(), request);
+        SerializeRequest(Request{Body{"blabla"}}, http_server.GetBaseUrl(), request);
 
-    auto response = request.perform();
-    EXPECT_EQ(response->status_code(), 200);
+        auto response = request.perform();
+        EXPECT_EQ(response->status_code(), 200);
+    };
+
+    namespace single = ::clients::multiple_content_types::test_single_octet::post;
+    test.operator()<client::Request, client::RequestBodyApplicationOctetStream>();
+    test.operator()<single::Request, single::Body>();
 }
 
 class RequestsQueryLogMode : public utest::LogCaptureFixture<> {};

--- a/chaotic-openapi/integration_tests/src/requests_test.cpp
+++ b/chaotic-openapi/integration_tests/src/requests_test.cpp
@@ -22,7 +22,34 @@ USERVER_NAMESPACE_BEGIN
 
 namespace {
 
-namespace client = ::clients::multiple_content_types::test1::post;
+using namespace ::clients::multiple_content_types;
+
+class RequestsMultipleContentTypes : public ::testing::Test {
+protected: 
+    template <typename Callback>
+    void SetupCallback(Callback&& callback){
+        mock_server_ = std::make_unique<utest::HttpServerMock>(
+            [hook = std::move(callback)](const utest::HttpServerMock::HttpRequest& request) {
+                hook(request);
+                utest::HttpServerMock::HttpResponse response{};
+                response.response_status = 200;
+                return response;
+            });
+    }
+
+    template <typename Request>
+    void PerformRequest(Request&& request_obj) {
+        EXPECT_NE(mock_server_.get(), nullptr);
+        auto http_client_ptr = utest::CreateHttpClient();
+        auto request = http_client_ptr->CreateRequest();
+        SerializeRequest(std::move(request_obj), mock_server_->GetBaseUrl(), request);
+        auto response = request.perform();
+        EXPECT_EQ(response->status_code(), 200);
+    }
+
+private:
+    std::unique_ptr<utest::HttpServerMock> mock_server_;
+};
 
 UTEST(Requests, RegexDestinationName) {
     const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest&) {
@@ -60,33 +87,18 @@ UTEST(Requests, RegexDestinationName) {
     );
 }
 
-UTEST(RequestsMultipleContentTypes, Json) {
-    auto test = []<typename Request, typename Body>() {
-        const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
+UTEST_F(RequestsMultipleContentTypes, Json) {
+    SetupCallback([](const utest::HttpServerMock::HttpRequest& request) {
             EXPECT_EQ(request.body, R"({"foo":"a"})");
             EXPECT_EQ(request.headers.at(std::string{"Content-Type"}), "application/json");
-            utest::HttpServerMock::HttpResponse response{};
-            response.response_status = 200;
-            return response;
         });
-
-        auto http_client_ptr = utest::CreateHttpClient();
-        auto request = http_client_ptr->CreateRequest();
-
-        SerializeRequest(Request{Body{"a"}}, http_server.GetBaseUrl(), request);
-
-        auto response = request.perform();
-        EXPECT_EQ(response->status_code(), 200);
-    };
-
-    namespace single = ::clients::multiple_content_types::test_single_json::post;
-    test.operator()<client::Request, client::RequestBodyApplicationJson>();
-    test.operator()<single::Request, single::Body>();
+    const auto& json_obj = single_json{"a"};
+    PerformRequest(test1::post::Request{json_obj});
+    PerformRequest(test_single_json::post::Request{json_obj});
 }
 
-UTEST(RequestsMultipleContentTypes, XWwwFormUrlencoded) {
-    auto test = []<typename Request, typename Body>() {
-        const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
+UTEST_F(RequestsMultipleContentTypes, XWwwFormUrlencoded) {
+    SetupCallback([](const utest::HttpServerMock::HttpRequest& request) {
             // x-www-form-urlencoded field order is unspecified (serialized from a
             // std::unordered_map), so compare the '&'-separated parts order-independently.
             const auto parts = utils::text::Split(request.body, "&");
@@ -101,28 +113,15 @@ UTEST(RequestsMultipleContentTypes, XWwwFormUrlencoded) {
                 )
             );
             EXPECT_EQ(request.headers.at(std::string{"Content-Type"}), "application/x-www-form-urlencoded");
-            utest::HttpServerMock::HttpResponse response{};
-            response.response_status = 200;
-            return response;
         });
-
-        auto http_client_ptr = utest::CreateHttpClient();
-        auto request = http_client_ptr->CreateRequest();
-
-        SerializeRequest(Request{Body{"abc", "123 456", 30, 1000.5, true}}, http_server.GetBaseUrl(), request);
-
-        auto response = request.perform();
-        EXPECT_EQ(response->status_code(), 200);
-    };
-
-    namespace single = ::clients::multiple_content_types::test_single_form_urlen::post;
-    test.operator()<client::Request, client::RequestBodyApplicationXWwwFormUrlencoded>();
-    test.operator()<single::Request, single::Body>();
+    const auto& form_urlen_obj = single_form_urlen{"abc", "123 456", 30, 1000.5, true};        
+    PerformRequest(test1::post::Request{form_urlen_obj});
+    PerformRequest(test_single_form_urlen::post::Request{form_urlen_obj});
 }
 
-UTEST(RequestsMultipleContentTypes, MultipartFormData) {
-    auto test = []<typename Request, typename Body>() {
-        const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
+
+UTEST_F(RequestsMultipleContentTypes, MultipartFormData) {
+    SetupCallback([](const utest::HttpServerMock::HttpRequest& request) {
             const auto& raw_content_type = request.headers.at(std::string{"Content-Type"});
             const http::ContentType content_type(raw_content_type);
             EXPECT_EQ(content_type.MediaType(), "multipart/form-data");
@@ -141,47 +140,20 @@ UTEST(RequestsMultipleContentTypes, MultipartFormData) {
                     "\r\nfile\ncontent\r\n" +
                     "--" + boundary + "--\r\n"
             );
-            utest::HttpServerMock::HttpResponse response{};
-            response.response_status = 200;
-            return response;
         });
-
-        auto http_client_ptr = utest::CreateHttpClient();
-        auto request = http_client_ptr->CreateRequest();
-
-        SerializeRequest(Request{Body{"filename", "file\ncontent"}}, http_server.GetBaseUrl(), request);
-
-        auto response = request.perform();
-        EXPECT_EQ(response->status_code(), 200);
-    };
-
-    namespace single = ::clients::multiple_content_types::test_single_form_data::post;
-    test.operator()<client::Request, client::RequestBodyMultipartFormData>();
-    test.operator()<single::Request, single::Body>();
+    const auto& form_data_obj = single_form_data{"filename", "file\ncontent"};
+    PerformRequest(test1::post::Request{form_data_obj});
+    PerformRequest(test_single_form_data::post::Request{form_data_obj});
 }
 
-UTEST(RequestsMultipleContentTypes, OctetStream) {
-    auto test = []<typename Request, typename Body>() {
-        const utest::HttpServerMock http_server([&](const utest::HttpServerMock::HttpRequest& request) {
+UTEST_F(RequestsMultipleContentTypes, OctetStream) {
+    SetupCallback([](const utest::HttpServerMock::HttpRequest& request) {
             EXPECT_EQ(request.body, "blabla");
             EXPECT_EQ(request.headers.at(std::string{"Content-Type"}), "application/octet-stream");
-            utest::HttpServerMock::HttpResponse response{};
-            response.response_status = 200;
-            return response;
-        });
-
-        auto http_client_ptr = utest::CreateHttpClient();
-        auto request = http_client_ptr->CreateRequest();
-
-        SerializeRequest(Request{Body{"blabla"}}, http_server.GetBaseUrl(), request);
-
-        auto response = request.perform();
-        EXPECT_EQ(response->status_code(), 200);
-    };
-
-    namespace single = ::clients::multiple_content_types::test_single_octet::post;
-    test.operator()<client::Request, client::RequestBodyApplicationOctetStream>();
-    test.operator()<single::Request, single::Body>();
+    });
+    const auto& single_octet_obj = single_octet("blabla");
+    PerformRequest(test1::post::Request{test1::post::RequestBodyApplicationOctetStream{single_octet_obj}});
+    PerformRequest(test_single_octet::post::Request{single_octet_obj});
 }
 
 class RequestsQueryLogMode : public utest::LogCaptureFixture<> {};

--- a/chaotic-openapi/integration_tests/src/swagger_form_data_test.cpp
+++ b/chaotic-openapi/integration_tests/src/swagger_form_data_test.cpp
@@ -1,0 +1,34 @@
+#include <userver/utest/utest.hpp>
+
+#include <userver/clients/http/client.hpp>
+#include <userver/utest/http_client.hpp>
+#include <userver/utest/http_server_mock.hpp>
+
+#include <clients/swagger_form_data/requests.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace {
+
+namespace client = ::clients::swagger_form_data::form_urlencoded::post;
+
+// A swagger "in: formData" parameter describes a single form field rather than
+// the whole request body, so it must be serialized as a field of the form.
+UTEST(SwaggerFormData, Urlencoded) {
+    std::string body;
+    const utest::HttpServerMock http_server([&body](const utest::HttpServerMock::HttpRequest& request) {
+        body = request.body;
+        return utest::HttpServerMock::HttpResponse{};
+    });
+
+    auto http_client_ptr = utest::CreateHttpClient();
+    auto request = http_client_ptr->CreateRequest();
+    client::SerializeRequest(client::Request{{"abc"}}, http_server.GetBaseUrl(), request);
+    EXPECT_EQ(request.perform()->status_code(), 200);
+
+    EXPECT_EQ(body, "name=abc");
+}
+
+}  // namespace
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
Serialization for single body requests misses several things:
1. It misses content type header
2. Serialization is not working for non json types

Upd: refactored tests with new openapi scheme revealed issues
3. Broken compilation because form fields treatment
4. Form fields work badly with $ref

Proposed pr fixes them also



------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

