### PR TITLE
fix ydb: link Brotli common library

### DIFF
--- a/cmake/modules/FindBrotli.cmake
+++ b/cmake/modules/FindBrotli.cmake
@@ -13,6 +13,8 @@ _userver_module_find_library(NAMES brotlidec)
 
 _userver_module_find_library(NAMES brotlienc)
 
+_userver_module_find_library(NAMES brotlicommon)
+
 _userver_module_end()
 
 if(NOT TARGET brotlidec)


### PR DESCRIPTION
Find and link `brotlicommon` together with the Brotli decoder and encoder libraries.

This fixes static YDB builds on Ubuntu 24.04, where `libbrotlienc.a` and `libbrotlidec.a` leave common Brotli symbols unresolved. Shared-library and non-YDB runtime behavior is unchanged.
