### PR TITLE
CPM provided deps selected incorrectly in some cases

### DIFF
--- a/cmake/ModuleHelpers.cmake
+++ b/cmake/ModuleHelpers.cmake
@@ -284,6 +284,8 @@ macro(_userver_module_end)
         endif()
     endif()
 
+    # Macros share the caller's scope, so reset state that may leak from a previous _userver_module_end run.
+    set(NEED_CPM FALSE)
     set(required_vars)
     # Important to check this way, because NOTFOUND still means that this kind of dependencies exist.
     if(NOT "${${libraries_variable}}" STREQUAL "")


### PR DESCRIPTION
NEED_CPM flag leaks to following packages if set where the macro is used. I had a problem where the build system always used CPM provided version of c-ares library even I have this library provided by the system. This solved the issue and also applied to nghttp2. The problem was analyzed and fixed by Kimi K3 model.








------------------------
Note: by creating a PR or an issue you automatically agree to the CLA. See [CONTRIBUTING.md](https://github.com/userver-framework/userver/blob/develop/CONTRIBUTING.md). Feel free to remove this note, the agreement holds.

