### PR TITLE
fix core: double truncation in request logging

### DIFF
--- a/core/include/userver/server/handlers/http_handler_base.hpp
+++ b/core/include/userver/server/handlers/http_handler_base.hpp
@@ -168,14 +168,18 @@ protected:
     /// condition
     virtual bool NeedCheckAuth() const { return true; }
 
-    /// Override it if you need a custom request body logging.
+    /// Override it if you need a custom request body logging. The returned
+    /// string is automatically truncated to the `request_body_size_log_limit`
+    /// before logging.
     virtual std::string GetRequestBodyForLogging(
         const http::HttpRequest& request,
         request::RequestContext& context,
         const std::string& request_body
     ) const;
 
-    /// Override it if you need a custom response data logging.
+    /// Override it if you need a custom response data logging. The returned
+    /// string is automatically truncated to the `response_data_size_log_limit`
+    /// before logging.
     virtual std::string GetResponseDataForLogging(
         const http::HttpRequest& request,
         request::RequestContext& context,

--- a/core/include/userver/server/handlers/http_handler_flatbuf_base.hpp
+++ b/core/include/userver/server/handlers/http_handler_flatbuf_base.hpp
@@ -9,7 +9,7 @@
 
 #include <userver/server/handlers/http_handler_base.hpp>
 #include <userver/server/http/http_error.hpp>
-#include <userver/utils/log.hpp>
+#include <userver/utils/encoding/hex.hpp>
 #include <userver/yaml_config/schema.hpp>
 
 USERVER_NAMESPACE_BEGIN
@@ -128,8 +128,7 @@ std::string HttpHandlerFlatbufBase<InputType, ReturnType>::GetRequestBodyForLogg
     request::RequestContext&,
     const std::string& request_body
 ) const {
-    const size_t limit = GetConfig().request_body_size_log_limit;
-    return utils::log::ToLimitedHex(request_body, limit);
+    return utils::encoding::ToHex(request_body);
 }
 
 template <typename InputType, typename ReturnType>
@@ -138,8 +137,7 @@ std::string HttpHandlerFlatbufBase<InputType, ReturnType>::GetResponseDataForLog
     request::RequestContext&,
     const std::string& response_data
 ) const {
-    const size_t limit = GetConfig().response_data_size_log_limit;
-    return utils::log::ToLimitedHex(response_data, limit);
+    return utils::encoding::ToHex(response_data);
 }
 
 template <typename InputType, typename ReturnType>

--- a/core/src/server/handlers/http_handler_base.cpp
+++ b/core/src/server/handlers/http_handler_base.cpp
@@ -318,8 +318,7 @@ std::string HttpHandlerBase::GetRequestBodyForLogging(
     request::RequestContext&,
     const std::string& request_body
 ) const {
-    const std::size_t limit = GetConfig().request_body_size_log_limit;
-    return utils::log::ToLimitedUtf8(request_body, limit);
+    return request_body;
 }
 
 std::string HttpHandlerBase::GetResponseDataForLogging(
@@ -327,8 +326,7 @@ std::string HttpHandlerBase::GetResponseDataForLogging(
     request::RequestContext&,
     const std::string& response_data
 ) const {
-    const std::size_t limit = GetConfig().response_data_size_log_limit;
-    return utils::log::ToLimitedUtf8(response_data, limit);
+    return response_data;
 }
 
 std::string HttpHandlerBase::GetUrlForLogging(const http::HttpRequest& request, request::RequestContext&) const {


### PR DESCRIPTION
### Problem:

Request and response body logs are truncated twice, which results in `(truncated, total X bytes)` message having an incorrect size value (roughly around `request_body_size_log_limit` / `response_data_size_log_limit`).

1st truncation happens in `GetRequestBodyForLogging()` and `GetResponseDataForLogging()` (the resulting string is bigger than the limit due to the `(truncated...)` message).

2nd truncation happens in `GetRequestBodyForLoggingChecked()` and `GetResponseDataForLoggingChecked()`. Since the string from the 1st truncation is bigger than the limit, the string is truncated again and incorrect size is shown in the message.

### Fix:

To fix the problem, I removed the 1st truncation call. This is okay, since request/response bodies are always truncated again in the 2nd call.

### Before / after:

To showcase the issue, I used a simple request which consists of the letter "a" repeated for 10 KiB.

Before:
<img width="3025" height="327" alt="Screenshot_20260909_190244" src="https://github.com/user-attachments/assets/5b4b7dbb-1440-48d8-b3ca-d1ed0b379a76" />
After:
<img width="3025" height="216" alt="Screenshot_20260909_190823" src="https://github.com/user-attachments/assets/55c6b233-c3e1-4a74-961a-2df5a18035d1" />
