### PR TITLE
fix postgresql: validate bit length in bitstring parser

### DIFF
--- a/postgresql/include/userver/storages/postgres/io/bitstring.hpp
+++ b/postgresql/include/userver/storages/postgres/io/bitstring.hpp
@@ -165,7 +165,12 @@ struct BufferParser<postgres::detail::BitStringRefWrapper<
     void operator()(FieldBuffer buffer) {
         Integer bit_count{0};
         buffer.Read(bit_count, BufferCategory::kPlainBuffer);
-        if (static_cast<std::size_t>((bit_count + 7) / 8) > buffer.length) {
+        if (bit_count < 0) {
+            throw InvalidBitStringRepresentation{};
+        }
+        // Compute the byte count in size_t: bit_count is a server-supplied int32,
+        // so `bit_count + 7` would be signed overflow (UB) for values near INT_MAX.
+        if ((static_cast<std::size_t>(bit_count) + 7) / 8 > buffer.length) {
             throw InvalidBitStringRepresentation{};
         }
 

--- a/postgresql/src/storages/postgres/tests/bitstring_buffer_test.cpp
+++ b/postgresql/src/storages/postgres/tests/bitstring_buffer_test.cpp
@@ -1,0 +1,59 @@
+#include <userver/utest/utest.hpp>
+
+#include <bitset>
+#include <initializer_list>
+
+#include <storages/postgres/tests/test_buffers.hpp>
+
+#include <userver/storages/postgres/exceptions.hpp>
+#include <userver/storages/postgres/io/bitstring.hpp>
+
+USERVER_NAMESPACE_BEGIN
+
+namespace pg = storages::postgres;
+namespace io = pg::io;
+
+namespace {
+
+const pg::UserTypes types;
+
+pg::test::Buffer MakeBuffer(std::initializer_list<unsigned char> bytes) {
+    pg::test::Buffer buffer;
+    for (const auto b : bytes) {
+        buffer.push_back(static_cast<char>(b));
+    }
+    return buffer;
+}
+
+// A server-sent bit/varbit field whose 4-byte length prefix is negative must be
+// rejected instead of being silently accepted as an empty bit string.
+TEST(PostgreIOBitStringBuffer, NegativeBitCount) {
+    const auto buffer = MakeBuffer({0xFF, 0xFF, 0xFF, 0xFF});  // bit count = -1
+    auto fb = pg::test::MakeFieldBuffer(buffer);
+    std::bitset<8> tgt;
+    UEXPECT_THROW(io::ReadBuffer(fb, tgt), pg::InvalidBitStringRepresentation);
+}
+
+// A bit count near INT_MAX used to overflow `bit_count + 7` (signed overflow,
+// UB) before the byte-count comparison; the field must be rejected.
+TEST(PostgreIOBitStringBuffer, HugeBitCount) {
+    const auto buffer = MakeBuffer({0x7F, 0xFF, 0xFF, 0xFF});  // bit count = INT_MAX
+    auto fb = pg::test::MakeFieldBuffer(buffer);
+    std::bitset<8> tgt;
+    UEXPECT_THROW(io::ReadBuffer(fb, tgt), pg::InvalidBitStringRepresentation);
+}
+
+// A valid bit string still round-trips unchanged after the added validation.
+TEST(PostgreIOBitStringBuffer, ValidRoundtrip) {
+    const std::bitset<8> src{0xF2};
+    pg::test::Buffer buffer;
+    UEXPECT_NO_THROW(io::WriteBuffer(types, buffer, src));
+    auto fb = pg::test::MakeFieldBuffer(buffer);
+    std::bitset<8> tgt;
+    UEXPECT_NO_THROW(io::ReadBuffer(fb, tgt));
+    EXPECT_EQ(src, tgt);
+}
+
+}  // namespace
+
+USERVER_NAMESPACE_END


### PR DESCRIPTION
1. The `bit`/`bit varying` binary parser (`BufferParser` for `BitStringRefWrapper` in `postgresql/include/userver/storages/postgres/io/bitstring.hpp`) reads the field's bit-length prefix into an `Integer` (int32) directly from the server buffer, so `bit_count` is peer-controlled.
2. It then computes the byte count as `(bit_count + 7) / 8` before comparing against the remaining buffer length. For a value near `INT_MAX` this addition is signed overflow (undefined behavior, reported by the UBSan build), and a negative `bit_count` passes the length check and skips the read loop, so a malformed field is silently accepted as an empty bit string instead of being rejected.
3. Reject `bit_count < 0` up front and perform the ceil-division in `size_t`, so the value is validated before use and the addition cannot overflow. Parsing of valid lengths is unchanged, and both `bit`/`bit varying` and the `Flags`/`bitset`/`array` containers route through this parser.

Added a non-DB unit test that feeds a negative and an `INT_MAX` length prefix (both now throw `InvalidBitStringRepresentation`) plus a valid round-trip.